### PR TITLE
Harden local storage and socket permissions

### DIFF
--- a/pi-extension/src/config.ts
+++ b/pi-extension/src/config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { writePrivateFileAtomicSync } from "./secure_fs.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".pi", "remote");
 const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
@@ -28,10 +29,9 @@ export function loadConfig(): RemotePiConfig {
 }
 
 export function saveConfig(patch: Partial<RemotePiConfig>): void {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
   const current = loadConfig();
   const next = { ...current, ...patch };
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(next, null, 2));
+  writePrivateFileAtomicSync(CONFIG_FILE, JSON.stringify(next, null, 2) + "\n");
 }
 
 export type RelayResolution = { url: string; source: "env" | "config" | "default" };

--- a/pi-extension/src/daemon/registry.test.ts
+++ b/pi-extension/src/daemon/registry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -80,9 +80,13 @@ describe("loadRegistry / saveRegistry", () => {
     expect(loadRegistry()).toEqual({ daemons: [{ cwd: "/tmp/a" }, { cwd: "/tmp/b" }] });
   });
 
-  test("creates parent dirs on save", () => {
+  test("creates parent dirs as 0700 and registry file as 0600 on POSIX", () => {
     saveRegistry({ daemons: [] });
     expect(existsSync(registryPath())).toBe(true);
+    if (process.platform !== "win32") {
+      expect(statSync(join(testHome, ".pi", "remote")).mode & 0o777).toBe(0o700);
+      expect(statSync(registryPath()).mode & 0o777).toBe(0o600);
+    }
   });
 
   test("malformed JSON tolerated (returns empty)", () => {

--- a/pi-extension/src/daemon/registry.ts
+++ b/pi-extension/src/daemon/registry.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
+import { writePrivateFileAtomicSync } from "../secure_fs.js";
 import { daemonIdForCwd } from "./id.js";
 
 /**
@@ -80,8 +81,7 @@ export function loadRegistry(): DaemonRegistry {
 }
 
 export function saveRegistry(reg: DaemonRegistry): void {
-  mkdirSync(dirname(registryPathInternal()), { recursive: true });
-  writeFileSync(registryPathInternal(), JSON.stringify(reg, null, 2) + "\n");
+  writePrivateFileAtomicSync(registryPathInternal(), JSON.stringify(reg, null, 2) + "\n");
 }
 
 /**

--- a/pi-extension/src/daemon/supervisor.test.ts
+++ b/pi-extension/src/daemon/supervisor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { createConnection } from "node:net";
 import { join } from "node:path";
@@ -70,6 +70,12 @@ afterEach(async () => {
 });
 
 describe("Supervisor — control UDS surface", () => {
+  test("supervisor socket parent is 0700 and socket is 0600 on POSIX", () => {
+    if (process.platform === "win32") return;
+    expect(statSync(join(testHome, ".pi", "remote")).mode & 0o777).toBe(0o700);
+    expect(statSync(getSupervisorSockPath()).mode & 0o777).toBe(0o600);
+  });
+
   test("list returns empty daemons array when registry is empty", async () => {
     const r = await ask({ op: "list" });
     expect(r).toMatchObject({ ok: true, data: { daemons: [] } });

--- a/pi-extension/src/daemon/supervisor.ts
+++ b/pi-extension/src/daemon/supervisor.ts
@@ -1,7 +1,8 @@
-import { existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { existsSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { PRIVATE_FILE_MODE, chmodPrivatePathSync, ensurePrivateDirSync } from "../secure_fs.js";
 import { addDaemon, listDaemons, removeDaemon } from "./registry.js";
 import { daemonIdForCwd } from "./id.js";
 import { loadLocalConfig, defaultAgentName } from "../session/local_config.js";
@@ -101,7 +102,7 @@ export class Supervisor {
   // ── UDS binding ──────────────────────────────────────────────────────────
 
   private _mkdirParent(): void {
-    mkdirSync(dirname(supervisorSockPath()), { recursive: true });
+    ensurePrivateDirSync(dirname(supervisorSockPath()));
   }
 
   private async _bindUds(): Promise<void> {
@@ -115,7 +116,10 @@ export class Supervisor {
     const server = createServer((socket) => this._onConnection(socket));
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
-      server.listen(path, () => resolve());
+      server.listen(path, () => {
+        chmodPrivatePathSync(path, PRIVATE_FILE_MODE);
+        resolve();
+      });
     });
     this.server = server;
   }

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -67,6 +67,7 @@ import { handleListCommands } from "./commands/list_commands.js";
 import { discoverSelfLabel, discoverSiblings, fallbackLabel } from "./mesh/siblings.js";
 import {
   ensureGlobalDirs,
+  ensureSessionDir,
   LOCAL_SESSION_NAME,
   sessionAuditPath,
   sessionSockPath,
@@ -2053,7 +2054,7 @@ async function _cmdJoin(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void
   }
 
   ensureGlobalDirs();
-  mkdirSync(join(skillsDir(), "..", "sessions", sessionName), { recursive: true });
+  ensureSessionDir(sessionName);
 
   const sock = sessionSockPath(sessionName);
   const audit = sessionAuditPath(sessionName);

--- a/pi-extension/src/pairing/storage.test.ts
+++ b/pi-extension/src/pairing/storage.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -17,9 +16,13 @@ vi.mock("node:os", async (importOriginal) => {
 const storage = await import("./storage.js");
 const {
   getOrCreateEd25519Keypair,
+  addPeer,
+  listPeers,
+  removePeer,
   _setKeyStoreBackendForTest,
   _unlinkIdentityFileForTest,
   _IDENTITY_FILE_FOR_TEST,
+  _PEERS_FILE_FOR_TEST,
 } = storage;
 import type { KeyStoreBackend } from "./storage.js";
 
@@ -71,6 +74,7 @@ beforeEach(async () => {
   vi.spyOn(console, "info").mockImplementation(() => undefined);
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
   await _unlinkIdentityFileForTest();
+  rmSync(_PEERS_FILE_FOR_TEST, { force: true });
 });
 
 afterEach(() => {
@@ -214,5 +218,32 @@ describe("getOrCreateEd25519Keypair — headless Linux fallback", () => {
       Buffer.from(second.publicKey).toString("base64"),
     );
   });
+});
 
+describe("peers.json storage", () => {
+  test("addPeer creates peers.json as 0600 and parent dir as 0700 on POSIX", async () => {
+    await addPeer({ name: "phone", remote_epk: "peer-a", paired_at: "2026-05-29T00:00:00.000Z" });
+
+    expect(await listPeers()).toEqual([
+      { name: "phone", remote_epk: "peer-a", paired_at: "2026-05-29T00:00:00.000Z" },
+    ]);
+
+    if (process.platform !== "win32") {
+      expect(statSync(join(_tmpHome, ".pi", "remote")).mode & 0o777).toBe(0o700);
+      expect(statSync(_PEERS_FILE_FOR_TEST).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  test("removePeer rewrites peers.json atomically and keeps 0600 on POSIX", async () => {
+    await addPeer({ name: "phone", remote_epk: "peer-a", paired_at: "2026-05-29T00:00:00.000Z" });
+    await addPeer({ name: "tablet", remote_epk: "peer-b", paired_at: "2026-05-29T00:00:01.000Z" });
+
+    await expect(removePeer("peer-a")).resolves.toBe(true);
+    expect(await listPeers()).toEqual([
+      { name: "tablet", remote_epk: "peer-b", paired_at: "2026-05-29T00:00:01.000Z" },
+    ]);
+    if (process.platform !== "win32") {
+      expect(statSync(_PEERS_FILE_FOR_TEST).mode & 0o777).toBe(0o600);
+    }
+  });
 });

--- a/pi-extension/src/pairing/storage.ts
+++ b/pi-extension/src/pairing/storage.ts
@@ -1,7 +1,8 @@
-import { mkdir, readFile, writeFile, chmod, unlink } from "node:fs/promises";
+import { readFile, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { AsyncEntry } from "@napi-rs/keyring";
+import { writePrivateFile, writePrivateFileAtomic } from "../secure_fs.js";
 import { generateEd25519Keypair, type Ed25519Keypair } from "./crypto.js";
 
 /**
@@ -115,12 +116,7 @@ async function _readKeypairFromFile(): Promise<Ed25519Keypair | null> {
 }
 
 async function _writeKeypairToFile(kp: Ed25519Keypair): Promise<void> {
-  await mkdir(PI_DIR, { recursive: true, mode: 0o700 });
-  // Best-effort tighten of the dir in case it pre-existed with looser
-  // permissions (mkdir's mode is only applied to NEW dirs).
-  try { await chmod(PI_DIR, 0o700); } catch { /* not fatal */ }
-  await writeFile(IDENTITY_FILE, _serialize(kp), { mode: 0o600 });
-  try { await chmod(IDENTITY_FILE, 0o600); } catch { /* not fatal */ }
+  await writePrivateFile(IDENTITY_FILE, _serialize(kp));
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────
@@ -202,8 +198,7 @@ export async function addPeer(record: PeerRecord): Promise<void> {
   } else {
     peers.push(record);
   }
-  await mkdir(dirname(PEERS_PATH), { recursive: true });
-  await writeFile(PEERS_PATH, JSON.stringify({ peers }, null, 2));
+  await writePrivateFileAtomic(PEERS_PATH, JSON.stringify({ peers }, null, 2) + "\n");
 }
 
 /**
@@ -225,8 +220,7 @@ export async function removePeer(remoteEpk: string): Promise<boolean> {
   const peers = await listPeers();
   const filtered = peers.filter((p) => p.remote_epk !== remoteEpk);
   if (filtered.length === peers.length) return false;
-  await mkdir(dirname(PEERS_PATH), { recursive: true });
-  await writeFile(PEERS_PATH, JSON.stringify({ peers: filtered }, null, 2));
+  await writePrivateFileAtomic(PEERS_PATH, JSON.stringify({ peers: filtered }, null, 2) + "\n");
   return true;
 }
 
@@ -234,6 +228,8 @@ export async function removePeer(remoteEpk: string): Promise<boolean> {
 
 /** Test-only: expose the identity-file path so tests can clean it. */
 export const _IDENTITY_FILE_FOR_TEST = IDENTITY_FILE;
+/** Test-only: expose the peers-file path for mode/atomic-write checks. */
+export const _PEERS_FILE_FOR_TEST = PEERS_PATH;
 /** Test-only: expose unlink for cleanup. */
 export const _unlinkIdentityFileForTest = async (): Promise<void> => {
   try { await unlink(IDENTITY_FILE); } catch { /* fine if missing */ }

--- a/pi-extension/src/secure_fs.test.ts
+++ b/pi-extension/src/secure_fs.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  PRIVATE_DIR_MODE,
+  PRIVATE_FILE_MODE,
+  ensurePrivateDirSync,
+  writePrivateFileAtomic,
+  writePrivateFileAtomicSync,
+  writePrivateFileSync,
+} from "./secure_fs.js";
+
+function mode(path: string): number {
+  return statSync(path).mode & 0o777;
+}
+
+const checkModes = process.platform !== "win32";
+
+describe("secure_fs", () => {
+  test("ensurePrivateDirSync creates and tightens directories to 0700 on POSIX", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-secure-dir-"));
+    const target = join(dir, "nested");
+    ensurePrivateDirSync(target);
+    expect(existsSync(target)).toBe(true);
+    if (checkModes) expect(mode(target)).toBe(PRIVATE_DIR_MODE);
+  });
+
+  test("writePrivateFileSync creates parent 0700 and file 0600 on POSIX", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-secure-file-"));
+    const path = join(dir, "remote", "identity.json");
+    writePrivateFileSync(path, "secret");
+    expect(readFileSync(path, "utf8")).toBe("secret");
+    if (checkModes) {
+      expect(mode(dirname(path))).toBe(PRIVATE_DIR_MODE);
+      expect(mode(path)).toBe(PRIVATE_FILE_MODE);
+    }
+  });
+
+  test("writePrivateFileAtomic replaces file contents and preserves 0600 on POSIX", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-secure-atomic-"));
+    const path = join(dir, "peers.json");
+    writeFileSync(path, "old", { mode: 0o644 });
+    await writePrivateFileAtomic(path, "new");
+    expect(readFileSync(path, "utf8")).toBe("new");
+    if (checkModes) expect(mode(path)).toBe(PRIVATE_FILE_MODE);
+  });
+
+  test("writePrivateFileAtomicSync writes in the same directory and leaves no temp files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-secure-atomic-sync-"));
+    const path = join(dir, "daemons.json");
+    writePrivateFileAtomicSync(path, "{}\n");
+    expect(readFileSync(path, "utf8")).toBe("{}\n");
+    if (checkModes) expect(mode(path)).toBe(PRIVATE_FILE_MODE);
+  });
+});

--- a/pi-extension/src/secure_fs.ts
+++ b/pi-extension/src/secure_fs.ts
@@ -1,0 +1,119 @@
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { appendFile, chmod, mkdir, open, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+export const PRIVATE_DIR_MODE = 0o700;
+export const PRIVATE_FILE_MODE = 0o600;
+
+function isPosix(): boolean {
+  return process.platform !== "win32";
+}
+
+function tmpPathFor(path: string): string {
+  return join(dirname(path), `.${process.pid}.${Date.now()}.${randomBytes(6).toString("hex")}.tmp`);
+}
+
+export async function ensurePrivateDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: PRIVATE_DIR_MODE });
+  if (!isPosix()) return;
+  try { await chmod(path, PRIVATE_DIR_MODE); } catch { /* best-effort on non-POSIX mounts */ }
+}
+
+export function ensurePrivateDirSync(path: string): void {
+  mkdirSync(path, { recursive: true, mode: PRIVATE_DIR_MODE });
+  if (!isPosix()) return;
+  try { chmodSync(path, PRIVATE_DIR_MODE); } catch { /* best-effort on non-POSIX mounts */ }
+}
+
+export async function ensurePrivateParent(path: string): Promise<void> {
+  await ensurePrivateDir(dirname(path));
+}
+
+export function ensurePrivateParentSync(path: string): void {
+  ensurePrivateDirSync(dirname(path));
+}
+
+export async function writePrivateFile(path: string, data: string | Buffer): Promise<void> {
+  await ensurePrivateParent(path);
+  await writeFile(path, data, { mode: PRIVATE_FILE_MODE });
+  if (!isPosix()) return;
+  try { await chmod(path, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+}
+
+export function writePrivateFileSync(path: string, data: string | Buffer): void {
+  ensurePrivateParentSync(path);
+  writeFileSync(path, data, { mode: PRIVATE_FILE_MODE });
+  if (!isPosix()) return;
+  try { chmodSync(path, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+}
+
+export async function writePrivateFileAtomic(path: string, data: string | Buffer): Promise<void> {
+  await ensurePrivateParent(path);
+  const tmp = tmpPathFor(path);
+  try {
+    await writeFile(tmp, data, { mode: PRIVATE_FILE_MODE });
+    if (isPosix()) {
+      try { await chmod(tmp, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+    }
+    const handle = await open(tmp, "r");
+    try { await handle.sync(); } finally { await handle.close(); }
+    await rename(tmp, path);
+    if (isPosix()) {
+      try { await chmod(path, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+    }
+  } catch (err) {
+    try { await unlink(tmp); } catch { /* best-effort cleanup */ }
+    throw err;
+  }
+}
+
+export function writePrivateFileAtomicSync(path: string, data: string | Buffer): void {
+  ensurePrivateParentSync(path);
+  const tmp = tmpPathFor(path);
+  try {
+    writeFileSync(tmp, data, { mode: PRIVATE_FILE_MODE });
+    if (isPosix()) {
+      try { chmodSync(tmp, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+    }
+    const fd = openSync(tmp, "r");
+    try { fsyncSync(fd); } finally { closeSync(fd); }
+    renameSync(tmp, path);
+    if (isPosix()) {
+      try { chmodSync(path, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+    }
+  } catch (err) {
+    try { unlinkSync(tmp); } catch { /* best-effort cleanup */ }
+    throw err;
+  }
+}
+
+export async function appendPrivateFile(path: string, data: string | Buffer): Promise<void> {
+  await ensurePrivateParent(path);
+  await appendFile(path, data, { mode: PRIVATE_FILE_MODE });
+  if (!isPosix()) return;
+  try { await chmod(path, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+}
+
+export function appendPrivateFileSync(path: string, data: string | Buffer): void {
+  ensurePrivateParentSync(path);
+  appendFileSync(path, data, { mode: PRIVATE_FILE_MODE });
+  if (!isPosix()) return;
+  try { chmodSync(path, PRIVATE_FILE_MODE); } catch { /* best-effort */ }
+}
+
+export function chmodPrivatePathSync(path: string, mode: number): void {
+  if (!isPosix() || !existsSync(path)) return;
+  try { chmodSync(path, mode); } catch { /* best-effort */ }
+}

--- a/pi-extension/src/session/broker.ts
+++ b/pi-extension/src/session/broker.ts
@@ -1,7 +1,6 @@
 import type { Server, Socket } from "node:net";
-import { appendFile, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
-import { type Envelope, parse, serialize, uuidv7, EnvelopeError } from "./envelope.js";
+import { appendPrivateFile } from "../secure_fs.js";
+import { EnvelopeError, type Envelope, parse, serialize, uuidv7 } from "./envelope.js";
 
 /**
  * Broker hosted by the session leader. Accepts UDS connections, maintains a
@@ -437,8 +436,7 @@ export class Broker {
       via,
     }) + "\n";
     try {
-      await mkdir(dirname(this.auditPath), { recursive: true });
-      await appendFile(this.auditPath, line, "utf8");
+      await appendPrivateFile(this.auditPath, line);
     } catch { /* audit best-effort */ }
   }
 }

--- a/pi-extension/src/session/cwd_lock.ts
+++ b/pi-extension/src/session/cwd_lock.ts
@@ -1,8 +1,8 @@
-import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { Server } from "node:net";
 import { roomIdForCwd } from "../rooms.js";
+import { ensurePrivateDirSync } from "../secure_fs.js";
 import { removeStaleSock, tryBind, tryConnect } from "./leader_election.js";
 
 /**
@@ -67,7 +67,7 @@ export function lockPathForCwd(cwd: string): string {
  */
 export async function acquireCwdLock(cwd: string): Promise<CwdLockResult> {
   const lockPath = lockPathForCwd(cwd);
-  mkdirSync(dirname(lockPath), { recursive: true });
+  ensurePrivateDirSync(dirname(lockPath));
 
   // First attempt: bind directly.
   let server: Server | null = await tryBind(lockPath);

--- a/pi-extension/src/session/global_config.ts
+++ b/pi-extension/src/session/global_config.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { ensurePrivateDirSync } from "../secure_fs.js";
 
 const HOME_PI_REMOTE = join(homedir(), ".pi", "remote");
 const SESSIONS_DIR = join(HOME_PI_REMOTE, "sessions");
@@ -18,8 +19,13 @@ export const LOCAL_SESSION_NAME = "local";
 
 /** Ensures the new subdirs exist inside the existing ~/.pi/remote/. */
 export function ensureGlobalDirs(): void {
-  mkdirSync(SESSIONS_DIR, { recursive: true });
-  mkdirSync(SKILLS_DIR, { recursive: true });
+  ensurePrivateDirSync(HOME_PI_REMOTE);
+  ensurePrivateDirSync(SESSIONS_DIR);
+  ensurePrivateDirSync(SKILLS_DIR);
+}
+
+export function ensureSessionDir(name: string): void {
+  ensurePrivateDirSync(dirname(sessionSockPath(name)));
 }
 
 /** Path to the UDS socket for a named session. */

--- a/pi-extension/src/session/leader_election.test.ts
+++ b/pi-extension/src/session/leader_election.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { existsSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { joinOrLead } from "./leader_election.js";
@@ -26,6 +26,7 @@ describe("joinOrLead", () => {
     const sock = tmpSock();
     const r1 = await joinOrLead(sock);
     expect(r1.role).toBe("leader");
+    if (process.platform !== "win32") expect(statSync(sock).mode & 0o777).toBe(0o600);
 
     const r2 = await joinOrLead(sock);
     expect(r2.role).toBe("follower");

--- a/pi-extension/src/session/leader_election.ts
+++ b/pi-extension/src/session/leader_election.ts
@@ -1,6 +1,7 @@
 import { Server, Socket, createConnection, createServer } from "node:net";
 import { existsSync, lstatSync, unlinkSync } from "node:fs";
 import { setTimeout as delay } from "node:timers/promises";
+import { PRIVATE_FILE_MODE, chmodPrivatePathSync } from "../secure_fs.js";
 
 const MAX_ATTEMPTS = 20;
 const BASE_BACKOFF_MS = 30;
@@ -89,7 +90,10 @@ function _tryBind(sockPath: string): Promise<Server | null> {
       resolve(val);
     };
     server.once("error", () => settle(null));
-    server.listen(sockPath, () => settle(server));
+    server.listen(sockPath, () => {
+      chmodPrivatePathSync(sockPath, PRIVATE_FILE_MODE);
+      settle(server);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- add centralized secure filesystem helpers for private dirs/files and atomic writes
- keep `~/.pi/remote` directories at `0700` where created/touched
- write sensitive JSON files such as identity/config/daemon registry/peers with `0600`
- rewrite `peers.json` and daemon registry through temp-file + fsync + same-directory rename
- tighten UDS parent directories and best-effort chmod broker/supervisor socket paths
- add POSIX mode regression tests

## Motivation

Local `remote_pi` state contains pairing, identity, daemon, and IPC control surfaces. Default process umasks can leave files or sockets broader than intended, and non-atomic `peers.json` writes can leave partial state after interruption. This hardening reduces local accidental exposure without changing the protocol.

## Tests

```sh
cd pi-extension
corepack pnpm typecheck
corepack pnpm exec vitest run src/secure_fs.test.ts src/pairing/storage.test.ts src/daemon/registry.test.ts src/daemon/supervisor.test.ts src/session/leader_election.test.ts src/session/cwd_lock.test.ts
corepack pnpm test
corepack pnpm build
```
