### PR TITLE
Add owner-signed pairing

### DIFF
--- a/app/lib/pairing/pair_request_flow.dart
+++ b/app/lib/pairing/pair_request_flow.dart
@@ -14,8 +14,10 @@ import 'dart:typed_data';
 import 'package:app/data/transport/relay_config.dart';
 import 'package:app/protocol/protocol.dart' show PairOk;
 import 'package:app/protocol/uuid7.dart';
+import 'package:cryptography/cryptography.dart';
 
 import 'qr_scanner.dart';
+import 'signed_pairing.dart';
 import 'storage.dart';
 
 // ---------------------------------------------------------------------------
@@ -66,6 +68,9 @@ Future<PairingResult> performPairing({
   required PeerTransport transport,
   required PairingStorage storage,
   required String deviceName,
+  /// Owner key used to sign pair_request_v2. Required for QR codes that
+  /// carry signed-pairing fields; omitted only for legacy tests/old Pis.
+  SimpleKeyPair? ownerKey,
   /// Effective relay URL the app is currently connected to. Used to
   /// detect mismatch vs `qr.relayUrl` for legacy QRs. Passed in by
   /// the caller (PairingViewModel reads it from Preferences).
@@ -103,12 +108,37 @@ Future<PairingResult> performPairing({
   }
 
   final id = uuid7();
-  final req = {
-    'type': 'pair_request',
-    'id': id,
-    'token': qr.token,
-    'device_name': deviceName,
-  };
+  final Map<String, dynamic> req;
+  String? ownerPk;
+  String? appPeerPk;
+  if (qr.supportsSignedPairing) {
+    final key = ownerKey;
+    if (key == null) {
+      throw const PairingError(
+        code: 'owner_identity_required',
+        message: 'Signed pairing requires the synced Owner identity.',
+      );
+    }
+    req = await buildSignedPairRequestV2(
+      id: id,
+      token: qr.token,
+      deviceName: deviceName,
+      ownerKey: key,
+      piPk: base64.encode(qr.epkBytes),
+      roomId: pairingRoomId,
+      pairNonce: qr.pairNonce!,
+      expiresAt: qr.expiresAt!,
+    );
+    ownerPk = req['owner_pk'] as String;
+    appPeerPk = req['app_peer_pk'] as String;
+  } else {
+    req = {
+      'type': 'pair_request',
+      'id': id,
+      'token': qr.token,
+      'device_name': deviceName,
+    };
+  }
   await transport.send(Uint8List.fromList(utf8.encode(jsonEncode(req))));
 
   final raw = await transport.receive();
@@ -145,6 +175,8 @@ Future<PairingResult> performPairing({
       // Plan/27 Wave A — null when pi-extension hasn't been upgraded
       // yet to publish `harness` in pair_ok.
       harness: pairOk.harness,
+      ownerPk: ownerPk,
+      appPeerPk: appPeerPk,
     );
     await storage.savePeer(peer);
     return PairingResult(peer: peer, hostnameHint: pairOk.hostname);
@@ -172,12 +204,14 @@ Future<PairingResult> performPairingWithRelay(
   required PeerTransport transport,
   required PairingStorage storage,
   required String deviceName,
+  SimpleKeyPair? ownerKey,
 }) =>
     performPairing(
       qr: qr,
       transport: transport,
       storage: storage,
       deviceName: deviceName,
+      ownerKey: ownerKey,
       currentRelayUrl: currentRelayUrl,
     );
 

--- a/app/lib/pairing/qr_scanner.dart
+++ b/app/lib/pairing/qr_scanner.dart
@@ -17,6 +17,8 @@ import 'dart:convert';
 //         "dest (peer, room) not found"). Optional; legacy QRs without
 //         `rm` make the app fall back to `'main'` during pair_request
 //         and rely on subscribe_rooms-based discovery afterwards.
+//   pn  — pair nonce for signed pair_request_v2.
+//   exp — token/session expiry timestamp in milliseconds since epoch.
 
 class QrPairPayload {
   final String token;
@@ -30,6 +32,12 @@ class QrPairPayload {
   /// right Pi-WS. `null` for pre-plan-17 QRs — caller must fall back to
   /// `'main'` and discover the real room id via subscribe_rooms.
   final String? roomId;
+  /// Pair nonce for pair_request_v2. Null for legacy QRs.
+  final String? pairNonce;
+  /// Expiry timestamp in milliseconds since epoch for pair_request_v2.
+  final int? expiresAt;
+
+  bool get supportsSignedPairing => pairNonce != null && expiresAt != null;
 
   const QrPairPayload({
     required this.token,
@@ -37,6 +45,8 @@ class QrPairPayload {
     required this.sessionName,
     this.relayUrl,
     this.roomId,
+    this.pairNonce,
+    this.expiresAt,
   });
 
   static QrPairPayload? tryParse(String raw) {
@@ -48,6 +58,8 @@ class QrPairPayload {
       final r = uri.queryParameters['r']; // legacy/optional
       final n = uri.queryParameters['n'];
       final rm = uri.queryParameters['rm']; // plan 17 — Pi-side room
+      final pn = uri.queryParameters['pn']; // signed pairing nonce
+      final expRaw = uri.queryParameters['exp']; // signed pairing expiry ms
       // r is no longer required — plan 14 dropped it from the canonical
       // contract. Legacy QRs continue to include it; we capture it for
       // mismatch detection but don't reject when absent.
@@ -56,12 +68,21 @@ class QrPairPayload {
       if (t == null || epk == null || n == null) return null;
       if (base64Url.decode(_pad(t)).length != 16) return null;
       if (base64Url.decode(_pad(epk)).length != 32) return null;
+      int? expiresAt;
+      if (expRaw != null && expRaw.isNotEmpty) {
+        expiresAt = int.tryParse(expRaw);
+        if (expiresAt == null || expiresAt <= 0) return null;
+      }
+      if ((pn == null) != (expiresAt == null)) return null;
+      if (pn != null && base64Url.decode(_pad(pn)).length != 16) return null;
       return QrPairPayload(
         token: t,
         epk: epk,
         sessionName: n,
         relayUrl: (r != null && r.isNotEmpty) ? r : null,
         roomId: (rm != null && rm.isNotEmpty) ? rm : null,
+        pairNonce: (pn != null && pn.isNotEmpty) ? pn : null,
+        expiresAt: expiresAt,
       );
     } catch (_) {
       return null;

--- a/app/lib/pairing/signed_pairing.dart
+++ b/app/lib/pairing/signed_pairing.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+
+Map<String, dynamic> pairRequestV2UnsignedFields({
+  required String id,
+  required String token,
+  required String deviceName,
+  required String ownerPk,
+  required String appPeerPk,
+  required String piPk,
+  required String roomId,
+  required String pairNonce,
+  required int expiresAt,
+}) => {
+      'type': 'pair_request_v2',
+      'id': id,
+      'token': token,
+      'device_name': deviceName,
+      'owner_pk': ownerPk,
+      'app_peer_pk': appPeerPk,
+      'pi_pk': piPk,
+      'room_id': roomId,
+      'pair_nonce': pairNonce,
+      'expires_at': expiresAt,
+    };
+
+String canonicalPairRequestV2(Map<String, dynamic> unsigned) => jsonEncode({
+      'type': unsigned['type'],
+      'id': unsigned['id'],
+      'token': unsigned['token'],
+      'device_name': unsigned['device_name'],
+      'owner_pk': unsigned['owner_pk'],
+      'app_peer_pk': unsigned['app_peer_pk'],
+      'pi_pk': unsigned['pi_pk'],
+      'room_id': unsigned['room_id'],
+      'pair_nonce': unsigned['pair_nonce'],
+      'expires_at': unsigned['expires_at'],
+    });
+
+Future<Map<String, dynamic>> buildSignedPairRequestV2({
+  required String id,
+  required String token,
+  required String deviceName,
+  required SimpleKeyPair ownerKey,
+  required String piPk,
+  required String roomId,
+  required String pairNonce,
+  required int expiresAt,
+}) async {
+  final ownerPub = await ownerKey.extractPublicKey();
+  final ownerPk = base64.encode(ownerPub.bytes);
+  // Current app challenge-response also authenticates with the Owner key, so
+  // the relay-authenticated app peer key is the Owner public key. Keeping the
+  // field explicit binds the signature to the relay peer and leaves room for a
+  // future per-device app key without changing the canonical payload shape.
+  final appPeerPk = ownerPk;
+  final unsigned = pairRequestV2UnsignedFields(
+    id: id,
+    token: token,
+    deviceName: deviceName,
+    ownerPk: ownerPk,
+    appPeerPk: appPeerPk,
+    piPk: piPk,
+    roomId: roomId,
+    pairNonce: pairNonce,
+    expiresAt: expiresAt,
+  );
+  final canonical = canonicalPairRequestV2(unsigned);
+  final sig = await Ed25519().sign(
+    Uint8List.fromList(utf8.encode(canonical)),
+    keyPair: ownerKey,
+  );
+  return {
+    ...unsigned,
+    'sig': base64.encode(sig.bytes),
+  };
+}

--- a/app/lib/pairing/storage.dart
+++ b/app/lib/pairing/storage.dart
@@ -100,6 +100,10 @@ class PeerRecord {
   /// fall back to [PiHarness.piCodingAgentUnknown] so the UI never
   /// renders an empty subtitle.
   final PiHarness? harness;
+  /// Owner signing public key proven during pair_request_v2.
+  final String? ownerPk;
+  /// Relay-authenticated app peer key bound into pair_request_v2.
+  final String? appPeerPk;
 
   const PeerRecord({
     required this.remoteEpk,
@@ -109,6 +113,8 @@ class PeerRecord {
     this.nickname,
     this.roomId,
     this.harness,
+    this.ownerPk,
+    this.appPeerPk,
   });
 
   Map<String, dynamic> toJson() => {
@@ -119,6 +125,8 @@ class PeerRecord {
     'nickname': nickname,
     'room_id': roomId,
     if (harness != null) 'harness': harness!.toJson(),
+    if (ownerPk != null) 'owner_pk': ownerPk,
+    if (appPeerPk != null) 'app_peer_pk': appPeerPk,
   };
 
   factory PeerRecord.fromJson(Map<String, dynamic> j) {
@@ -139,6 +147,8 @@ class PeerRecord {
       harness: harnessJson is Map<String, dynamic>
           ? PiHarness.fromJson(harnessJson)
           : null,
+      ownerPk: j['owner_pk'] as String?,
+      appPeerPk: j['app_peer_pk'] as String?,
     );
   }
 
@@ -148,6 +158,8 @@ class PeerRecord {
     Object? nickname = _unset,
     Object? roomId = _unset,
     Object? harness = _unset,
+    Object? ownerPk = _unset,
+    Object? appPeerPk = _unset,
   }) => PeerRecord(
     remoteEpk: remoteEpk,
     sessionName: sessionName ?? this.sessionName,
@@ -162,6 +174,12 @@ class PeerRecord {
     harness: identical(harness, _unset)
         ? this.harness
         : harness as PiHarness?,
+    ownerPk: identical(ownerPk, _unset)
+        ? this.ownerPk
+        : ownerPk as String?,
+    appPeerPk: identical(appPeerPk, _unset)
+        ? this.appPeerPk
+        : appPeerPk as String?,
   );
 
   @override
@@ -173,7 +191,9 @@ class PeerRecord {
       other.pairedAt == pairedAt &&
       other.nickname == nickname &&
       other.roomId == roomId &&
-      other.harness == harness;
+      other.harness == harness &&
+      other.ownerPk == ownerPk &&
+      other.appPeerPk == appPeerPk;
 
   @override
   int get hashCode => Object.hash(
@@ -184,6 +204,8 @@ class PeerRecord {
         nickname,
         roomId,
         harness,
+        ownerPk,
+        appPeerPk,
       );
 }
 

--- a/app/lib/ui/pairing/viewmodels/pairing_viewmodel.dart
+++ b/app/lib/ui/pairing/viewmodels/pairing_viewmodel.dart
@@ -69,6 +69,7 @@ class PairingViewModel extends ViewModel<PairingState> {
         transport: transport,
         storage: _storage,
         deviceName: _deviceName(),
+        ownerKey: ownerKey,
         currentRelayUrl: resolveRelayUrl(_prefs),
       ).timeout(
         const Duration(seconds: 30),

--- a/app/test/pairing/pair_request_flow_test.dart
+++ b/app/test/pairing/pair_request_flow_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:app/pairing/pair_request_flow.dart';
 import 'package:app/pairing/qr_scanner.dart';
 import 'package:app/pairing/storage.dart';
+import 'package:cryptography/cryptography.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _Q {
@@ -230,5 +231,89 @@ void main() {
             reason: 'when QR lacks r=, persist currentRelayUrl');
       },
     );
+
+    test('signed QR without Owner key throws owner_identity_required before sending', () async {
+      final q1 = _Q();
+      final q2 = _Q();
+      final app = _MemTransport(send: q2, recv: q1);
+      final qr = QrPairPayload(
+        token: 'AAAAAAAAAAAAAAAAAAAAAA',
+        epk: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        sessionName: 'Pi',
+        roomId: 'room-from-qr',
+        pairNonce: 'AQEBAQEBAQEBAQEBAQEBAQ',
+        expiresAt: 1700000000000,
+      );
+
+      await expectLater(
+        performPairing(
+          qr: qr,
+          transport: app,
+          storage: _FakeStorage(),
+          deviceName: 'phone',
+          currentRelayUrl: 'wss://relay.example',
+        ),
+        throwsA(
+          isA<PairingError>().having(
+            (e) => e.code,
+            'code',
+            'owner_identity_required',
+          ),
+        ),
+      );
+      expect(q2._buf, isEmpty);
+    });
+
+    test('signed QR sends pair_request_v2 and persists owner/app peer keys', () async {
+      final q1 = _Q();
+      final q2 = _Q();
+      final pi = _MemTransport(send: q1, recv: q2);
+      final app = _MemTransport(send: q2, recv: q1);
+      final storage = _FakeStorage();
+      final ownerKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[31] = 9);
+      final ownerPk = base64.encode((await ownerKey.extractPublicKey()).bytes);
+      final qr = QrPairPayload(
+        token: 'AAAAAAAAAAAAAAAAAAAAAA',
+        epk: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        sessionName: 'Pi',
+        roomId: 'room-from-qr',
+        pairNonce: 'AQEBAQEBAQEBAQEBAQEBAQ',
+        expiresAt: 1700000000000,
+      );
+
+      unawaited(() async {
+        final raw = await pi.receive();
+        final req = jsonDecode(utf8.decode(raw)) as Map<String, dynamic>;
+        expect(req['type'], 'pair_request_v2');
+        expect(req['owner_pk'], ownerPk);
+        expect(req['app_peer_pk'], ownerPk);
+        expect(req['pi_pk'], base64.encode(qr.epkBytes));
+        expect(req['room_id'], 'room-from-qr');
+        expect(req['pair_nonce'], 'AQEBAQEBAQEBAQEBAQEBAQ');
+        expect(req['expires_at'], 1700000000000);
+        expect(req['sig'], isA<String>());
+        await pi.send(Uint8List.fromList(utf8.encode(jsonEncode({
+          'type': 'pair_ok',
+          'in_reply_to': req['id'],
+          'session_name': 'Pi',
+          'session_started_at': 1700000000000,
+          'room_id': 'room-from-qr',
+        }))));
+      }());
+
+      final result = await performPairing(
+        qr: qr,
+        transport: app,
+        storage: storage,
+        deviceName: 'phone',
+        ownerKey: ownerKey,
+        currentRelayUrl: 'wss://relay.example',
+      );
+
+      expect(result.peer.ownerPk, ownerPk);
+      expect(result.peer.appPeerPk, ownerPk);
+      expect(storage.saved.single.ownerPk, ownerPk);
+      expect(storage.saved.single.appPeerPk, ownerPk);
+    });
   });
 }

--- a/app/test/pairing/qr_scanner_test.dart
+++ b/app/test/pairing/qr_scanner_test.dart
@@ -86,5 +86,30 @@ void main() {
       expect(qr, isNotNull);
       expect(qr!.roomId, isNull);
     });
+
+    test('parses signed-pairing nonce and expiry', () {
+      final raw = 'remotepi://pair?t=$goodToken&epk=$goodEpk&'
+          'rm=abc123def456&pn=AQEBAQEBAQEBAQEBAQEBAQ&exp=1700000000000&n=$sessionName';
+      final qr = QrPairPayload.tryParse(raw);
+      expect(qr, isNotNull);
+      expect(qr!.supportsSignedPairing, isTrue);
+      expect(qr.pairNonce, 'AQEBAQEBAQEBAQEBAQEBAQ');
+      expect(qr.expiresAt, 1700000000000);
+    });
+
+    test('rejects partial or malformed signed-pairing fields', () {
+      expect(
+        QrPairPayload.tryParse(
+          'remotepi://pair?t=$goodToken&epk=$goodEpk&pn=AQEBAQEBAQEBAQEBAQEBAQ&n=$sessionName',
+        ),
+        isNull,
+      );
+      expect(
+        QrPairPayload.tryParse(
+          'remotepi://pair?t=$goodToken&epk=$goodEpk&pn=bad&exp=1700000000000&n=$sessionName',
+        ),
+        isNull,
+      );
+    });
   });
 }

--- a/app/test/pairing/signed_pairing_test.dart
+++ b/app/test/pairing/signed_pairing_test.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:app/pairing/signed_pairing.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  group('signed pairing helpers', () {
+    test('canonicalPairRequestV2 is stable and excludes sig', () {
+      final unsigned = pairRequestV2UnsignedFields(
+        id: 'id-1',
+        token: 'token-1',
+        deviceName: 'phone',
+        ownerPk: 'owner-pk',
+        appPeerPk: 'app-peer-pk',
+        piPk: 'pi-pk',
+        roomId: 'room-1',
+        pairNonce: 'nonce-1',
+        expiresAt: 1700000000000,
+      );
+
+      expect(
+        canonicalPairRequestV2({...unsigned, 'sig': 'must-not-appear'}),
+        '{"type":"pair_request_v2","id":"id-1","token":"token-1","device_name":"phone",'
+        '"owner_pk":"owner-pk","app_peer_pk":"app-peer-pk","pi_pk":"pi-pk",'
+        '"room_id":"room-1","pair_nonce":"nonce-1","expires_at":1700000000000}',
+      );
+    });
+
+    test('buildSignedPairRequestV2 signs the canonical payload', () async {
+      final key = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[31] = 7);
+      final req = await buildSignedPairRequestV2(
+        id: 'id-1',
+        token: 'token-1',
+        deviceName: 'phone',
+        ownerKey: key,
+        piPk: base64.encode(Uint8List(32)..[0] = 1),
+        roomId: 'room-1',
+        pairNonce: 'nonce-1',
+        expiresAt: 1700000000000,
+      );
+
+      expect(req['type'], 'pair_request_v2');
+      expect(req['owner_pk'], req['app_peer_pk']);
+      final sig = Signature(base64.decode(req['sig'] as String), publicKey: await key.extractPublicKey());
+      final ok = await Ed25519().verify(
+        utf8.encode(canonicalPairRequestV2(req)),
+        signature: sig,
+      );
+      expect(ok, isTrue);
+    });
+  });
+}

--- a/app/test/pairing/storage_test.dart
+++ b/app/test/pairing/storage_test.dart
@@ -163,6 +163,23 @@ void main() {
       expect(restored.harness!.version, '0.4.2');
     });
 
+    test('owner/app peer keys round-trip through toJson/fromJson', () {
+      const record = PeerRecord(
+        remoteEpk: 'pk1',
+        sessionName: 'name',
+        relayUrl: 'ws://x',
+        pairedAt: '2026-01-01T00:00:00Z',
+        ownerPk: 'owner-key',
+        appPeerPk: 'app-peer-key',
+      );
+      final json = record.toJson();
+      expect(json['owner_pk'], 'owner-key');
+      expect(json['app_peer_pk'], 'app-peer-key');
+      final restored = PeerRecord.fromJson(json);
+      expect(restored.ownerPk, 'owner-key');
+      expect(restored.appPeerPk, 'app-peer-key');
+    });
+
     test('legacy record without harness field → fromJson keeps null', () {
       final restored = PeerRecord.fromJson({
         'remote_epk': 'pk1',

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -9,6 +9,7 @@ import { EventEmitter } from "node:events";
 import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { roomIdForCwd } from "./rooms.js";
 
 // ── Mock RelayClient ──────────────────────────────────────────────────────────
 
@@ -40,9 +41,31 @@ vi.mock("./transport/relay_client.js", () => ({
   RoomAlreadyOpenError: MockRoomAlreadyOpenError,
 }));
 
+vi.mock("./pairing/signed_pairing.js", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("./pairing/signed_pairing.js")>();
+  return {
+    ...orig,
+    verifyPairRequestV2Signature: vi.fn().mockImplementation((req: { app_peer_pk?: string; sig?: string }, relayPeer: string) => {
+      if (req.app_peer_pk !== relayPeer) {
+        return { ok: false, code: "app_peer_mismatch", message: "app_peer_pk does not match relay-authenticated peer" };
+      }
+      if (req.sig === "bad-signature") {
+        return { ok: false, code: "signature_invalid", message: "Invalid pair_request_v2 signature" };
+      }
+      return { ok: true };
+    }),
+  };
+});
+
 // ── Mock storage ──────────────────────────────────────────────────────────────
 
-type StoredPeer = { name: string; remote_epk: string; paired_at: string };
+type StoredPeer = {
+  name: string;
+  remote_epk: string;
+  paired_at: string;
+  owner_pk?: string;
+  app_peer_pk?: string;
+};
 const _knownPeers: StoredPeer[] = [];
 const _addedPeers: StoredPeer[] = [];
 const _removedPeers: string[] = [];
@@ -103,7 +126,7 @@ vi.mock("./config.js", async (importOriginal) => {
   };
 });
 
-// ── Mock qrSession.consumeToken control ───────────────────────────────────────
+// ── Mock qrSession token control ──────────────────────────────────────────────
 
 let _tokenStatus: "ok" | "expired" | "consumed" | "unknown" = "ok";
 const _consumeCalls: string[] = [];
@@ -116,7 +139,12 @@ vi.mock("./pairing/qr.js", async (importOriginal) => {
     qrSession: {
       issueToken: vi.fn().mockReturnValue({
         token: "test-token",
-        expiresAt: Date.now() + 60_000,
+        pairNonce: "test-pair-nonce",
+        expiresAt: 1_700_000_060_000,
+      }),
+      checkToken: vi.fn().mockImplementation((token: string) => {
+        if (_tokenStatus !== "ok") return { status: _tokenStatus };
+        return { status: "ok", pairNonce: "test-pair-nonce", expiresAt: 1_700_000_060_000 };
       }),
       consumeToken: vi.fn().mockImplementation((token: string) => {
         _consumeCalls.push(token);
@@ -141,6 +169,7 @@ const {
   _getMessageBufferForTest,
   _setCurrentModelForTest,
   _connectForTest,
+  _stopForTest,
   _hasActivePeerForTest,
   _getActivePeerCountForTest,
 } = await import("./index.js");
@@ -184,7 +213,21 @@ function captureHandler(commandName: string): CmdHandler {
 }
 
 function makeInnerLine(peer: string, inner: object): string {
-  const ct = Buffer.from(JSON.stringify(inner)).toString("base64");
+  const record = inner as Record<string, unknown>;
+  const wire = record["type"] === "pair_request"
+    ? {
+        ...record,
+        type: "pair_request_v2",
+        owner_pk: record["owner_pk"] ?? peer,
+        app_peer_pk: record["app_peer_pk"] ?? peer,
+        pi_pk: record["pi_pk"] ?? Buffer.from(new Uint8Array(32)).toString("base64"),
+        room_id: record["room_id"] ?? roomIdForCwd("/home/user/projects/remote_pi"),
+        pair_nonce: record["pair_nonce"] ?? "test-pair-nonce",
+        expires_at: record["expires_at"] ?? 1_700_000_060_000,
+        sig: record["sig"] ?? "test-signature",
+      }
+    : record;
+  const ct = Buffer.from(JSON.stringify(wire)).toString("base64");
   return JSON.stringify({ peer, ct });
 }
 
@@ -262,8 +305,14 @@ describe("state machine + pair_request flow", () => {
     _consumeCalls.length = 0;
     _tokenStatus = "ok";
     relayRef.current = null;
-    // Restore default consumeToken behavior — earlier tests can override it.
+    // Restore default token behavior — earlier tests can override it.
     const qr = await import("./pairing/qr.js");
+    (qr.qrSession.checkToken as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (token: string) => {
+        if (_tokenStatus !== "ok") return { status: _tokenStatus };
+        return { status: "ok", pairNonce: "test-pair-nonce", expiresAt: 1_700_000_060_000 };
+      },
+    );
     (qr.qrSession.consumeToken as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       (token: string) => {
         _consumeCalls.push(token);
@@ -337,7 +386,81 @@ describe("state machine + pair_request flow", () => {
     expect(_addedPeers[0]).toMatchObject({
       name: "iPhone do Jacob",
       remote_epk: APP_PEER_ID,
+      owner_pk: APP_PEER_ID,
+      app_peer_pk: APP_PEER_ID,
     });
+  });
+
+  test("legacy unsigned pair_request is rejected", async () => {
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx());
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "legacy-peer",
+      ct: Buffer.from(JSON.stringify({
+        type: "pair_request",
+        id: "req-legacy",
+        token: "test-token",
+        device_name: "Old App",
+      })).toString("base64"),
+    }));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(_getState()).toBe("started");
+    expect(_addedPeers).toHaveLength(0);
+    const sent = relayRef.current!.send.mock.calls.map((c) => c[0] as string);
+    const errs = sent.map(decodeSentCt).filter((d) => d.inner.type === "pair_error");
+    expect(errs).toHaveLength(1);
+    expect(errs[0]!.inner).toMatchObject({
+      type: "pair_error",
+      in_reply_to: "req-legacy",
+      code: "pair_unsupported",
+    });
+  });
+
+  test("pair_request_v2 QR-binding mismatches fail before token consumption", async () => {
+    const cases: Array<{ name: string; patch: Record<string, unknown> }> = [
+      { name: "pi_pk", patch: { pi_pk: Buffer.from(new Uint8Array(32).fill(9)).toString("base64") } },
+      { name: "room_id", patch: { room_id: "wrong-room" } },
+      { name: "pair_nonce", patch: { pair_nonce: "wrong-nonce" } },
+      { name: "expires_at", patch: { expires_at: 1_700_000_999_000 } },
+      { name: "app_peer_pk", patch: { app_peer_pk: "different-app-peer" } },
+      { name: "sig", patch: { sig: "bad-signature" } },
+    ];
+
+    for (const c of cases) {
+      await _stopForTest(makeMockCtx());
+      vi.clearAllMocks();
+      _addedPeers.length = 0;
+      _consumeCalls.length = 0;
+      _tokenStatus = "ok";
+      relayRef.current = null;
+
+      captureHandler("remote-pi");
+      await _connectForTest(makeMockCtx());
+
+      relayRef.current!.emit("message", makeInnerLine(`bad-${c.name}`, {
+        type: "pair_request",
+        id: `req-bad-${c.name}`,
+        token: "test-token",
+        device_name: "Bad Phone",
+        ...c.patch,
+      }));
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(_getState(), c.name).toBe("started");
+      expect(_addedPeers, c.name).toHaveLength(0);
+      expect(_consumeCalls, c.name).toHaveLength(0);
+      const sent = relayRef.current!.send.mock.calls.map((call) => call[0] as string);
+      const errs = sent.map(decodeSentCt).filter((d) => d.inner.type === "pair_error");
+      expect(errs, c.name).toHaveLength(1);
+      expect(errs[0]!.inner).toMatchObject({
+        type: "pair_error",
+        in_reply_to: `req-bad-${c.name}`,
+        code: "pair_invalid",
+      });
+    }
   });
 
   test("expired token → pair_error{token_expired} + state stays started", async () => {
@@ -685,11 +808,8 @@ describe("/remote-pi revoke", () => {
     captureHandler("remote-pi");
     await _connectForTest(makeMockCtx());
 
-    relayRef.current!.emit("message", JSON.stringify({
-      peer: ACTIVE_PEER,
-      ct: Buffer.from(JSON.stringify({
-        type: "pair_request", id: "req-1", token: "test-token", device_name: "Active Phone",
-      })).toString("base64"),
+    relayRef.current!.emit("message", makeInnerLine(ACTIVE_PEER, {
+      type: "pair_request", id: "req-1", token: "test-token", device_name: "Active Phone",
     }));
     await vi.waitFor(() => expect(_getState()).toBe("paired"), { timeout: 2000 });
 
@@ -715,11 +835,8 @@ describe("/remote-pi revoke", () => {
 
     await _connectForTest(makeMockCtx());
 
-    relayRef.current!.emit("message", JSON.stringify({
-      peer: ACTIVE_PEER,
-      ct: Buffer.from(JSON.stringify({
-        type: "pair_request", id: "req-1", token: "test-token", device_name: "Active Phone",
-      })).toString("base64"),
+    relayRef.current!.emit("message", makeInnerLine(ACTIVE_PEER, {
+      type: "pair_request", id: "req-1", token: "test-token", device_name: "Active Phone",
     }));
     await vi.waitFor(() => expect(_getState()).toBe("paired"), { timeout: 2000 });
 
@@ -763,11 +880,8 @@ function captureEventHandler(eventName: string): EventHandler {
 async function _pairForTest(appPeerId: string): Promise<void> {
   captureHandler("remote-pi");
   await _connectForTest(makeMockCtx());
-  relayRef.current!.emit("message", JSON.stringify({
-    peer: appPeerId,
-    ct: Buffer.from(JSON.stringify({
-      type: "pair_request", id: "req-1", token: "test-token", device_name: "Phone",
-    })).toString("base64"),
+  relayRef.current!.emit("message", makeInnerLine(appPeerId, {
+    type: "pair_request", id: "req-1", token: "test-token", device_name: "Phone",
   }));
   await vi.waitFor(() => expect(_getState()).toBe("paired"), { timeout: 2000 });
 }
@@ -775,11 +889,8 @@ async function _pairForTest(appPeerId: string): Promise<void> {
 /** Adds a second pair_request from a new peer to an already-running Pi.
  *  Used by multi-channel tests to verify the catch-22 is gone. */
 async function _pairAdditionalForTest(appPeerId: string, deviceName: string): Promise<void> {
-  relayRef.current!.emit("message", JSON.stringify({
-    peer: appPeerId,
-    ct: Buffer.from(JSON.stringify({
-      type: "pair_request", id: `req-${appPeerId.slice(0, 6)}`, token: "test-token", device_name: deviceName,
-    })).toString("base64"),
+  relayRef.current!.emit("message", makeInnerLine(appPeerId, {
+    type: "pair_request", id: `req-${appPeerId.slice(0, 6)}`, token: "test-token", device_name: deviceName,
   }));
   await vi.waitFor(
     () => expect(_hasActivePeerForTest(appPeerId)).toBe(true),
@@ -1476,7 +1587,17 @@ describe("rooms wiring", () => {
     relayRef.current!.emit("message", JSON.stringify({
       peer: "peer-room-test",
       ct: Buffer.from(JSON.stringify({
-        type: "pair_request", id: "req-1", token: "test-token", device_name: "Phone",
+        type: "pair_request_v2",
+        id: "req-1",
+        token: "test-token",
+        device_name: "Phone",
+        owner_pk: "peer-room-test",
+        app_peer_pk: "peer-room-test",
+        pi_pk: Buffer.from(new Uint8Array(32)).toString("base64"),
+        room_id: roomIdForCwd("/tmp/remote-pi-room-test"),
+        pair_nonce: "test-pair-nonce",
+        expires_at: 1_700_000_060_000,
+        sig: "test-signature",
       })).toString("base64"),
     }));
     await vi.waitFor(() => expect(_getState()).toBe("paired"), { timeout: 2000 });

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -39,6 +39,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import { type Ed25519Keypair } from "./pairing/crypto.js";
 import { buildQRUri, qrSession, renderQRAscii } from "./pairing/qr.js";
+import { verifyPairRequestV2Signature } from "./pairing/signed_pairing.js";
 import {
   addPeer,
   getOrCreateEd25519Keypair,
@@ -782,8 +783,13 @@ function _installAutoListener(relay: RelayClient): () => void {
 
     const appPeerId = outer.peer;
 
+    if (inner.type === "pair_request_v2") {
+      await _handlePairRequestV2(relay, appPeerId, inner);
+      return;
+    }
+
     if (inner.type === "pair_request") {
-      await _handlePairRequest(relay, appPeerId, inner);
+      _sendPairError(relay, appPeerId, inner.id, "pair_unsupported", "This Pi requires signed pair_request_v2. Update the Remote Pi app and re-scan QR.");
       return;
     }
 
@@ -841,31 +847,67 @@ const _HARNESS = {
 } as const;
 const _HOSTNAME = hostname();
 
-async function _handlePairRequest(
+function _sendPairInner(relay: RelayClient, appPeerId: string, msg: ServerMessage): void {
+  const ct = Buffer.from(JSON.stringify(msg)).toString("base64");
+  relay.send(JSON.stringify({ peer: appPeerId, ct }));
+}
+
+function _sendPairError(
   relay: RelayClient,
   appPeerId: string,
-  inner: Extract<ClientMessage, { type: "pair_request" }>,
+  inReplyTo: string,
+  code: PairErrorCode,
+  message: string,
+): void {
+  _sendPairInner(relay, appPeerId, { type: "pair_error", in_reply_to: inReplyTo, code, message });
+}
+
+async function _handlePairRequestV2(
+  relay: RelayClient,
+  appPeerId: string,
+  inner: Extract<ClientMessage, { type: "pair_request_v2" }>,
 ): Promise<void> {
-  const sendInner = (msg: ServerMessage) => {
-    const ct = Buffer.from(JSON.stringify(msg)).toString("base64");
-    relay.send(JSON.stringify({ peer: appPeerId, ct }));
-  };
-
-  const sendError = (code: PairErrorCode, message: string) => {
-    sendInner({ type: "pair_error", in_reply_to: inner.id, code, message });
-  };
-
-  const status = qrSession.consumeToken(inner.token);
-  if (status !== "ok") {
+  const tokenCheck = qrSession.checkToken(inner.token);
+  if (tokenCheck.status !== "ok") {
     const code: PairErrorCode =
-      status === "expired"  ? "token_expired"
-      : status === "consumed" ? "token_consumed"
+      tokenCheck.status === "expired"  ? "token_expired"
+      : tokenCheck.status === "consumed" ? "token_consumed"
       : "token_unknown";
     const msg =
       code === "token_expired"  ? "Ephemeral token expired. Generate a new QR with /remote-pi pair."
       : code === "token_consumed" ? "Token already consumed by another pair_request."
       : "Token was not issued by this Pi.";
-    sendError(code, msg);
+    _sendPairError(relay, appPeerId, inner.id, code, msg);
+    return;
+  }
+
+  const cwd = _lastCtx && "cwd" in _lastCtx
+    ? (_lastCtx as ExtensionCommandContext).cwd
+    : process.cwd();
+  const expectedPiPk = _cachedEd25519
+    ? Buffer.from(_cachedEd25519.publicKey).toString("base64")
+    : "";
+  const expectedRoomId = _myRoomId ?? roomIdForCwd(cwd);
+
+  if (
+    inner.pi_pk !== expectedPiPk ||
+    inner.room_id !== expectedRoomId ||
+    inner.pair_nonce !== tokenCheck.pairNonce ||
+    inner.expires_at !== tokenCheck.expiresAt
+  ) {
+    _sendPairError(relay, appPeerId, inner.id, "pair_invalid", "Pair request does not match the active QR session.");
+    return;
+  }
+
+  const sigCheck = verifyPairRequestV2Signature(inner, appPeerId);
+  if (!sigCheck.ok) {
+    _sendPairError(relay, appPeerId, inner.id, "pair_invalid", sigCheck.message);
+    return;
+  }
+
+  const consumeStatus = qrSession.consumeToken(inner.token);
+  if (consumeStatus !== "ok") {
+    _sendPairError(relay, appPeerId, inner.id, "token_consumed", "Token already consumed by another pair_request.");
     return;
   }
 
@@ -874,16 +916,15 @@ async function _handlePairRequest(
       name: inner.device_name,
       remote_epk: appPeerId,
       paired_at: new Date().toISOString(),
+      owner_pk: inner.owner_pk,
+      app_peer_pk: inner.app_peer_pk,
     });
     _refreshPairingsCache();
   } catch (err) {
-    sendError("internal_error", `Failed to persist peer: ${String(err)}`);
+    _sendPairError(relay, appPeerId, inner.id, "internal_error", `Failed to persist peer: ${String(err)}`);
     return;
   }
 
-  const cwd = _lastCtx && "cwd" in _lastCtx
-    ? (_lastCtx as ExtensionCommandContext).cwd
-    : process.cwd();
   // Prefer the user-configured agent_name (with broker suffix when on the
   // mesh) over the legacy parent/folder path — matches what the user sees
   // in the terminal title and in /remote-pi status.
@@ -891,16 +932,14 @@ async function _handlePairRequest(
 
   _attachOwner(relay, appPeerId, inner.device_name);
 
-  sendInner({
+  _sendPairInner(relay, appPeerId, {
     type: "pair_ok",
     in_reply_to: inner.id,
     session_name: sessionName,
     session_started_at: _sessionStartedAt ?? Date.now(),
     // App uses this to address subsequent inner messages to the right room
-    // when this Pi runs alongside others with the same epk. Defensive fallback
-    // to roomIdForCwd(cwd) covers the edge case where pair_request lands
-    // before _cmdStart could set _myRoomId (shouldn't happen in practice).
-    room_id: _myRoomId ?? roomIdForCwd(cwd),
+    // when this Pi runs alongside others with the same epk.
+    room_id: expectedRoomId,
     // Plan/27 Wave A — surface the host coding-agent identity + machine
     // hostname so the app can render a meaningful device row (and tell
     // two PCs apart even when nicknames collide).
@@ -1515,9 +1554,9 @@ async function _cmdPair(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void
   // raw path snippet).
   const sessionName = _displayName(cwd);
 
-  const { token, expiresAt } = qrSession.issueToken();
+  const { token, pairNonce, expiresAt } = qrSession.issueToken();
   const roomId = _myRoomId ?? roomIdForCwd(cwd);
-  const qrUri = buildQRUri(token, edKp.publicKey, sessionName, roomId);
+  const qrUri = buildQRUri(token, edKp.publicKey, sessionName, roomId, pairNonce, expiresAt);
   // Render both the QR ASCII and the copy-paste URI inside the Pi TUI's
   // chat panel via `pi.sendMessage` — the same channel the SDK uses for
   // agent responses + tool results. `process.stderr.write` (the old QR

--- a/pi-extension/src/pairing/qr.test.ts
+++ b/pi-extension/src/pairing/qr.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from "vitest";
+import { buildQRUri, QRSession } from "./qr.js";
+
+describe("QRSession", () => {
+  test("issueToken records pair nonce and expiry for signed pairing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    try {
+      const session = new QRSession();
+      const issued = session.issueToken();
+      expect(Buffer.from(issued.token, "base64url")).toHaveLength(16);
+      expect(Buffer.from(issued.pairNonce, "base64url")).toHaveLength(16);
+      expect(issued.expiresAt).toBe(1_700_000_060_000);
+      expect(session.checkToken(issued.token)).toEqual({
+        status: "ok",
+        pairNonce: issued.pairNonce,
+        expiresAt: issued.expiresAt,
+      });
+      expect(session.consumeToken(issued.token)).toBe("ok");
+      expect(session.checkToken(issued.token)).toEqual({ status: "consumed" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("buildQRUri", () => {
+  test("includes signed-pairing nonce and expiry when provided", () => {
+    const uri = buildQRUri(
+      "AAAAAAAAAAAAAAAAAAAAAA",
+      new Uint8Array(32),
+      "Pi",
+      "room-1",
+      "AQEBAQEBAQEBAQEBAQEBAQ",
+      1_700_000_000_000,
+    );
+    const parsed = new URL(uri);
+    expect(parsed.searchParams.get("pn")).toBe("AQEBAQEBAQEBAQEBAQEBAQ");
+    expect(parsed.searchParams.get("exp")).toBe("1700000000000");
+  });
+});

--- a/pi-extension/src/pairing/qr.ts
+++ b/pi-extension/src/pairing/qr.ts
@@ -5,6 +5,7 @@ const TOKEN_TTL_MS = 60_000;
 
 interface ActiveToken {
   token: string;
+  pairNonce: string;
   expiresAt: number;
   consumed: boolean;
 }
@@ -20,13 +21,28 @@ export class QRSession {
 
   /**
    * Issues a new active token, invalidating any previous one.
-   * Returns the token and its expiry timestamp.
+   * Returns the token, pair nonce, and expiry timestamp.
    */
-  issueToken(): { token: string; expiresAt: number } {
+  issueToken(): { token: string; pairNonce: string; expiresAt: number } {
     const token = this.generateToken();
+    const pairNonce = randomBytes(16).toString("base64url");
     const expiresAt = Date.now() + TOKEN_TTL_MS;
-    this.active = { token, expiresAt, consumed: false };
-    return { token, expiresAt };
+    this.active = { token, pairNonce, expiresAt, consumed: false };
+    return { token, pairNonce, expiresAt };
+  }
+
+  /** Checks a token without consuming it; used before v2 signature verification. */
+  checkToken(token: string):
+    | { status: "ok"; pairNonce: string; expiresAt: number }
+    | { status: "expired" | "consumed" | "unknown" } {
+    if (!this.active || this.active.token !== token) return { status: "unknown" };
+    if (this.active.consumed) return { status: "consumed" };
+    if (Date.now() > this.active.expiresAt) return { status: "expired" };
+    return {
+      status: "ok",
+      pairNonce: this.active.pairNonce,
+      expiresAt: this.active.expiresAt,
+    };
   }
 
   /** Validates and atomically consumes a token. */
@@ -60,6 +76,8 @@ export function buildQRUri(
    * cai em room=main e o relay drops com "dest not found").
    */
   roomId?: string,
+  pairNonce?: string,
+  expiresAt?: number,
 ): string {
   // `r` (relay URL) removed in plano 14 — relay now comes from app config /
   // pi-ext env|config|default chain. Keeps QR ~30-50 chars shorter.
@@ -75,6 +93,8 @@ export function buildQRUri(
     n: sessionName.slice(0, 80),
   });
   if (roomId) params.set("rm", roomId);
+  if (pairNonce) params.set("pn", pairNonce);
+  if (expiresAt !== undefined) params.set("exp", String(expiresAt));
   return `remotepi://pair?${params.toString()}`;
 }
 
@@ -121,8 +141,8 @@ export function startQRRotation(
 
   const rotate = () => {
     if (stopped) return;
-    const { token, expiresAt } = qrSession.issueToken();
-    const uri = buildQRUri(token, longtermEdPk, sessionName, roomId);
+    const { token, pairNonce, expiresAt } = qrSession.issueToken();
+    const uri = buildQRUri(token, longtermEdPk, sessionName, roomId, pairNonce, expiresAt);
     displayQR(uri);
     console.log(
       `⏱  Renews at ${new Date(expiresAt).toLocaleTimeString()} — waiting for scan…`,

--- a/pi-extension/src/pairing/signed_pairing.test.ts
+++ b/pi-extension/src/pairing/signed_pairing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { ed25519Sign, generateEd25519Keypair } from "./crypto.js";
+import {
+  canonicalPairRequestV2,
+  type PairRequestV2,
+  verifyPairRequestV2Signature,
+} from "./signed_pairing.js";
+
+function makeSigned(overrides: Partial<PairRequestV2> = {}): PairRequestV2 {
+  const owner = generateEd25519Keypair();
+  const pi = generateEd25519Keypair();
+  const ownerPk = Buffer.from(owner.publicKey).toString("base64");
+  const base = {
+    type: "pair_request_v2" as const,
+    id: "id-1",
+    token: "token-1",
+    device_name: "phone",
+    owner_pk: ownerPk,
+    app_peer_pk: ownerPk,
+    pi_pk: Buffer.from(pi.publicKey).toString("base64"),
+    room_id: "room-1",
+    pair_nonce: "nonce-1",
+    expires_at: 1_700_000_000_000,
+  };
+  const req = { ...base, ...overrides };
+  const sig = Buffer.from(ed25519Sign(owner.secretKey, Buffer.from(canonicalPairRequestV2(req), "utf8")))
+    .toString("base64");
+  return { ...req, sig, ...overrides };
+}
+
+describe("signed pairing", () => {
+  test("canonicalPairRequestV2 is stable and excludes sig", () => {
+    const req = makeSigned();
+    const canonical = canonicalPairRequestV2(req);
+    expect(canonical).toBe(
+      '{"type":"pair_request_v2","id":"id-1","token":"token-1","device_name":"phone",' +
+      `"owner_pk":"${req.owner_pk}","app_peer_pk":"${req.app_peer_pk}",` +
+      `"pi_pk":"${req.pi_pk}","room_id":"room-1","pair_nonce":"nonce-1",` +
+      '"expires_at":1700000000000}',
+    );
+    expect(canonical).not.toContain(req.sig);
+  });
+
+  test("valid signature verifies", () => {
+    const req = makeSigned();
+    expect(verifyPairRequestV2Signature(req, req.app_peer_pk)).toEqual({ ok: true });
+  });
+
+  test("tampering and relay-authenticated peer mismatch fail", () => {
+    const req = makeSigned();
+    expect(verifyPairRequestV2Signature({ ...req, token: "other" }, req.app_peer_pk)).toMatchObject({
+      ok: false,
+      code: "signature_invalid",
+    });
+    expect(verifyPairRequestV2Signature(req, Buffer.from(generateEd25519Keypair().publicKey).toString("base64")))
+      .toMatchObject({ ok: false, code: "app_peer_mismatch" });
+  });
+});

--- a/pi-extension/src/pairing/signed_pairing.ts
+++ b/pi-extension/src/pairing/signed_pairing.ts
@@ -1,0 +1,88 @@
+import { ed25519Verify } from "./crypto.js";
+
+export interface PairRequestV2 {
+  type: "pair_request_v2";
+  id: string;
+  token: string;
+  device_name: string;
+  owner_pk: string;
+  app_peer_pk: string;
+  pi_pk: string;
+  room_id: string;
+  pair_nonce: string;
+  expires_at: number;
+  sig: string;
+}
+
+export type PairRequestV2Validation =
+  | { ok: true }
+  | { ok: false; code: string; message: string };
+
+export function canonicalPairRequestV2(req: Omit<PairRequestV2, "sig">): string {
+  return JSON.stringify({
+    type: req.type,
+    id: req.id,
+    token: req.token,
+    device_name: req.device_name,
+    owner_pk: req.owner_pk,
+    app_peer_pk: req.app_peer_pk,
+    pi_pk: req.pi_pk,
+    room_id: req.room_id,
+    pair_nonce: req.pair_nonce,
+    expires_at: req.expires_at,
+  });
+}
+
+function decodeB64(value: string, expectedLength: number): Buffer | null {
+  try {
+    const bytes = Buffer.from(value, "base64");
+    return bytes.length === expectedLength ? bytes : null;
+  } catch {
+    return null;
+  }
+}
+
+export function verifyPairRequestV2Signature(
+  req: PairRequestV2,
+  authenticatedAppPeerPk: string,
+): PairRequestV2Validation {
+  if (req.app_peer_pk !== authenticatedAppPeerPk) {
+    return {
+      ok: false,
+      code: "app_peer_mismatch",
+      message: "Pair request app peer does not match relay-authenticated peer.",
+    };
+  }
+
+  const ownerPk = decodeB64(req.owner_pk, 32);
+  if (!ownerPk) {
+    return { ok: false, code: "bad_owner_pk", message: "Owner public key is invalid." };
+  }
+  if (!decodeB64(req.app_peer_pk, 32)) {
+    return { ok: false, code: "bad_app_peer_pk", message: "App peer public key is invalid." };
+  }
+  if (!decodeB64(req.pi_pk, 32)) {
+    return { ok: false, code: "bad_pi_pk", message: "Pi public key is invalid." };
+  }
+  const sig = decodeB64(req.sig, 64);
+  if (!sig) {
+    return { ok: false, code: "bad_signature", message: "Pair request signature is invalid." };
+  }
+
+  const canonical = canonicalPairRequestV2({
+    type: req.type,
+    id: req.id,
+    token: req.token,
+    device_name: req.device_name,
+    owner_pk: req.owner_pk,
+    app_peer_pk: req.app_peer_pk,
+    pi_pk: req.pi_pk,
+    room_id: req.room_id,
+    pair_nonce: req.pair_nonce,
+    expires_at: req.expires_at,
+  });
+  const ok = ed25519Verify(ownerPk, Buffer.from(canonical, "utf8"), sig);
+  return ok
+    ? { ok: true }
+    : { ok: false, code: "signature_invalid", message: "Pair request signature verification failed." };
+}

--- a/pi-extension/src/pairing/storage.test.ts
+++ b/pi-extension/src/pairing/storage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,7 +16,9 @@ vi.mock("node:os", async (importOriginal) => {
 // Re-import after the mock is installed.
 const storage = await import("./storage.js");
 const {
+  addPeer,
   getOrCreateEd25519Keypair,
+  listOwnerPubkeys,
   _setKeyStoreBackendForTest,
   _unlinkIdentityFileForTest,
   _IDENTITY_FILE_FOR_TEST,
@@ -71,6 +73,7 @@ beforeEach(async () => {
   vi.spyOn(console, "info").mockImplementation(() => undefined);
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
   await _unlinkIdentityFileForTest();
+  rmSync(join(_tmpHome, ".pi", "remote", "peers.json"), { force: true });
 });
 
 afterEach(() => {
@@ -215,4 +218,25 @@ describe("getOrCreateEd25519Keypair — headless Linux fallback", () => {
     );
   });
 
+});
+
+// ── peers.json ───────────────────────────────────────────────────────────────
+
+describe("peers.json owner key helpers", () => {
+  test("listOwnerPubkeys prefers pair_request_v2 owner_pk and falls back for legacy peers", async () => {
+    await addPeer({
+      name: "Signed Phone",
+      remote_epk: "app-peer-key",
+      paired_at: "2026-05-29T00:00:00.000Z",
+      owner_pk: "owner-signing-key",
+      app_peer_pk: "app-peer-key",
+    });
+    await addPeer({
+      name: "Legacy Phone",
+      remote_epk: "legacy-owner-key",
+      paired_at: "2026-05-29T00:00:01.000Z",
+    });
+
+    expect(await listOwnerPubkeys()).toEqual(["owner-signing-key", "legacy-owner-key"]);
+  });
 });

--- a/pi-extension/src/pairing/storage.ts
+++ b/pi-extension/src/pairing/storage.ts
@@ -180,8 +180,12 @@ export async function getOrCreateEd25519Keypair(): Promise<Ed25519Keypair> {
 
 export interface PeerRecord {
   name: string;
-  remote_epk: string; // base64 standard, 32B Ed25519
+  remote_epk: string; // relay-authenticated app peer key, base64 standard, 32B Ed25519
   paired_at: string;  // ISO-8601
+  /** Owner signing public key proven by pair_request_v2. */
+  owner_pk?: string;
+  /** Relay-authenticated app peer key bound into pair_request_v2. */
+  app_peer_pk?: string;
 }
 
 export async function listPeers(): Promise<PeerRecord[]> {
@@ -207,17 +211,16 @@ export async function addPeer(record: PeerRecord): Promise<void> {
 }
 
 /**
- * Returns the set of distinct `remote_epk` values in peers.json.
+ * Returns the set of distinct Owner signing public keys in peers.json.
  *
- * In the current pairing model (plan/23 + plan/24), each `remote_epk` is the
- * Owner's Ed25519 pubkey — and we treat each as a distinct Owner the Pi has
- * been paired with. Used by the mesh self-revoke poller (plan/24 Wave 3) to
- * know which Owners' mesh blobs to fetch.
+ * New pair_request_v2 records store `owner_pk` separately from the
+ * relay-authenticated app peer key. Legacy records used `remote_epk` for the
+ * Owner key, so keep that fallback for backward compatibility.
  */
 export async function listOwnerPubkeys(): Promise<string[]> {
   const peers = await listPeers();
   const seen = new Set<string>();
-  for (const p of peers) seen.add(p.remote_epk);
+  for (const p of peers) seen.add(p.owner_pk ?? p.remote_epk);
   return [...seen];
 }
 

--- a/pi-extension/src/protocol/types.ts
+++ b/pi-extension/src/protocol/types.ts
@@ -2,10 +2,25 @@ export type PairErrorCode =
   | "token_expired"
   | "token_consumed"
   | "token_unknown"
+  | "pair_invalid"
+  | "pair_unsupported"
   | "internal_error";
 
 export type ClientMessage =
   | { type: "pair_request"; id: string; token: string; device_name: string }
+  | {
+      type: "pair_request_v2";
+      id: string;
+      token: string;
+      device_name: string;
+      owner_pk: string;
+      app_peer_pk: string;
+      pi_pk: string;
+      room_id: string;
+      pair_nonce: string;
+      expires_at: number;
+      sig: string;
+    }
   | { type: "user_message"; id: string; text: string }
   | { type: "approve_tool"; id: string; tool_call_id: string; decision: "allow" | "deny" }
   | { type: "cancel"; id: string; target_id: string }

--- a/pi-extension/test/ping.test.ts
+++ b/pi-extension/test/ping.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, test, vi, beforeEach } from "vitest";
 import { EventEmitter } from "node:events";
+import { roomIdForCwd } from "../src/rooms.js";
 
 // ── Mock RelayClient ──────────────────────────────────────────────────────────
 
@@ -53,6 +54,14 @@ vi.mock("../src/config.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../src/pairing/signed_pairing.js", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("../src/pairing/signed_pairing.js")>();
+  return {
+    ...orig,
+    verifyPairRequestV2Signature: vi.fn().mockReturnValue({ ok: true }),
+  };
+});
+
 // ── Mock qr ───────────────────────────────────────────────────────────────────
 
 vi.mock("../src/pairing/qr.js", async (importOriginal) => {
@@ -61,7 +70,8 @@ vi.mock("../src/pairing/qr.js", async (importOriginal) => {
     ...orig,
     displayQR: vi.fn(),
     qrSession: {
-      issueToken: vi.fn().mockReturnValue({ token: "test-token", expiresAt: Date.now() + 60_000 }),
+      issueToken: vi.fn().mockReturnValue({ token: "test-token", pairNonce: "test-pair-nonce", expiresAt: 1_700_000_060_000 }),
+      checkToken: vi.fn().mockReturnValue({ status: "ok", pairNonce: "test-pair-nonce", expiresAt: 1_700_000_060_000 }),
       consumeToken: vi.fn().mockReturnValue("ok"),
       clear: vi.fn(),
       generateToken: vi.fn().mockReturnValue("test-token"),
@@ -93,7 +103,21 @@ function makeMockCtx() {
 }
 
 function makeInnerLine(peer: string, inner: object): string {
-  const ct = Buffer.from(JSON.stringify(inner)).toString("base64");
+  const record = inner as Record<string, unknown>;
+  const wire = record["type"] === "pair_request"
+    ? {
+        ...record,
+        type: "pair_request_v2",
+        owner_pk: peer,
+        app_peer_pk: peer,
+        pi_pk: Buffer.from(new Uint8Array(32)).toString("base64"),
+        room_id: roomIdForCwd("/tmp/test"),
+        pair_nonce: "test-pair-nonce",
+        expires_at: 1_700_000_060_000,
+        sig: "test-signature",
+      }
+    : record;
+  const ct = Buffer.from(JSON.stringify(wire)).toString("base64");
   return JSON.stringify({ peer, ct });
 }
 


### PR DESCRIPTION
## Summary

Adds owner-signed pairing via `pair_request_v2` so possession of an ephemeral QR token is no longer enough to pair a controller.

- QR sessions now include a pairing nonce and expiry (`pn`, `exp`) alongside the Pi key/room/token metadata.
- The app signs a canonical `pair_request_v2` payload with the synced Owner Ed25519 key.
- The Pi validates the active QR session fields and relay-authenticated app peer key, verifies the Owner signature, then consumes the token.
- New pair records persist `owner_pk` and `app_peer_pk`; legacy peer storage remains readable.
- Legacy unsigned `pair_request` from unknown peers is rejected with `pair_unsupported`.

## Security property

A relay that can see the plaintext QR token cannot pair its own controller unless it also has the Owner signing key. The signature binds:

- `pi_pk`
- `room_id`
- `token`
- `pair_nonce`
- `expires_at`
- `owner_pk`
- relay-authenticated `app_peer_pk`

## Tests

Pi extension:

```sh
cd pi-extension
corepack pnpm typecheck
corepack pnpm test
corepack pnpm build
```

App:

```sh
cd app
flutter analyze
flutter test
```

Covered cases include valid signed pairing, legacy unsigned rejection, tampered QR binding fields (`pi_pk`, `room_id`, nonce, expiry), wrong relay-authenticated app peer key, bad signature, expired/consumed token, missing Owner key on the app side, QR parse validation, and peer storage round-trip.
