### PR TITLE
Add no-payload logging guardrails

### DIFF
--- a/app/lib/data/log_safety.dart
+++ b/app/lib/data/log_safety.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+const Set<String> _sensitiveKeys = {
+  'ct',
+  'token',
+  't',
+  'sig',
+  'signature',
+  'auth',
+  'secret',
+  'sk',
+  'privateKey',
+  'private_key',
+  'prompt',
+  'reply',
+  'response',
+  'text',
+  'message',
+  'body',
+  'payload',
+  'qr',
+  'uri',
+};
+
+Object? redactForLog(Object? value, [String? key]) {
+  if (key != null && _sensitiveKeys.contains(key)) return '[redacted]';
+  if (value is String) return safeLogString(value);
+  if (value is List) return value.map((v) => redactForLog(v)).toList();
+  if (value is Map) {
+    return {
+      for (final entry in value.entries)
+        entry.key: redactForLog(entry.value, entry.key.toString()),
+    };
+  }
+  return value;
+}
+
+String safeLogString(String value) {
+  if (value.startsWith('remotepi://')) return '[redacted-uri]';
+  if (value.length > 48 && RegExp(r'^[A-Za-z0-9+/=_-]+$').hasMatch(value)) {
+    return '${value.substring(0, 8)}…(${value.length} chars)';
+  }
+  return value;
+}
+
+String shortId(String value, {int visible = 8}) {
+  if (value.length <= visible) return value;
+  return '${value.substring(0, visible)}…';
+}
+
+String logTextStats(String value) =>
+    'text.chars=${value.length} text.bytes=${utf8.encode(value).length}';

--- a/app/lib/data/repositories/session_repository.dart
+++ b/app/lib/data/repositories/session_repository.dart
@@ -10,6 +10,7 @@
 
 import 'dart:async';
 
+import 'package:app/data/log_safety.dart';
 import 'package:app/data/repositories/i_session_repository.dart';
 import 'package:app/data/repositories/session_history_store.dart';
 import 'package:app/data/transport/channel.dart';
@@ -262,17 +263,14 @@ class SessionRepository extends Repository implements ISessionRepository {
       // The only outbound log we keep (alongside its echo counterpart
       // in `case UserInput`). Together they form the canonical send→
       // confirm cycle for the optimistic UI.
-      debugPrint('[msg-send] id=${msg.id} text=${_preview(text)}');
+      debugPrint('[msg-send] id=${msg.id} ${logTextStats(text)}');
       await ch.send(msg);
     } else {
       debugPrint(
-        '[msg-send] id=${msg.id} text=${_preview(text)} (channel offline → held pending)',
+        '[msg-send] id=${msg.id} ${logTextStats(text)} (channel offline → held pending)',
       );
     }
   }
-
-  static String _preview(String s) =>
-      s.length <= 60 ? s : '${s.substring(0, 60)}…';
 
   /// Schedule the `pending → failed` transition for [id] if Pi's
   /// rebroadcast doesn't arrive within [_echoTimeout].

--- a/app/test/data/log_safety_test.dart
+++ b/app/test/data/log_safety_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:app/data/log_safety.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('redactForLog removes frame payloads, tokens, and signatures', () {
+    final redacted = redactForLog({
+      'type': 'pair_request',
+      'id': 'msg-1',
+      'ct': 'base64-ciphertext',
+      'token': 'pair-token-secret',
+      'sig': 'auth-signature-secret',
+      'body': {'type': 'user_message', 'text': 'please leak this prompt'},
+      'payload': {'response': 'assistant reply secret'},
+    });
+
+    final rendered = jsonEncode(redacted);
+    expect(rendered, contains('pair_request'));
+    expect(rendered, contains('msg-1'));
+    for (final secret in [
+      'base64-ciphertext',
+      'pair-token-secret',
+      'auth-signature-secret',
+      'please leak this prompt',
+      'assistant reply secret',
+    ]) {
+      expect(rendered, isNot(contains(secret)));
+    }
+  });
+
+  test('safeLogString redacts QR URIs and abbreviates long peer keys', () {
+    expect(safeLogString('remotepi://pair?t=secret&epk=peer'), '[redacted-uri]');
+    expect(
+      safeLogString('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=='),
+      'ABCDEFGH…(66 chars)',
+    );
+    expect(shortId('ABCDEFGHIJKLMNOPQRSTUVWXYZ', visible: 10), 'ABCDEFGHIJ…');
+  });
+
+  test('logTextStats exposes only size metadata', () {
+    final line = logTextStats('sensitive prompt body');
+    expect(line, contains('text.chars='));
+    expect(line, contains('text.bytes='));
+    expect(line, isNot(contains('sensitive prompt body')));
+  });
+}

--- a/pi-extension/src/log_safety.test.ts
+++ b/pi-extension/src/log_safety.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { redactForLog, safeLogString, shortId } from "./log_safety.js";
+
+describe("log safety helpers", () => {
+  test("redacts protocol payloads, tokens, signatures, and message bodies", () => {
+    const redacted = redactForLog({
+      type: "pair_request",
+      id: "msg-1",
+      ct: "base64-ciphertext",
+      token: "pair-token-secret",
+      sig: "auth-signature-secret",
+      body: { type: "user_message", text: "please leak this prompt" },
+      payload: { response: "assistant reply secret" },
+    });
+
+    const rendered = JSON.stringify(redacted);
+    expect(rendered).toContain("pair_request");
+    expect(rendered).toContain("msg-1");
+    for (const secret of [
+      "base64-ciphertext",
+      "pair-token-secret",
+      "auth-signature-secret",
+      "please leak this prompt",
+      "assistant reply secret",
+    ]) {
+      expect(rendered).not.toContain(secret);
+    }
+  });
+
+  test("redacts QR URIs and abbreviates long peer keys", () => {
+    expect(safeLogString("remotepi://pair?t=secret&epk=peer")).toBe("[redacted-uri]");
+    expect(safeLogString("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=="))
+      .toBe("ABCDEFGH…(66 chars)");
+    expect(shortId("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 10)).toBe("ABCDEFGHIJ…");
+  });
+});

--- a/pi-extension/src/log_safety.ts
+++ b/pi-extension/src/log_safety.ts
@@ -1,0 +1,54 @@
+const SENSITIVE_KEYS = new Set([
+  "ct",
+  "token",
+  "t",
+  "sig",
+  "signature",
+  "auth",
+  "secret",
+  "sk",
+  "privateKey",
+  "private_key",
+  "prompt",
+  "reply",
+  "response",
+  "text",
+  "message",
+  "body",
+  "payload",
+  "qr",
+  "uri",
+]);
+
+const REDACTED = "[redacted]";
+const REDACTED_URI = "[redacted-uri]";
+
+export function shortId(value: string, visible = 8): string {
+  if (value.length <= visible) return value;
+  return `${value.slice(0, visible)}…`;
+}
+
+export function safeLogString(value: string): string {
+  if (value.startsWith("remotepi://")) return REDACTED_URI;
+  if (value.length > 48 && /^[A-Za-z0-9+/=_-]+$/.test(value)) {
+    return `${value.slice(0, 8)}…(${value.length} chars)`;
+  }
+  return value;
+}
+
+export function redactForLog(value: unknown): unknown {
+  return redactValue(value, undefined);
+}
+
+function redactValue(value: unknown, key: string | undefined): unknown {
+  if (key && SENSITIVE_KEYS.has(key)) return REDACTED;
+  if (typeof value === "string") return safeLogString(value);
+  if (Array.isArray(value)) return value.map((item) => redactValue(item, undefined));
+  if (!value || typeof value !== "object") return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [entryKey, entryValue] of Object.entries(value)) {
+    out[entryKey] = redactValue(entryValue, entryKey);
+  }
+  return out;
+}

--- a/pi-extension/src/session/broker_remote.ts
+++ b/pi-extension/src/session/broker_remote.ts
@@ -1,4 +1,5 @@
 import type { Broker, RemoteInjectStatus, RemoteRouter } from "./broker.js";
+import { safeLogString, shortId } from "../log_safety.js";
 import { type Envelope, envelope, uuidv7 } from "./envelope.js";
 import type { PiForwardClient } from "../transport/pi_forward_client.js";
 
@@ -311,7 +312,7 @@ export class BrokerRemote implements RemoteRouter {
     const claimedLabel = this.siblingByPubkey.get(fromPc);
     if (!claimedLabel) {
       this.log(
-        `[broker_remote] drop: from_pc ${fromPc.slice(0, 12)}… not in sibling cache`,
+        `[broker_remote] drop: from_pc ${shortId(fromPc, 12)} not in sibling cache`,
       );
       return;
     }
@@ -319,8 +320,8 @@ export class BrokerRemote implements RemoteRouter {
       const fromPrefix = env.from.split(":", 1)[0];
       if (fromPrefix !== claimedLabel) {
         this.log(
-          `[broker_remote] drop: envelope.from "${env.from}" prefix ` +
-          `mismatches sibling label "${claimedLabel}"`,
+          `[broker_remote] drop: envelope.from "${safeLogString(env.from)}" prefix ` +
+          `mismatches sibling label "${safeLogString(claimedLabel)}"`,
         );
         return;
       }
@@ -376,8 +377,8 @@ export class BrokerRemote implements RemoteRouter {
     } else if (toParsed) {
       // `to` carries a third-party prefix — not for us. Drop.
       this.log(
-        `[broker_remote] drop: envelope.to "${env.to}" not addressed to ` +
-        `selfPcLabel "${this.selfPcLabel}"`,
+        `[broker_remote] drop: envelope.to "${safeLogString(env.to)}" not addressed to ` +
+        `selfPcLabel "${safeLogString(this.selfPcLabel)}"`,
       );
       return;
     }

--- a/relay/src/handlers/peer.rs
+++ b/relay/src/handlers/peer.rs
@@ -15,6 +15,7 @@ use crate::AppState;
 use crate::auth::challenge::{
     HELLO_TIMEOUT_MS, challenge_line, gen_nonce, parse_hello, verify_auth,
 };
+use crate::log_safety::{safe_frame_type, short_id};
 use crate::protocol::outer::{OuterEnvelope, parse_line};
 use crate::rooms::RoomMeta;
 
@@ -81,7 +82,7 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
     }
 
     let peer_id = B64.encode(vk.to_bytes());
-    let peer_short = peer_id[peer_id.len().saturating_sub(8)..].to_string();
+    let peer_short = short_id(&peer_id);
 
     // Extract room_id and room_meta from hello (auth handled separately above).
     let room_meta = {
@@ -292,7 +293,7 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
                                 _ => {
                                     warn!(
                                         peer = %peer_short,
-                                        frame_type = %t,
+                                        frame_type = %safe_frame_type(t),
                                         "unknown control frame type, dropping"
                                     );
                                 }
@@ -309,8 +310,7 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
                                 let ct_len = env.ct.len();
                                 let dest_peer = env.peer;
                                 let dest_room = env.room;
-                                let dest_tail =
-                                    dest_peer[dest_peer.len().saturating_sub(8)..].to_string();
+                                let dest_tail = short_id(&dest_peer);
                                 // Rewrite: recipient sees sender's peer_id + sender's room_id.
                                 let rewritten = OuterEnvelope {
                                     peer: peer_id.clone(),

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod handlers;
+pub mod log_safety;
 pub mod mesh;
 pub mod metrics;
 pub mod peers;

--- a/relay/src/log_safety.rs
+++ b/relay/src/log_safety.rs
@@ -1,0 +1,139 @@
+use serde_json::{Map, Value};
+
+const SENSITIVE_KEYS: &[&str] = &[
+    "ct",
+    "token",
+    "t",
+    "sig",
+    "signature",
+    "auth",
+    "secret",
+    "sk",
+    "privateKey",
+    "private_key",
+    "prompt",
+    "reply",
+    "response",
+    "text",
+    "message",
+    "body",
+    "payload",
+    "qr",
+    "uri",
+];
+
+pub fn short_id(value: &str) -> String {
+    let visible = 8;
+    let mut chars = value.chars();
+    let prefix: String = chars.by_ref().take(visible).collect();
+    if chars.next().is_none() {
+        value.to_string()
+    } else {
+        format!("{prefix}…")
+    }
+}
+
+pub fn safe_log_string(value: &str) -> String {
+    if value.starts_with("remotepi://") {
+        return "[redacted-uri]".to_string();
+    }
+    if value.len() > 48
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '/' | '=' | '_' | '-'))
+    {
+        return format!("{}…({} chars)", &value[..8], value.len());
+    }
+    value.to_string()
+}
+
+pub fn safe_frame_type(value: &str) -> String {
+    if value.len() <= 64 && value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        value.to_string()
+    } else {
+        "[redacted-type]".to_string()
+    }
+}
+
+pub fn redact_for_log(value: &Value) -> Value {
+    redact_value(None, value)
+}
+
+fn redact_value(key: Option<&str>, value: &Value) -> Value {
+    if key.is_some_and(|k| SENSITIVE_KEYS.contains(&k)) {
+        return Value::String("[redacted]".to_string());
+    }
+
+    match value {
+        Value::String(s) => Value::String(safe_log_string(s)),
+        Value::Array(values) => {
+            Value::Array(values.iter().map(|v| redact_value(None, v)).collect())
+        }
+        Value::Object(map) => {
+            let redacted = map
+                .iter()
+                .map(|(entry_key, entry_value)| {
+                    (
+                        entry_key.clone(),
+                        redact_value(Some(entry_key), entry_value),
+                    )
+                })
+                .collect::<Map<String, Value>>();
+            Value::Object(redacted)
+        }
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_protocol_payloads_tokens_signatures_and_message_bodies() {
+        let redacted = redact_for_log(&serde_json::json!({
+            "type": "pair_request",
+            "id": "msg-1",
+            "ct": "base64-ciphertext",
+            "token": "pair-token-secret",
+            "sig": "auth-signature-secret",
+            "body": { "type": "user_message", "text": "please leak this prompt" },
+            "payload": { "response": "assistant reply secret" },
+        }));
+
+        let rendered = redacted.to_string();
+        assert!(rendered.contains("pair_request"));
+        assert!(rendered.contains("msg-1"));
+        for secret in [
+            "base64-ciphertext",
+            "pair-token-secret",
+            "auth-signature-secret",
+            "please leak this prompt",
+            "assistant reply secret",
+        ] {
+            assert!(!rendered.contains(secret), "leaked {secret}");
+        }
+    }
+
+    #[test]
+    fn redacts_qr_uris_and_abbreviates_long_peer_keys() {
+        assert_eq!(
+            safe_log_string("remotepi://pair?t=secret&epk=peer"),
+            "[redacted-uri]"
+        );
+        assert_eq!(
+            safe_log_string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=="),
+            "ABCDEFGH…(66 chars)"
+        );
+        assert_eq!(short_id("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "ABCDEFGH…");
+    }
+
+    #[test]
+    fn safe_frame_type_only_allows_compact_identifiers() {
+        assert_eq!(safe_frame_type("rooms_check"), "rooms_check");
+        assert_eq!(
+            safe_frame_type("pair-token-secret-with/slashes"),
+            "[redacted-type]"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add log-safety helpers for relay, mobile app, and Pi extension
- redact representative sensitive protocol fields (`ct`, pairing tokens, signatures, prompt/reply/body/payload text, QR URIs, private key-like fields)
- change mobile `[msg-send]` logs from prompt previews to id + text size metadata
- sanitize relay unknown control-frame type logs before rendering attacker-controlled values
- sanitize Pi extension broker-remote drop logs for untrusted envelope address strings
- add regression tests proving representative sensitive fields are not rendered raw

## Motivation

`remote_pi` currently treats the relay as plaintext, so logs must be metadata-only. Operators should be able to debug routing with type, id, size, short peer IDs, room, and result metadata without retaining prompt bodies, responses, pairing tokens, QR URLs, `ct`, auth signatures, or key material.

## Tests

```sh
cd relay
cargo test --locked log_safety
cargo test --locked
cargo clippy --locked -- -D warnings

cd ../pi-extension
corepack pnpm typecheck
corepack pnpm exec vitest run src/log_safety.test.ts src/session/broker_remote.test.ts
corepack pnpm test
corepack pnpm build

cd ../app
flutter analyze
flutter test test/data/log_safety_test.dart test/data/repositories/session_repository_test.dart test/data/transport/relay_config_test.dart
flutter test
```
