### PR TITLE
Add relay bind address configuration

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -92,6 +92,7 @@ state at the next mutation.
 
 | Variable | Default | Description |
 |---|---|---|
+| `REMOTEPI_RELAY_BIND_ADDR` | `0.0.0.0` | IP address to bind. Use `127.0.0.1` behind a local reverse proxy, a Tailscale/WireGuard interface IP for private-network-only exposure, or `0.0.0.0` for the existing all-interface behavior |
 | `REMOTEPI_RELAY_PORT` | `3000` | TCP port that serves the WebSocket upgrade, `/health`, and `/mesh/*` (all on the same port) |
 | `REMOTEPI_MESH_DB_PATH` | `/data/mesh.db` in Docker · `data/mesh.db` (cwd-relative) for bare-metal builds | Path to the SQLite database that stores signed membership versions. The parent directory is created automatically on first boot. The Docker image presets this to `/data/mesh.db` and declares `/data` as a volume — see the volume note above |
 | `RUST_LOG` | _(none)_ | Log level filter — e.g. `info`, `debug`, `warn` |
@@ -103,6 +104,7 @@ docker run -d \
   --name remote-pi-relay \
   -p 8080:8080 \
   -v remote-pi-data:/data \
+  -e REMOTEPI_RELAY_BIND_ADDR=127.0.0.1 \
   -e REMOTEPI_RELAY_PORT=8080 \
   -e RUST_LOG=info \
   --restart unless-stopped \
@@ -157,7 +159,7 @@ cargo build --release
 ```
 
 ```bash
-REMOTEPI_RELAY_PORT=8080 RUST_LOG=info ./target/release/relay
+REMOTEPI_RELAY_BIND_ADDR=127.0.0.1 REMOTEPI_RELAY_PORT=8080 RUST_LOG=info ./target/release/relay
 ```
 
 ## Running tests

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -1,0 +1,93 @@
+use std::net::{IpAddr, SocketAddr};
+
+use anyhow::{bail, Context};
+
+pub const DEFAULT_RELAY_BIND_ADDR: &str = "0.0.0.0";
+pub const DEFAULT_RELAY_PORT: u16 = 3000;
+
+pub fn relay_socket_addr_from_env() -> anyhow::Result<SocketAddr> {
+    relay_socket_addr(
+        std::env::var("REMOTEPI_RELAY_BIND_ADDR").ok().as_deref(),
+        std::env::var("REMOTEPI_RELAY_PORT").ok().as_deref(),
+    )
+}
+
+pub fn relay_socket_addr(
+    bind_addr: Option<&str>,
+    port: Option<&str>,
+) -> anyhow::Result<SocketAddr> {
+    let bind_addr = bind_addr.unwrap_or(DEFAULT_RELAY_BIND_ADDR);
+    let ip: IpAddr = bind_addr
+        .parse()
+        .with_context(|| format!("invalid REMOTEPI_RELAY_BIND_ADDR {bind_addr:?}"))?;
+
+    let port = match port {
+        Some(raw) => raw
+            .parse::<u16>()
+            .with_context(|| format!("invalid REMOTEPI_RELAY_PORT {raw:?}"))?,
+        None => DEFAULT_RELAY_PORT,
+    };
+
+    if port == 0 {
+        bail!("REMOTEPI_RELAY_PORT must be between 1 and 65535");
+    }
+
+    Ok(SocketAddr::new(ip, port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_existing_public_bind() {
+        assert_eq!(
+            relay_socket_addr(None, None).unwrap(),
+            SocketAddr::from(([0, 0, 0, 0], DEFAULT_RELAY_PORT)),
+        );
+    }
+
+    #[test]
+    fn parses_loopback_bind_address() {
+        assert_eq!(
+            relay_socket_addr(Some("127.0.0.1"), Some("8080")).unwrap(),
+            SocketAddr::from(([127, 0, 0, 1], 8080)),
+        );
+    }
+
+    #[test]
+    fn parses_tailscale_style_bind_address() {
+        assert_eq!(
+            relay_socket_addr(Some("100.64.12.34"), Some("3000")).unwrap(),
+            SocketAddr::from(([100, 64, 12, 34], 3000)),
+        );
+    }
+
+    #[test]
+    fn parses_ipv6_bind_address() {
+        assert_eq!(
+            relay_socket_addr(Some("::1"), Some("3000")).unwrap(),
+            SocketAddr::new("::1".parse().unwrap(), 3000),
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_bind_address() {
+        let err = relay_socket_addr(Some("not an ip"), Some("3000")).unwrap_err();
+        assert!(err.to_string().contains("invalid REMOTEPI_RELAY_BIND_ADDR"));
+    }
+
+    #[test]
+    fn rejects_invalid_port() {
+        let err = relay_socket_addr(Some("127.0.0.1"), Some("99999")).unwrap_err();
+        assert!(err.to_string().contains("invalid REMOTEPI_RELAY_PORT"));
+    }
+
+    #[test]
+    fn rejects_zero_port() {
+        let err = relay_socket_addr(Some("127.0.0.1"), Some("0")).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("REMOTEPI_RELAY_PORT must be between 1 and 65535"));
+    }
+}

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod config;
 pub mod handlers;
 pub mod mesh;
 pub mod metrics;

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -9,10 +9,7 @@ use tracing::info;
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let port: u16 = std::env::var("REMOTEPI_RELAY_PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(3000);
+    let addr = relay::config::relay_socket_addr_from_env()?;
 
     // Default puts the SQLite file (and any transient -journal) under data/,
     // so bare-metal `cargo run` doesn't litter the project root.
@@ -57,8 +54,7 @@ async fn main() -> anyhow::Result<()> {
     };
     let app = relay::build_router(state);
 
-    let addr = format!("0.0.0.0:{port}");
-    let listener = TcpListener::bind(&addr)
+    let listener = TcpListener::bind(addr)
         .await
         .with_context(|| format!("failed to bind {addr}"))?;
 


### PR DESCRIPTION
## Summary

- add `REMOTEPI_RELAY_BIND_ADDR` for relay listen IP selection
- preserve existing default `0.0.0.0:<port>` behavior
- validate invalid bind address and port values with clear startup errors
- document localhost/private-network bind examples

## Motivation

Self-hosted relay operators often put the relay behind a private reverse proxy, Tailscale/WireGuard interface, or localhost-only service. Today the relay always binds all interfaces and relies on firewall/proxy controls. This option lets operators bind directly to `127.0.0.1`, a private interface IP, or the existing public/all-interface address.

## Tests

```sh
cd relay
cargo test --locked
cargo clippy --locked -- -D warnings
```

Note: `cargo fmt --check` currently reports broad pre-existing formatting drift in upstream files unrelated to this branch, so I did not auto-format the repo and make this PR noisy.
