### PR TITLE
Add signed inner message replay protection

### DIFF
--- a/app/lib/config/dependencies.dart
+++ b/app/lib/config/dependencies.dart
@@ -153,7 +153,13 @@ Future<IChannel> _productionConnectionFactory(
     throw _CancelledError();
   }
 
-  return PlainPeerChannel(transport: transport);
+  return PlainPeerChannel(
+    transport: transport,
+    signingKey: peer.supportsSignedInnerV1 ? ownerKey : null,
+    expectedRemotePubkey: peer.supportsSignedInnerV1 ? peer.remoteEpk : null,
+    roomId: peer.supportsSignedInnerV1 ? peer.roomId : null,
+    requireSigned: peer.supportsSignedInnerV1,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/app/lib/data/transport/peer_channel.dart
+++ b/app/lib/data/transport/peer_channel.dart
@@ -8,6 +8,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:typed_data';
 
 import 'package:app/data/transport/channel.dart';
@@ -27,6 +28,16 @@ class PeerChannelError implements Exception {
 }
 
 class PlainPeerChannel implements IChannel, IControlLink {
+  static final _sharedReplayCaches = <String, SignedInnerReplayCache>{};
+
+  static SignedInnerReplayCache _sharedReplayCache({
+    required String expectedRemotePubkey,
+    required String roomId,
+  }) => _sharedReplayCaches.putIfAbsent(
+    '$expectedRemotePubkey\u0000$roomId',
+    SignedInnerReplayCache.new,
+  );
+
   final PeerTransport _transport;
 
   final _controller = StreamController<ServerMessage>.broadcast();
@@ -34,6 +45,7 @@ class PlainPeerChannel implements IChannel, IControlLink {
   final String? _expectedRemotePubkey;
   final bool _requireSigned;
   final SignedInnerReplayCache _replayCache;
+  final _signedDropLogAt = <String, DateTime>{};
   String? _activeRoomId;
   bool _started = false;
   bool _closed = false;
@@ -45,14 +57,25 @@ class PlainPeerChannel implements IChannel, IControlLink {
     String? roomId,
     bool requireSigned = true,
     SignedInnerReplayCache? replayCache,
-  })  : _transport = transport,
-        _signingKey = signingKey,
-        _expectedRemotePubkey = expectedRemotePubkey == null
-            ? null
-            : toStandardB64(expectedRemotePubkey),
-        _activeRoomId = roomId,
-        _requireSigned = requireSigned,
-        _replayCache = replayCache ?? SignedInnerReplayCache();
+  }) : _transport = transport,
+       _signingKey = signingKey,
+       _expectedRemotePubkey = expectedRemotePubkey == null
+           ? null
+           : toStandardB64(expectedRemotePubkey),
+       _activeRoomId = roomId,
+       _requireSigned = requireSigned,
+       _replayCache =
+           replayCache ??
+           (expectedRemotePubkey != null && roomId != null
+               ? _sharedReplayCache(
+                   expectedRemotePubkey: toStandardB64(expectedRemotePubkey),
+                   roomId: roomId,
+                 )
+               : SignedInnerReplayCache()) {
+    if (roomId != null) {
+      _propagateActiveRoom(roomId);
+    }
+  }
 
   // ---- IControlLink — forwards to the underlying transport when it
   //      supports raw control frames (production: WsTransport). For
@@ -76,12 +99,29 @@ class PlainPeerChannel implements IChannel, IControlLink {
   /// No-op when the transport doesn't support it (in-memory test fakes).
   void setActiveRoom(String roomId) {
     _activeRoomId = roomId;
+    _propagateActiveRoom(roomId);
+  }
+
+  void _propagateActiveRoom(String roomId) {
     final t = _transport;
     try {
       (t as dynamic).setActiveRoom(roomId);
     } catch (_) {
       // Non-WS transports don't track rooms — fine to ignore.
     }
+  }
+
+  void _logSignedDrop(String reason) {
+    final now = DateTime.now();
+    final last = _signedDropLogAt[reason];
+    if (last != null && now.difference(last) < const Duration(seconds: 30)) {
+      return;
+    }
+    _signedDropLogAt[reason] = now;
+    developer.log(
+      'signed_inner_v1 drop: reason=$reason',
+      name: 'remote_pi.peer_channel',
+    );
   }
 
   @override
@@ -98,15 +138,30 @@ class PlainPeerChannel implements IChannel, IControlLink {
     final payload = msg.toJson();
     final signingKey = _signingKey;
     final expectedRemote = _expectedRemotePubkey;
-    final roomId = _activeRoomId;
-    final Object wire = signingKey != null && expectedRemote != null && roomId != null
-        ? await signInnerV1(
-            payload: payload,
-            senderKey: signingKey,
-            recipientPk: expectedRemote,
-            roomId: roomId,
-          )
-        : payload;
+    Object wire = payload;
+    String? signedRoomId;
+
+    if (signingKey != null && expectedRemote != null) {
+      while (true) {
+        final roomId = _activeRoomId;
+        if (roomId == null) break;
+        final signed = await signInnerV1(
+          payload: payload,
+          senderKey: signingKey,
+          recipientPk: expectedRemote,
+          roomId: roomId,
+        );
+        if (_activeRoomId == roomId) {
+          wire = signed;
+          signedRoomId = roomId;
+          break;
+        }
+      }
+    }
+
+    if (signedRoomId != null) {
+      _propagateActiveRoom(signedRoomId);
+    }
     final bytes = Uint8List.fromList(utf8.encode(jsonEncode(wire)));
     await _transport.send(bytes);
   }
@@ -138,8 +193,12 @@ class PlainPeerChannel implements IChannel, IControlLink {
         final signingKey = _signingKey;
         final expectedRemote = _expectedRemotePubkey;
         final roomId = _activeRoomId;
-        if (signingKey == null || expectedRemote == null || roomId == null) return;
-        final localPk = base64.encode((await signingKey.extractPublicKey()).bytes);
+        if (signingKey == null || expectedRemote == null || roomId == null) {
+          return;
+        }
+        final localPk = base64.encode(
+          (await signingKey.extractPublicKey()).bytes,
+        );
         final verified = await verifyInnerV1(
           frame: decoded,
           expectedSenderPk: expectedRemote,
@@ -147,9 +206,13 @@ class PlainPeerChannel implements IChannel, IControlLink {
           expectedRoomId: roomId,
           replay: _replayCache,
         );
-        if (verified == null) return;
+        if (verified == null) {
+          _logSignedDrop('verify_failed');
+          return;
+        }
         payload = verified;
       } else if (_signingKey != null && _requireSigned) {
+        _logSignedDrop('unsigned_required');
         return;
       }
       final msg = ServerMessage.fromJson(payload);
@@ -158,7 +221,10 @@ class PlainPeerChannel implements IChannel, IControlLink {
       // Forward-compat: surface unknown server types as ErrorMessage.
       if (!_controller.isClosed) {
         _controller.add(
-          ErrorMessage(code: 'unsupported_type', message: 'unknown server type'),
+          ErrorMessage(
+            code: 'unsupported_type',
+            message: 'unknown server type',
+          ),
         );
       }
     } catch (_) {

--- a/app/lib/data/transport/peer_channel.dart
+++ b/app/lib/data/transport/peer_channel.dart
@@ -11,10 +11,12 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:app/data/transport/channel.dart';
+import 'package:app/data/transport/epk_encoding.dart';
 import 'package:app/pairing/pair_request_flow.dart';
-import 'package:app/protocol/codec.dart';
+import 'package:app/protocol/signed_inner.dart';
 // ControlInbound + IControlLink come from these.
 import 'package:app/protocol/protocol.dart';
+import 'package:cryptography/cryptography.dart';
 
 class PeerChannelError implements Exception {
   final String message;
@@ -28,10 +30,29 @@ class PlainPeerChannel implements IChannel, IControlLink {
   final PeerTransport _transport;
 
   final _controller = StreamController<ServerMessage>.broadcast();
+  final SimpleKeyPair? _signingKey;
+  final String? _expectedRemotePubkey;
+  final bool _requireSigned;
+  final SignedInnerReplayCache _replayCache;
+  String? _activeRoomId;
   bool _started = false;
   bool _closed = false;
 
-  PlainPeerChannel({required PeerTransport transport}) : _transport = transport;
+  PlainPeerChannel({
+    required PeerTransport transport,
+    SimpleKeyPair? signingKey,
+    String? expectedRemotePubkey,
+    String? roomId,
+    bool requireSigned = true,
+    SignedInnerReplayCache? replayCache,
+  })  : _transport = transport,
+        _signingKey = signingKey,
+        _expectedRemotePubkey = expectedRemotePubkey == null
+            ? null
+            : toStandardB64(expectedRemotePubkey),
+        _activeRoomId = roomId,
+        _requireSigned = requireSigned,
+        _replayCache = replayCache ?? SignedInnerReplayCache();
 
   // ---- IControlLink — forwards to the underlying transport when it
   //      supports raw control frames (production: WsTransport). For
@@ -54,6 +75,7 @@ class PlainPeerChannel implements IChannel, IControlLink {
   /// transport so subsequent `send`s carry the right outer `room` field.
   /// No-op when the transport doesn't support it (in-memory test fakes).
   void setActiveRoom(String roomId) {
+    _activeRoomId = roomId;
     final t = _transport;
     try {
       (t as dynamic).setActiveRoom(roomId);
@@ -73,7 +95,19 @@ class PlainPeerChannel implements IChannel, IControlLink {
 
   @override
   Future<void> send(ClientMessage msg) async {
-    final bytes = Uint8List.fromList(utf8.encode(encodeClient(msg).trimRight()));
+    final payload = msg.toJson();
+    final signingKey = _signingKey;
+    final expectedRemote = _expectedRemotePubkey;
+    final roomId = _activeRoomId;
+    final Object wire = signingKey != null && expectedRemote != null && roomId != null
+        ? await signInnerV1(
+            payload: payload,
+            senderKey: signingKey,
+            recipientPk: expectedRemote,
+            roomId: roomId,
+          )
+        : payload;
+    final bytes = Uint8List.fromList(utf8.encode(jsonEncode(wire)));
     await _transport.send(bytes);
   }
 
@@ -89,16 +123,36 @@ class PlainPeerChannel implements IChannel, IControlLink {
     try {
       while (!_closed) {
         final bytes = await _transport.receive();
-        _handleFrame(bytes);
+        await _handleFrame(bytes);
       }
     } catch (_) {
       if (!_controller.isClosed) await _controller.close();
     }
   }
 
-  void _handleFrame(Uint8List bytes) {
+  Future<void> _handleFrame(Uint8List bytes) async {
     try {
-      final msg = decodeServer(utf8.decode(bytes));
+      final decoded = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
+      Map<String, dynamic> payload = decoded;
+      if (isSignedInnerV1(decoded)) {
+        final signingKey = _signingKey;
+        final expectedRemote = _expectedRemotePubkey;
+        final roomId = _activeRoomId;
+        if (signingKey == null || expectedRemote == null || roomId == null) return;
+        final localPk = base64.encode((await signingKey.extractPublicKey()).bytes);
+        final verified = await verifyInnerV1(
+          frame: decoded,
+          expectedSenderPk: expectedRemote,
+          expectedRecipientPk: localPk,
+          expectedRoomId: roomId,
+          replay: _replayCache,
+        );
+        if (verified == null) return;
+        payload = verified;
+      } else if (_signingKey != null && _requireSigned) {
+        return;
+      }
+      final msg = ServerMessage.fromJson(payload);
       if (!_controller.isClosed) _controller.add(msg);
     } on UnsupportedTypeException {
       // Forward-compat: surface unknown server types as ErrorMessage.

--- a/app/lib/pairing/pair_request_flow.dart
+++ b/app/lib/pairing/pair_request_flow.dart
@@ -108,6 +108,7 @@ Future<PairingResult> performPairing({
     'id': id,
     'token': qr.token,
     'device_name': deviceName,
+    'capabilities': ['signed_inner_v1'],
   };
   await transport.send(Uint8List.fromList(utf8.encode(jsonEncode(req))));
 
@@ -133,6 +134,16 @@ Future<PairingResult> performPairing({
     final piRoomId = piEchoedRoom
         ? pairOk.roomId
         : (qr.roomId ?? 'main');
+    // signed_inner_v1 starts after pair_ok. The pair_ok itself is bootstrap
+    // traffic so old Pis/apps can still pair; only persist strict mode when
+    // the Pi explicitly echoes the capability.
+    if (qr.signedInnerRequired && !pairOk.supportsSignedInnerV1) {
+      throw PairingError(
+        code: 'capability_downgrade',
+        message: 'Signed inner-message support was advertised in the QR but not confirmed by the Pi.',
+      );
+    }
+
     final peer = PeerRecord(
       remoteEpk: qr.epk,
       sessionName: pairOk.sessionName,
@@ -145,6 +156,7 @@ Future<PairingResult> performPairing({
       // Plan/27 Wave A — null when pi-extension hasn't been upgraded
       // yet to publish `harness` in pair_ok.
       harness: pairOk.harness,
+      supportsSignedInnerV1: pairOk.supportsSignedInnerV1,
     );
     await storage.savePeer(peer);
     return PairingResult(peer: peer, hostnameHint: pairOk.hostname);

--- a/app/lib/pairing/pair_request_flow.dart
+++ b/app/lib/pairing/pair_request_flow.dart
@@ -12,7 +12,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:app/data/transport/relay_config.dart';
-import 'package:app/protocol/protocol.dart' show PairOk;
+import 'package:app/protocol/protocol.dart' show PairOk, PairRequest;
 import 'package:app/protocol/uuid7.dart';
 
 import 'qr_scanner.dart';
@@ -103,14 +103,13 @@ Future<PairingResult> performPairing({
   }
 
   final id = uuid7();
-  final req = {
-    'type': 'pair_request',
-    'id': id,
-    'token': qr.token,
-    'device_name': deviceName,
-    'capabilities': ['signed_inner_v1'],
-  };
-  await transport.send(Uint8List.fromList(utf8.encode(jsonEncode(req))));
+  final req = PairRequest(
+    id: id,
+    token: qr.token,
+    deviceName: deviceName,
+    capabilities: const ['signed_inner_v1'],
+  );
+  await transport.send(Uint8List.fromList(utf8.encode(jsonEncode(req.toJson()))));
 
   final raw = await transport.receive();
   final inner = jsonDecode(utf8.decode(raw)) as Map<String, dynamic>;

--- a/app/lib/pairing/qr_scanner.dart
+++ b/app/lib/pairing/qr_scanner.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 // QR URI format:
-//   remotepi://pair?t=<base64url>&epk=<base64url>&n=<name>[&r=<url>][&rm=<roomId>]
+//   remotepi://pair?t=<base64url>&epk=<base64url>&n=<name>[&r=<url>][&rm=<roomId>][&si=1]
 //
 // Fields:
 //   t   — token efêmero (16 bytes, base64url), single-use, valid 60s
@@ -17,6 +17,8 @@ import 'dart:convert';
 //         "dest (peer, room) not found"). Optional; legacy QRs without
 //         `rm` make the app fall back to `'main'` during pair_request
 //         and rely on subscribe_rooms-based discovery afterwards.
+//   si  — when "1", the Pi supports and requires signed_inner_v1 after
+//         pairing; app rejects pair_ok if the relay strips negotiation.
 
 class QrPairPayload {
   final String token;
@@ -30,6 +32,7 @@ class QrPairPayload {
   /// right Pi-WS. `null` for pre-plan-17 QRs — caller must fall back to
   /// `'main'` and discover the real room id via subscribe_rooms.
   final String? roomId;
+  final bool signedInnerRequired;
 
   const QrPairPayload({
     required this.token,
@@ -37,6 +40,7 @@ class QrPairPayload {
     required this.sessionName,
     this.relayUrl,
     this.roomId,
+    this.signedInnerRequired = false,
   });
 
   static QrPairPayload? tryParse(String raw) {
@@ -48,6 +52,7 @@ class QrPairPayload {
       final r = uri.queryParameters['r']; // legacy/optional
       final n = uri.queryParameters['n'];
       final rm = uri.queryParameters['rm']; // plan 17 — Pi-side room
+      final si = uri.queryParameters['si'];
       // r is no longer required — plan 14 dropped it from the canonical
       // contract. Legacy QRs continue to include it; we capture it for
       // mismatch detection but don't reject when absent.
@@ -62,6 +67,7 @@ class QrPairPayload {
         sessionName: n,
         relayUrl: (r != null && r.isNotEmpty) ? r : null,
         roomId: (rm != null && rm.isNotEmpty) ? rm : null,
+        signedInnerRequired: si == '1',
       );
     } catch (_) {
       return null;

--- a/app/lib/pairing/storage.dart
+++ b/app/lib/pairing/storage.dart
@@ -100,6 +100,9 @@ class PeerRecord {
   /// fall back to [PiHarness.piCodingAgentUnknown] so the UI never
   /// renders an empty subtitle.
   final PiHarness? harness;
+  /// True only when pairing negotiated signed_inner_v1 support on both ends.
+  /// Missing on legacy records, so default false preserves compatibility.
+  final bool supportsSignedInnerV1;
 
   const PeerRecord({
     required this.remoteEpk,
@@ -109,6 +112,7 @@ class PeerRecord {
     this.nickname,
     this.roomId,
     this.harness,
+    this.supportsSignedInnerV1 = false,
   });
 
   Map<String, dynamic> toJson() => {
@@ -119,6 +123,7 @@ class PeerRecord {
     'nickname': nickname,
     'room_id': roomId,
     if (harness != null) 'harness': harness!.toJson(),
+    if (supportsSignedInnerV1) 'supports_signed_inner_v1': true,
   };
 
   factory PeerRecord.fromJson(Map<String, dynamic> j) {
@@ -139,6 +144,7 @@ class PeerRecord {
       harness: harnessJson is Map<String, dynamic>
           ? PiHarness.fromJson(harnessJson)
           : null,
+      supportsSignedInnerV1: j['supports_signed_inner_v1'] == true,
     );
   }
 
@@ -148,6 +154,7 @@ class PeerRecord {
     Object? nickname = _unset,
     Object? roomId = _unset,
     Object? harness = _unset,
+    bool? supportsSignedInnerV1,
   }) => PeerRecord(
     remoteEpk: remoteEpk,
     sessionName: sessionName ?? this.sessionName,
@@ -162,6 +169,7 @@ class PeerRecord {
     harness: identical(harness, _unset)
         ? this.harness
         : harness as PiHarness?,
+    supportsSignedInnerV1: supportsSignedInnerV1 ?? this.supportsSignedInnerV1,
   );
 
   @override
@@ -173,7 +181,8 @@ class PeerRecord {
       other.pairedAt == pairedAt &&
       other.nickname == nickname &&
       other.roomId == roomId &&
-      other.harness == harness;
+      other.harness == harness &&
+      other.supportsSignedInnerV1 == supportsSignedInnerV1;
 
   @override
   int get hashCode => Object.hash(
@@ -184,6 +193,7 @@ class PeerRecord {
         nickname,
         roomId,
         harness,
+        supportsSignedInnerV1,
       );
 }
 

--- a/app/lib/protocol/protocol.dart
+++ b/app/lib/protocol/protocol.dart
@@ -362,10 +362,12 @@ class PairRequest extends ClientMessage {
   final String id;
   final String token;
   final String deviceName;
+  final List<String> capabilities;
   PairRequest({
     required this.id,
     required this.token,
     required this.deviceName,
+    this.capabilities = const [],
   });
 
   @override
@@ -374,6 +376,7 @@ class PairRequest extends ClientMessage {
     'id': id,
     'token': token,
     'device_name': deviceName,
+    if (capabilities.isNotEmpty) 'capabilities': capabilities,
   };
 }
 

--- a/app/lib/protocol/protocol.dart
+++ b/app/lib/protocol/protocol.dart
@@ -566,6 +566,8 @@ class PairOk extends ServerMessage {
   /// pre-fill a sensible placeholder ("Mac do Jacob") instead of a
   /// generic "Pi". `null` on legacy Pis.
   final String? hostname;
+  final List<String> capabilities;
+  bool get supportsSignedInnerV1 => capabilities.contains('signed_inner_v1');
   PairOk({
     required this.inReplyTo,
     required this.sessionName,
@@ -573,11 +575,13 @@ class PairOk extends ServerMessage {
     required this.roomId,
     this.harness,
     this.hostname,
+    this.capabilities = const [],
   });
 
   factory PairOk.fromJson(Map<String, dynamic> j) {
     final harnessJson = j['harness'];
     final hostname = j['hostname'];
+    final capabilitiesJson = j['capabilities'];
     final startedAt = j['session_started_at'];
     return PairOk(
       inReplyTo: j['in_reply_to'] as String,
@@ -594,6 +598,9 @@ class PairOk extends ServerMessage {
           ? PiHarness.fromJson(harnessJson)
           : null,
       hostname: hostname is String && hostname.isNotEmpty ? hostname : null,
+      capabilities: capabilitiesJson is List
+          ? capabilitiesJson.whereType<String>().toList(growable: false)
+          : const [],
     );
   }
 }

--- a/app/lib/protocol/signed_inner.dart
+++ b/app/lib/protocol/signed_inner.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+
+class SignedInnerReplayCache {
+  final Duration maxAge;
+  final int maxEntries;
+  final _seen = <String, int>{};
+
+  SignedInnerReplayCache({
+    this.maxAge = const Duration(minutes: 5),
+    this.maxEntries = 2048,
+  });
+
+  bool accept({
+    required String senderPk,
+    required String roomId,
+    required String msgId,
+    required int issuedAt,
+    int? now,
+  }) {
+    final current = now ?? DateTime.now().millisecondsSinceEpoch;
+    _prune(current);
+    if ((current - issuedAt).abs() > maxAge.inMilliseconds) return false;
+    final key = '$senderPk\u0000$roomId\u0000$msgId';
+    if (_seen.containsKey(key)) return false;
+    _seen[key] = issuedAt;
+    if (_seen.length > maxEntries) _seen.remove(_seen.keys.first);
+    return true;
+  }
+
+  void _prune(int now) {
+    _seen.removeWhere((_, issuedAt) => (now - issuedAt).abs() > maxAge.inMilliseconds);
+  }
+}
+
+String _stableJson(Object? value) {
+  if (value == null || value is num || value is bool || value is String) {
+    return jsonEncode(value);
+  }
+  if (value is List) return '[${value.map(_stableJson).join(',')}]';
+  final map = (value as Map).cast<String, Object?>();
+  final keys = map.keys.toList()..sort();
+  return '{${keys.map((k) => '${jsonEncode(k)}:${_stableJson(map[k])}').join(',')}}';
+}
+
+Map<String, dynamic> _orderedUnsigned(Map<String, dynamic> frame) => {
+      'type': 'signed_inner_v1',
+      'sender_pk': frame['sender_pk'],
+      'recipient_pk': frame['recipient_pk'],
+      'room_id': frame['room_id'],
+      'msg_id': frame['msg_id'],
+      'issued_at': frame['issued_at'],
+      'payload_type': frame['payload_type'],
+      'payload': jsonDecode(_stableJson(frame['payload'])),
+    };
+
+String canonicalSignedInnerV1(Map<String, dynamic> unsigned) => jsonEncode(_orderedUnsigned(unsigned));
+
+String _randomMsgId() {
+  final rnd = Random.secure();
+  final bytes = Uint8List.fromList(List<int>.generate(16, (_) => rnd.nextInt(256)));
+  return base64.encode(bytes);
+}
+
+Future<Map<String, dynamic>> signInnerV1({
+  required Map<String, dynamic> payload,
+  required SimpleKeyPair senderKey,
+  required String recipientPk,
+  required String roomId,
+  int? now,
+  String? msgId,
+}) async {
+  final senderPk = base64.encode((await senderKey.extractPublicKey()).bytes);
+  final unsigned = <String, dynamic>{
+    'type': 'signed_inner_v1',
+    'sender_pk': senderPk,
+    'recipient_pk': recipientPk,
+    'room_id': roomId,
+    'msg_id': msgId ?? _randomMsgId(),
+    'issued_at': now ?? DateTime.now().millisecondsSinceEpoch,
+    'payload_type': payload['type'],
+    'payload': payload,
+  };
+  final sig = await Ed25519().sign(utf8.encode(canonicalSignedInnerV1(unsigned)), keyPair: senderKey);
+  return {...unsigned, 'sig': base64.encode(sig.bytes)};
+}
+
+Future<Map<String, dynamic>?> verifyInnerV1({
+  required Map<String, dynamic> frame,
+  required String expectedSenderPk,
+  required String expectedRecipientPk,
+  required String expectedRoomId,
+  required SignedInnerReplayCache replay,
+  int? now,
+}) async {
+  if (frame['type'] != 'signed_inner_v1') return null;
+  if (frame['sender_pk'] != expectedSenderPk) return null;
+  if (frame['recipient_pk'] != expectedRecipientPk) return null;
+  if (frame['room_id'] != expectedRoomId) return null;
+  final payload = (frame['payload'] as Map).cast<String, dynamic>();
+  if (frame['payload_type'] != payload['type']) return null;
+  final senderPk = SimplePublicKey(base64.decode(frame['sender_pk'] as String), type: KeyPairType.ed25519);
+  final sig = Signature(base64.decode(frame['sig'] as String), publicKey: senderPk);
+  final unsigned = Map<String, dynamic>.from(frame)..remove('sig');
+  final ok = await Ed25519().verify(utf8.encode(canonicalSignedInnerV1(unsigned)), signature: sig);
+  if (!ok) return null;
+  final accepted = replay.accept(
+    senderPk: frame['sender_pk'] as String,
+    roomId: frame['room_id'] as String,
+    msgId: frame['msg_id'] as String,
+    issuedAt: (frame['issued_at'] as num).toInt(),
+    now: now,
+  );
+  return accepted ? payload : null;
+}
+
+bool isSignedInnerV1(Map<String, dynamic> json) => json['type'] == 'signed_inner_v1';

--- a/app/lib/ui/pairing/viewmodels/pairing_viewmodel.dart
+++ b/app/lib/ui/pairing/viewmodels/pairing_viewmodel.dart
@@ -78,7 +78,13 @@ class PairingViewModel extends ViewModel<PairingState> {
         ),
       );
 
-      final channel = PlainPeerChannel(transport: transport);
+      final channel = PlainPeerChannel(
+        transport: transport,
+        signingKey: result.peer.supportsSignedInnerV1 ? ownerKey : null,
+        expectedRemotePubkey: result.peer.supportsSignedInnerV1 ? result.peer.remoteEpk : null,
+        roomId: result.peer.supportsSignedInnerV1 ? result.peer.roomId : null,
+        requireSigned: result.peer.supportsSignedInnerV1,
+      );
       _liveChannel = channel;
       _transport = null; // channel now owns the transport
 

--- a/app/test/data/transport/peer_channel_signed_test.dart
+++ b/app/test/data/transport/peer_channel_signed_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:app/data/transport/epk_encoding.dart';
+import 'package:app/data/transport/peer_channel.dart';
+import 'package:app/pairing/pair_request_flow.dart';
+import 'package:app/protocol/protocol.dart';
+import 'package:app/protocol/signed_inner.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Q {
+  final items = <Uint8List>[];
+  final waiters = <Completer<Uint8List>>[];
+
+  void add(Uint8List data) {
+    if (waiters.isNotEmpty) {
+      waiters.removeAt(0).complete(data);
+    } else {
+      items.add(data);
+    }
+  }
+
+  Future<Uint8List> next() {
+    if (items.isNotEmpty) return Future.value(items.removeAt(0));
+    final c = Completer<Uint8List>();
+    waiters.add(c);
+    return c.future;
+  }
+}
+
+class _T implements PeerTransport {
+  final _Q sent;
+  final _Q recv;
+  _T({required this.sent, required this.recv});
+
+  @override
+  Future<void> send(Uint8List data) async => sent.add(data);
+
+  @override
+  Future<Uint8List> receive() => recv.next();
+
+  @override
+  Future<void> close() async {}
+}
+
+Future<void> main() async {
+  group('PlainPeerChannel signed_inner_v1', () {
+    test('wraps outbound ClientMessage when negotiated', () async {
+      final appKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 1);
+      final piKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 2);
+      final piPk = base64.encode((await piKey.extractPublicKey()).bytes);
+      final sent = _Q();
+      final recv = _Q();
+      final channel = PlainPeerChannel(
+        transport: _T(sent: sent, recv: recv),
+        signingKey: appKey,
+        expectedRemotePubkey: toAppEpk(piPk),
+        roomId: 'room-1',
+        requireSigned: true,
+      );
+
+      await channel.send(Ping(id: 'p1'));
+
+      final frame = jsonDecode(utf8.decode(await sent.next())) as Map<String, dynamic>;
+      expect(frame['type'], 'signed_inner_v1');
+      expect(frame['recipient_pk'], piPk);
+      expect(frame['room_id'], 'room-1');
+      expect(frame['payload_type'], 'ping');
+      expect(frame['payload'], {'type': 'ping', 'id': 'p1'});
+    });
+
+    test('unwraps signed inbound and drops unsigned/replayed frames in strict mode', () async {
+      final appKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 3);
+      final piKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 4);
+      final appPk = base64.encode((await appKey.extractPublicKey()).bytes);
+      final piPk = base64.encode((await piKey.extractPublicKey()).bytes);
+      final sent = _Q();
+      final recv = _Q();
+      final channel = PlainPeerChannel(
+        transport: _T(sent: sent, recv: recv),
+        signingKey: appKey,
+        expectedRemotePubkey: piPk,
+        roomId: 'room-1',
+        requireSigned: true,
+      );
+      final messages = <ServerMessage>[];
+      final sub = channel.serverMessages.listen(messages.add);
+
+      recv.add(Uint8List.fromList(utf8.encode(jsonEncode({'type': 'pong', 'in_reply_to': 'unsigned'}))));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(messages, isEmpty);
+
+      final signed = await signInnerV1(
+        payload: {'type': 'pong', 'in_reply_to': 'p1'},
+        senderKey: piKey,
+        recipientPk: appPk,
+        roomId: 'room-1',
+        now: DateTime.now().millisecondsSinceEpoch,
+        msgId: 'msg-1',
+      );
+      recv.add(Uint8List.fromList(utf8.encode(jsonEncode(signed))));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(messages.single, isA<Pong>());
+      expect((messages.single as Pong).inReplyTo, 'p1');
+
+      recv.add(Uint8List.fromList(utf8.encode(jsonEncode(signed))));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(messages, hasLength(1), reason: 'replay is dropped');
+
+      await sub.cancel();
+      await channel.close();
+    });
+  });
+}

--- a/app/test/data/transport/peer_channel_signed_test.dart
+++ b/app/test/data/transport/peer_channel_signed_test.dart
@@ -33,7 +33,12 @@ class _Q {
 class _T implements PeerTransport {
   final _Q sent;
   final _Q recv;
+  String activeRoom = 'main';
   _T({required this.sent, required this.recv});
+
+  void setActiveRoom(String roomId) {
+    activeRoom = roomId;
+  }
 
   @override
   Future<void> send(Uint8List data) async => sent.add(data);
@@ -47,6 +52,24 @@ class _T implements PeerTransport {
 
 Future<void> main() async {
   group('PlainPeerChannel signed_inner_v1', () {
+    test('propagates initial room into transport', () async {
+      final appKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 9);
+      final piKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 10);
+      final piPk = base64.encode((await piKey.extractPublicKey()).bytes);
+      final transport = _T(sent: _Q(), recv: _Q());
+
+      final channel = PlainPeerChannel(
+        transport: transport,
+        signingKey: appKey,
+        expectedRemotePubkey: piPk,
+        roomId: 'room-ctor',
+        requireSigned: true,
+      );
+
+      expect(transport.activeRoom, 'room-ctor');
+      await channel.close();
+    });
+
     test('wraps outbound ClientMessage when negotiated', () async {
       final appKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 1);
       final piKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 2);
@@ -63,7 +86,8 @@ Future<void> main() async {
 
       await channel.send(Ping(id: 'p1'));
 
-      final frame = jsonDecode(utf8.decode(await sent.next())) as Map<String, dynamic>;
+      final frame =
+          jsonDecode(utf8.decode(await sent.next())) as Map<String, dynamic>;
       expect(frame['type'], 'signed_inner_v1');
       expect(frame['recipient_pk'], piPk);
       expect(frame['room_id'], 'room-1');
@@ -71,46 +95,80 @@ Future<void> main() async {
       expect(frame['payload'], {'type': 'ping', 'id': 'p1'});
     });
 
-    test('unwraps signed inbound and drops unsigned/replayed frames in strict mode', () async {
-      final appKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 3);
-      final piKey = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 4);
-      final appPk = base64.encode((await appKey.extractPublicKey()).bytes);
-      final piPk = base64.encode((await piKey.extractPublicKey()).bytes);
-      final sent = _Q();
-      final recv = _Q();
-      final channel = PlainPeerChannel(
-        transport: _T(sent: sent, recv: recv),
-        signingKey: appKey,
-        expectedRemotePubkey: piPk,
-        roomId: 'room-1',
-        requireSigned: true,
-      );
-      final messages = <ServerMessage>[];
-      final sub = channel.serverMessages.listen(messages.add);
+    test(
+      'unwraps signed inbound and drops unsigned/replayed frames in strict mode',
+      () async {
+        final appKey = await Ed25519().newKeyPairFromSeed(
+          Uint8List(32)..[0] = 3,
+        );
+        final piKey = await Ed25519().newKeyPairFromSeed(
+          Uint8List(32)..[0] = 4,
+        );
+        final appPk = base64.encode((await appKey.extractPublicKey()).bytes);
+        final piPk = base64.encode((await piKey.extractPublicKey()).bytes);
+        final sent = _Q();
+        final recv = _Q();
+        final channel = PlainPeerChannel(
+          transport: _T(sent: sent, recv: recv),
+          signingKey: appKey,
+          expectedRemotePubkey: piPk,
+          roomId: 'room-1',
+          requireSigned: true,
+        );
+        final messages = <ServerMessage>[];
+        Completer<ServerMessage>? nextMessage;
+        final sub = channel.serverMessages.listen((msg) {
+          messages.add(msg);
+          nextMessage?.complete(msg);
+          nextMessage = null;
+        });
+        Future<ServerMessage> waitNextMessage() {
+          final c = Completer<ServerMessage>();
+          nextMessage = c;
+          return c.future.timeout(const Duration(seconds: 1));
+        }
 
-      recv.add(Uint8List.fromList(utf8.encode(jsonEncode({'type': 'pong', 'in_reply_to': 'unsigned'}))));
-      await Future<void>.delayed(const Duration(milliseconds: 20));
-      expect(messages, isEmpty);
+        final signed = await signInnerV1(
+          payload: {'type': 'pong', 'in_reply_to': 'p1'},
+          senderKey: piKey,
+          recipientPk: appPk,
+          roomId: 'room-1',
+          now: DateTime.now().millisecondsSinceEpoch,
+          msgId: 'msg-1',
+        );
+        final first = waitNextMessage();
+        recv.add(
+          Uint8List.fromList(
+            utf8.encode(
+              jsonEncode({'type': 'pong', 'in_reply_to': 'unsigned'}),
+            ),
+          ),
+        );
+        recv.add(Uint8List.fromList(utf8.encode(jsonEncode(signed))));
+        final firstMsg = await first;
+        expect(firstMsg, isA<Pong>());
+        expect((firstMsg as Pong).inReplyTo, 'p1');
+        expect(messages, hasLength(1), reason: 'unsigned frame is dropped');
 
-      final signed = await signInnerV1(
-        payload: {'type': 'pong', 'in_reply_to': 'p1'},
-        senderKey: piKey,
-        recipientPk: appPk,
-        roomId: 'room-1',
-        now: DateTime.now().millisecondsSinceEpoch,
-        msgId: 'msg-1',
-      );
-      recv.add(Uint8List.fromList(utf8.encode(jsonEncode(signed))));
-      await Future<void>.delayed(const Duration(milliseconds: 20));
-      expect(messages.single, isA<Pong>());
-      expect((messages.single as Pong).inReplyTo, 'p1');
+        final signed2 = await signInnerV1(
+          payload: {'type': 'pong', 'in_reply_to': 'p2'},
+          senderKey: piKey,
+          recipientPk: appPk,
+          roomId: 'room-1',
+          now: DateTime.now().millisecondsSinceEpoch,
+          msgId: 'msg-2',
+        );
+        final second = waitNextMessage();
+        recv.add(Uint8List.fromList(utf8.encode(jsonEncode(signed))));
+        recv.add(Uint8List.fromList(utf8.encode(jsonEncode(signed2))));
+        final secondMsg = await second;
+        expect(secondMsg, isA<Pong>());
+        expect((secondMsg as Pong).inReplyTo, 'p2');
+        expect(messages, hasLength(2), reason: 'replay is dropped');
 
-      recv.add(Uint8List.fromList(utf8.encode(jsonEncode(signed))));
-      await Future<void>.delayed(const Duration(milliseconds: 20));
-      expect(messages, hasLength(1), reason: 'replay is dropped');
-
-      await sub.cancel();
-      await channel.close();
-    });
+        await sub.cancel();
+        await channel.close();
+      },
+    );
   });
 }

--- a/app/test/pairing/pair_request_flow_test.dart
+++ b/app/test/pairing/pair_request_flow_test.dart
@@ -98,6 +98,7 @@ void main() {
         unawaited(() async {
           final raw = await pi.receive();
           final req = jsonDecode(utf8.decode(raw)) as Map<String, dynamic>;
+          expect(req['capabilities'], contains('signed_inner_v1'));
           await pi.send(Uint8List.fromList(utf8.encode(jsonEncode({
             'type': 'pair_ok',
             'in_reply_to': req['id'],
@@ -230,5 +231,81 @@ void main() {
             reason: 'when QR lacks r=, persist currentRelayUrl');
       },
     );
+
+    test('rejects downgrade when QR requires signed_inner_v1 but pair_ok omits it', () async {
+      final q1 = _Q();
+      final q2 = _Q();
+      final pi = _MemTransport(send: q1, recv: q2);
+      final app = _MemTransport(send: q2, recv: q1);
+      final qr = QrPairPayload(
+        token: 'AAAAAAAAAAAAAAAAAAAAAA',
+        epk: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        sessionName: 'Pi',
+        roomId: 'room-from-qr',
+        signedInnerRequired: true,
+      );
+
+      unawaited(() async {
+        final raw = await pi.receive();
+        final req = jsonDecode(utf8.decode(raw)) as Map<String, dynamic>;
+        await pi.send(Uint8List.fromList(utf8.encode(jsonEncode({
+          'type': 'pair_ok',
+          'in_reply_to': req['id'],
+          'session_name': 'Pi',
+          'session_started_at': 1700000000000,
+          'room_id': 'room-from-qr',
+        }))));
+      }());
+
+      await expectLater(
+        performPairing(
+          qr: qr,
+          transport: app,
+          storage: _FakeStorage(),
+          deviceName: 'phone',
+          currentRelayUrl: 'wss://relay.example',
+        ),
+        throwsA(isA<PairingError>().having((e) => e.code, 'code', 'capability_downgrade')),
+      );
+    });
+
+    test('persists signed_inner_v1 only when pair_ok negotiates it', () async {
+      final q1 = _Q();
+      final q2 = _Q();
+      final pi = _MemTransport(send: q1, recv: q2);
+      final app = _MemTransport(send: q2, recv: q1);
+      final storage = _FakeStorage();
+      final qr = QrPairPayload(
+        token: 'AAAAAAAAAAAAAAAAAAAAAA',
+        epk: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        sessionName: 'Pi',
+        roomId: 'room-from-qr',
+      );
+
+      unawaited(() async {
+        final raw = await pi.receive();
+        final req = jsonDecode(utf8.decode(raw)) as Map<String, dynamic>;
+        expect(req['capabilities'], contains('signed_inner_v1'));
+        await pi.send(Uint8List.fromList(utf8.encode(jsonEncode({
+          'type': 'pair_ok',
+          'in_reply_to': req['id'],
+          'session_name': 'Pi',
+          'session_started_at': 1700000000000,
+          'room_id': 'room-from-qr',
+          'capabilities': ['signed_inner_v1'],
+        }))));
+      }());
+
+      final result = await performPairing(
+        qr: qr,
+        transport: app,
+        storage: storage,
+        deviceName: 'phone',
+        currentRelayUrl: 'wss://relay.example',
+      );
+
+      expect(result.peer.supportsSignedInnerV1, isTrue);
+      expect(storage.saved.single.supportsSignedInnerV1, isTrue);
+    });
   });
 }

--- a/app/test/pairing/qr_scanner_test.dart
+++ b/app/test/pairing/qr_scanner_test.dart
@@ -86,5 +86,20 @@ void main() {
       expect(qr, isNotNull);
       expect(qr!.roomId, isNull);
     });
+
+    test('si=1 marks signed inner support as required by this QR', () {
+      final raw = 'remotepi://pair?t=$goodToken&epk=$goodEpk&'
+          'rm=abc123def456&si=1&n=$sessionName';
+      final qr = QrPairPayload.tryParse(raw);
+      expect(qr, isNotNull);
+      expect(qr!.signedInnerRequired, isTrue);
+    });
+
+    test('QR without si leaves signed inner optional for legacy compatibility', () {
+      final raw = 'remotepi://pair?t=$goodToken&epk=$goodEpk&n=$sessionName';
+      final qr = QrPairPayload.tryParse(raw);
+      expect(qr, isNotNull);
+      expect(qr!.signedInnerRequired, isFalse);
+    });
   });
 }

--- a/app/test/pairing/storage_test.dart
+++ b/app/test/pairing/storage_test.dart
@@ -101,11 +101,29 @@ void main() {
       expect(json['relay_url'], 'ws://localhost');
       expect(json['paired_at'], '2026-01-01T00:00:00Z');
       expect(json['nickname'], isNull);
+      expect(json.containsKey('supports_signed_inner_v1'), isFalse);
 
       final restored = PeerRecord.fromJson(json);
       expect(restored.remoteEpk, 'pk_ed25519');
       expect(restored.sessionName, 'test');
       expect(restored.nickname, isNull);
+      expect(restored.supportsSignedInnerV1, isFalse);
+    });
+
+    test('signed-inner capability round-trips only when true', () {
+      const record = PeerRecord(
+        remoteEpk: 'pk1',
+        sessionName: 'name',
+        relayUrl: 'ws://x',
+        pairedAt: '2026-01-01T00:00:00Z',
+        supportsSignedInnerV1: true,
+      );
+
+      final json = record.toJson();
+      expect(json['supports_signed_inner_v1'], isTrue);
+      final restored = PeerRecord.fromJson(json);
+      expect(restored.supportsSignedInnerV1, isTrue);
+      expect(restored.copyWith(supportsSignedInnerV1: false).supportsSignedInnerV1, isFalse);
     });
 
     test('nickname round-trips through toJson/fromJson', () {

--- a/app/test/protocol/signed_inner_test.dart
+++ b/app/test/protocol/signed_inner_test.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:app/protocol/signed_inner.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  group('signed_inner_v1', () {
+    test('canonicalSignedInnerV1 is deterministic and excludes sig', () {
+      final canonical = canonicalSignedInnerV1({
+        'type': 'signed_inner_v1',
+        'sender_pk': 'sender',
+        'recipient_pk': 'recipient',
+        'room_id': 'room-1',
+        'msg_id': 'msg-1',
+        'issued_at': 1,
+        'payload_type': 'tool_request',
+        'payload': {
+          'z': 1,
+          'type': 'tool_request',
+          'args': {'b': true, 'a': false},
+        },
+        'sig': 'ignored',
+      });
+      expect(
+        canonical,
+        '{"type":"signed_inner_v1","sender_pk":"sender","recipient_pk":"recipient",'
+        '"room_id":"room-1","msg_id":"msg-1","issued_at":1,"payload_type":"tool_request",'
+        '"payload":{"args":{"a":false,"b":true},"type":"tool_request","z":1}}',
+      );
+    });
+
+    test('cross-runtime vector stays stable and verifies', () async {
+      const senderPk = 'ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=';
+      const recipientPk = 'ZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4Q=';
+      final frame = <String, dynamic>{
+        'type': 'signed_inner_v1',
+        'sender_pk': senderPk,
+        'recipient_pk': recipientPk,
+        'room_id': 'room-vector',
+        'msg_id': 'msg-vector',
+        'issued_at': 1700000000123,
+        'payload_type': 'user_message',
+        'payload': {
+          'type': 'user_message',
+          'id': 'u-vector',
+          'text': 'hello',
+          'nested': {'b': 2, 'a': 1},
+        },
+        'sig': 'GxWRHj92N2l5IW1ApzmyE+5cfeWJAoLRoaqRhC5M40aV1rW13GYQ4pLI0ZMcIvbgOsfQwvwpMyQ4F/A972LxCA==',
+      };
+
+      expect(
+        canonicalSignedInnerV1(frame),
+        '{"type":"signed_inner_v1","sender_pk":"ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=",'
+        '"recipient_pk":"ZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4Q=","room_id":"room-vector",'
+        '"msg_id":"msg-vector","issued_at":1700000000123,"payload_type":"user_message",'
+        '"payload":{"id":"u-vector","nested":{"a":1,"b":2},"text":"hello","type":"user_message"}}',
+      );
+      expect(
+        await verifyInnerV1(
+          frame: frame,
+          expectedSenderPk: senderPk,
+          expectedRecipientPk: recipientPk,
+          expectedRoomId: 'room-vector',
+          replay: SignedInnerReplayCache(),
+          now: 1700000000200,
+        ),
+        {
+          'type': 'user_message',
+          'id': 'u-vector',
+          'text': 'hello',
+          'nested': {'b': 2, 'a': 1},
+        },
+      );
+    });
+
+    test('signs and verifies payload and rejects replay/tamper/wrong room', () async {
+      final sender = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 1);
+      final recipient = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 2);
+      final recipientPk = base64.encode((await recipient.extractPublicKey()).bytes);
+      final senderPk = base64.encode((await sender.extractPublicKey()).bytes);
+      final frame = await signInnerV1(
+        payload: {'type': 'ping', 'id': 'p1'},
+        senderKey: sender,
+        recipientPk: recipientPk,
+        roomId: 'room-1',
+        now: 1700000000000,
+        msgId: 'msg-1',
+      );
+
+      final replay = SignedInnerReplayCache();
+      expect(
+        await verifyInnerV1(
+          frame: frame,
+          expectedSenderPk: senderPk,
+          expectedRecipientPk: recipientPk,
+          expectedRoomId: 'room-1',
+          replay: replay,
+          now: 1700000000100,
+        ),
+        {'type': 'ping', 'id': 'p1'},
+      );
+      expect(
+        await verifyInnerV1(
+          frame: frame,
+          expectedSenderPk: senderPk,
+          expectedRecipientPk: recipientPk,
+          expectedRoomId: 'room-1',
+          replay: replay,
+          now: 1700000000100,
+        ),
+        isNull,
+      );
+      expect(
+        await verifyInnerV1(
+          frame: {...frame, 'payload': {'type': 'ping', 'id': 'p2'}},
+          expectedSenderPk: senderPk,
+          expectedRecipientPk: recipientPk,
+          expectedRoomId: 'room-1',
+          replay: SignedInnerReplayCache(),
+          now: 1700000000100,
+        ),
+        isNull,
+      );
+      expect(
+        await verifyInnerV1(
+          frame: frame,
+          expectedSenderPk: senderPk,
+          expectedRecipientPk: recipientPk,
+          expectedRoomId: 'room-2',
+          replay: SignedInnerReplayCache(),
+          now: 1700000000100,
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/app/test/protocol/signed_inner_test.dart
+++ b/app/test/protocol/signed_inner_test.dart
@@ -48,7 +48,8 @@ Future<void> main() async {
           'text': 'hello',
           'nested': {'b': 2, 'a': 1},
         },
-        'sig': 'GxWRHj92N2l5IW1ApzmyE+5cfeWJAoLRoaqRhC5M40aV1rW13GYQ4pLI0ZMcIvbgOsfQwvwpMyQ4F/A972LxCA==',
+        'sig':
+            'GxWRHj92N2l5IW1ApzmyE+5cfeWJAoLRoaqRhC5M40aV1rW13GYQ4pLI0ZMcIvbgOsfQwvwpMyQ4F/A972LxCA==',
       };
 
       expect(
@@ -76,65 +77,114 @@ Future<void> main() async {
       );
     });
 
-    test('signs and verifies payload and rejects replay/tamper/wrong room', () async {
-      final sender = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 1);
-      final recipient = await Ed25519().newKeyPairFromSeed(Uint8List(32)..[0] = 2);
-      final recipientPk = base64.encode((await recipient.extractPublicKey()).bytes);
-      final senderPk = base64.encode((await sender.extractPublicKey()).bytes);
-      final frame = await signInnerV1(
-        payload: {'type': 'ping', 'id': 'p1'},
-        senderKey: sender,
-        recipientPk: recipientPk,
-        roomId: 'room-1',
-        now: 1700000000000,
-        msgId: 'msg-1',
-      );
+    test(
+      'signs and verifies payload and rejects invalid signed frames',
+      () async {
+        final sender = await Ed25519().newKeyPairFromSeed(
+          Uint8List(32)..[0] = 1,
+        );
+        final recipient = await Ed25519().newKeyPairFromSeed(
+          Uint8List(32)..[0] = 2,
+        );
+        final other = await Ed25519().newKeyPairFromSeed(
+          Uint8List(32)..[0] = 3,
+        );
+        final recipientPk = base64.encode(
+          (await recipient.extractPublicKey()).bytes,
+        );
+        final senderPk = base64.encode((await sender.extractPublicKey()).bytes);
+        final otherPk = base64.encode((await other.extractPublicKey()).bytes);
+        final frame = await signInnerV1(
+          payload: {'type': 'ping', 'id': 'p1'},
+          senderKey: sender,
+          recipientPk: recipientPk,
+          roomId: 'room-1',
+          now: 1700000000000,
+          msgId: 'msg-1',
+        );
 
-      final replay = SignedInnerReplayCache();
-      expect(
-        await verifyInnerV1(
-          frame: frame,
-          expectedSenderPk: senderPk,
-          expectedRecipientPk: recipientPk,
-          expectedRoomId: 'room-1',
-          replay: replay,
-          now: 1700000000100,
-        ),
-        {'type': 'ping', 'id': 'p1'},
-      );
-      expect(
-        await verifyInnerV1(
-          frame: frame,
-          expectedSenderPk: senderPk,
-          expectedRecipientPk: recipientPk,
-          expectedRoomId: 'room-1',
-          replay: replay,
-          now: 1700000000100,
-        ),
-        isNull,
-      );
-      expect(
-        await verifyInnerV1(
-          frame: {...frame, 'payload': {'type': 'ping', 'id': 'p2'}},
-          expectedSenderPk: senderPk,
-          expectedRecipientPk: recipientPk,
-          expectedRoomId: 'room-1',
-          replay: SignedInnerReplayCache(),
-          now: 1700000000100,
-        ),
-        isNull,
-      );
-      expect(
-        await verifyInnerV1(
-          frame: frame,
-          expectedSenderPk: senderPk,
-          expectedRecipientPk: recipientPk,
-          expectedRoomId: 'room-2',
-          replay: SignedInnerReplayCache(),
-          now: 1700000000100,
-        ),
-        isNull,
-      );
-    });
+        final replay = SignedInnerReplayCache();
+        expect(
+          await verifyInnerV1(
+            frame: frame,
+            expectedSenderPk: senderPk,
+            expectedRecipientPk: recipientPk,
+            expectedRoomId: 'room-1',
+            replay: replay,
+            now: 1700000000100,
+          ),
+          {'type': 'ping', 'id': 'p1'},
+        );
+        expect(
+          await verifyInnerV1(
+            frame: frame,
+            expectedSenderPk: senderPk,
+            expectedRecipientPk: recipientPk,
+            expectedRoomId: 'room-1',
+            replay: replay,
+            now: 1700000000100,
+          ),
+          isNull,
+        );
+        expect(
+          await verifyInnerV1(
+            frame: {
+              ...frame,
+              'payload': {'type': 'ping', 'id': 'p2'},
+            },
+            expectedSenderPk: senderPk,
+            expectedRecipientPk: recipientPk,
+            expectedRoomId: 'room-1',
+            replay: SignedInnerReplayCache(),
+            now: 1700000000100,
+          ),
+          isNull,
+        );
+        expect(
+          await verifyInnerV1(
+            frame: frame,
+            expectedSenderPk: otherPk,
+            expectedRecipientPk: recipientPk,
+            expectedRoomId: 'room-1',
+            replay: SignedInnerReplayCache(),
+            now: 1700000000100,
+          ),
+          isNull,
+        );
+        expect(
+          await verifyInnerV1(
+            frame: frame,
+            expectedSenderPk: senderPk,
+            expectedRecipientPk: otherPk,
+            expectedRoomId: 'room-1',
+            replay: SignedInnerReplayCache(),
+            now: 1700000000100,
+          ),
+          isNull,
+        );
+        expect(
+          await verifyInnerV1(
+            frame: frame,
+            expectedSenderPk: senderPk,
+            expectedRecipientPk: recipientPk,
+            expectedRoomId: 'room-2',
+            replay: SignedInnerReplayCache(),
+            now: 1700000000100,
+          ),
+          isNull,
+        );
+        expect(
+          await verifyInnerV1(
+            frame: frame,
+            expectedSenderPk: senderPk,
+            expectedRecipientPk: recipientPk,
+            expectedRoomId: 'room-1',
+            replay: SignedInnerReplayCache(),
+            now: 1700001000000,
+          ),
+          isNull,
+        );
+      },
+    );
   });
 }

--- a/app/test/protocol_test.dart
+++ b/app/test/protocol_test.dart
@@ -260,12 +260,14 @@ void main() {
         id: '018f9c3a-0000-7000-9a3b-1c2d3e4f5a01',
         token: 'qBcD3fG4h5J6k7L8m9N0pQ',
         deviceName: 'iPhone do Jacob',
+        capabilities: const ['signed_inner_v1'],
       );
       final decoded =
           jsonDecode(encodeClient(msg).trim()) as Map<String, dynamic>;
       expect(decoded['type'], 'pair_request');
       expect(decoded['device_name'], 'iPhone do Jacob');
       expect(decoded['token'], 'qBcD3fG4h5J6k7L8m9N0pQ');
+      expect(decoded['capabilities'], ['signed_inner_v1']);
     });
   });
 

--- a/app/test/protocol_test.dart
+++ b/app/test/protocol_test.dart
@@ -145,6 +145,19 @@ void main() {
       expect(msg.harness!.version, '0.4.2');
     });
 
+    test('PairOk.fromJson decodes signed-inner capability', () {
+      final msg = PairOk.fromJson({
+        'type': 'pair_ok',
+        'in_reply_to': 'req-1',
+        'session_name': 'remote_pi · main',
+        'session_started_at': 1700000000000,
+        'room_id': 'room-xyz',
+        'capabilities': ['signed_inner_v1'],
+      });
+      expect(msg.capabilities, ['signed_inner_v1']);
+      expect(msg.supportsSignedInnerV1, isTrue);
+    });
+
     test('PairOk.fromJson tolerates missing harness/hostname (legacy Pi)', () {
       final msg = PairOk.fromJson({
         'type': 'pair_ok',

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -42,7 +42,7 @@ vi.mock("./transport/relay_client.js", () => ({
 
 // ── Mock storage ──────────────────────────────────────────────────────────────
 
-type StoredPeer = { name: string; remote_epk: string; paired_at: string };
+type StoredPeer = { name: string; remote_epk: string; paired_at: string; supports_signed_inner_v1?: boolean };
 const _knownPeers: StoredPeer[] = [];
 const _addedPeers: StoredPeer[] = [];
 const _removedPeers: string[] = [];
@@ -337,7 +337,35 @@ describe("state machine + pair_request flow", () => {
     expect(_addedPeers[0]).toMatchObject({
       name: "iPhone do Jacob",
       remote_epk: APP_PEER_ID,
+      supports_signed_inner_v1: false,
     });
+  });
+
+  test("signed-inner capability is persisted and echoed only when requested", async () => {
+    const { generateEd25519Keypair } = await import("./pairing/crypto.js");
+    const APP_PEER_ID = Buffer.from(generateEd25519Keypair().publicKey).toString("base64");
+
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx());
+
+    relayRef.current!.emit("message", makeInnerLine(APP_PEER_ID, {
+      type: "pair_request",
+      id: "req-cap",
+      token: "test-token",
+      device_name: "Capable Phone",
+      capabilities: ["signed_inner_v1"],
+    }));
+
+    await vi.waitFor(() => expect(_getState()).toBe("paired"), { timeout: 2000 });
+
+    expect(_addedPeers[0]).toMatchObject({
+      name: "Capable Phone",
+      remote_epk: APP_PEER_ID,
+      supports_signed_inner_v1: true,
+    });
+    const sent = relayRef.current!.send.mock.calls.map((c) => c[0] as string);
+    const pairOks = sent.map(decodeSentCt).filter((d) => d.inner.type === "pair_ok");
+    expect(pairOks[0]!.inner["capabilities"]).toEqual(["signed_inner_v1"]);
   });
 
   test("expired token → pair_error{token_expired} + state stays started", async () => {
@@ -457,6 +485,62 @@ describe("state machine + pair_request flow", () => {
     }));
 
     await vi.waitFor(() => expect(_getState()).toBe("paired"), { timeout: 2000 });
+  });
+
+  test("known signed-inner peer reconnect routes only after verification", async () => {
+    const { generateEd25519Keypair } = await import("./pairing/crypto.js");
+    const { signInnerV1 } = await import("./protocol/signed_inner.js");
+    const { roomIdForCwd } = await import("./rooms.js");
+    const app = generateEd25519Keypair();
+    const APP_PEER_ID = Buffer.from(app.publicKey).toString("base64");
+    const piPk = Buffer.from(new Uint8Array(32)).toString("base64");
+    _knownPeers.push({
+      name: "Signed App",
+      remote_epk: APP_PEER_ID,
+      paired_at: new Date().toISOString(),
+      supports_signed_inner_v1: true,
+    });
+
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx());
+
+    relayRef.current!.emit("message", makeInnerLine(APP_PEER_ID, signInnerV1({
+      payload: { type: "ping", id: "signed-ping" },
+      sender: app,
+      recipientPk: piPk,
+      roomId: roomIdForCwd("/home/user/projects/remote_pi"),
+    })));
+
+    await vi.waitFor(() => expect(_getState()).toBe("paired"), { timeout: 2000 });
+    const sent = relayRef.current!.send.mock.calls.map((c) => c[0] as string);
+    const signedReplies = sent.map(decodeSentCt).filter((d) => d.inner.type === "signed_inner_v1");
+    expect(signedReplies).toHaveLength(1);
+    expect(signedReplies[0]!.inner["payload_type"]).toBe("pong");
+    expect((signedReplies[0]!.inner["payload"] as Record<string, unknown>)["in_reply_to"]).toBe("signed-ping");
+  });
+
+  test("known signed-inner peer reconnect rejects unsigned first message", async () => {
+    const { generateEd25519Keypair } = await import("./pairing/crypto.js");
+    const app = generateEd25519Keypair();
+    const APP_PEER_ID = Buffer.from(app.publicKey).toString("base64");
+    _knownPeers.push({
+      name: "Signed App",
+      remote_epk: APP_PEER_ID,
+      paired_at: new Date().toISOString(),
+      supports_signed_inner_v1: true,
+    });
+
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx());
+
+    relayRef.current!.emit("message", makeInnerLine(APP_PEER_ID, {
+      type: "ping",
+      id: "unsigned-ping",
+    }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(_getState()).toBe("paired");
+    expect(relayRef.current!.send.mock.calls).toHaveLength(0);
   });
 
   test("unknown peer non-pair message → state stays started, no peer added", async () => {

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -43,18 +43,20 @@ vi.mock("./transport/relay_client.js", () => ({
 // ── Mock storage ──────────────────────────────────────────────────────────────
 
 type StoredPeer = { name: string; remote_epk: string; paired_at: string; supports_signed_inner_v1?: boolean };
+type TestEd25519Keypair = { publicKey: Uint8Array; secretKey: Uint8Array };
 const _knownPeers: StoredPeer[] = [];
 const _addedPeers: StoredPeer[] = [];
 const _removedPeers: string[] = [];
+let _piKeypair: TestEd25519Keypair = {
+  publicKey: new Uint8Array(32),
+  secretKey: new Uint8Array(32),
+};
 
 vi.mock("./pairing/storage.js", async (importOriginal) => {
   const orig = await importOriginal<typeof import("./pairing/storage.js")>();
   return {
     ...orig,
-    getOrCreateEd25519Keypair: vi.fn().mockResolvedValue({
-      publicKey: new Uint8Array(32),
-      secretKey: new Uint8Array(32),
-    }),
+    getOrCreateEd25519Keypair: vi.fn().mockImplementation(async () => _piKeypair),
     listPeers: vi.fn().mockImplementation(async () => [..._knownPeers]),
     addPeer: vi.fn().mockImplementation(async (p: StoredPeer) => {
       _addedPeers.push(p);
@@ -106,6 +108,7 @@ vi.mock("./config.js", async (importOriginal) => {
 // ── Mock qrSession.consumeToken control ───────────────────────────────────────
 
 let _tokenStatus: "ok" | "expired" | "consumed" | "unknown" = "ok";
+let _tokenRequiresSignedInner = false;
 const _consumeCalls: string[] = [];
 
 vi.mock("./pairing/qr.js", async (importOriginal) => {
@@ -122,6 +125,7 @@ vi.mock("./pairing/qr.js", async (importOriginal) => {
         _consumeCalls.push(token);
         return _tokenStatus;
       }),
+      requiresSignedInner: vi.fn().mockImplementation(() => _tokenRequiresSignedInner),
       clear: vi.fn(),
       generateToken: vi.fn().mockReturnValue("test-token"),
     },
@@ -261,14 +265,20 @@ describe("state machine + pair_request flow", () => {
     _removedPeers.length = 0;
     _consumeCalls.length = 0;
     _tokenStatus = "ok";
+    _tokenRequiresSignedInner = false;
     relayRef.current = null;
-    // Restore default consumeToken behavior — earlier tests can override it.
+    const crypto = await import("./pairing/crypto.js");
+    _piKeypair = crypto.generateEd25519Keypair();
+    // Restore default token behavior — earlier tests can override it.
     const qr = await import("./pairing/qr.js");
     (qr.qrSession.consumeToken as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       (token: string) => {
         _consumeCalls.push(token);
         return _tokenStatus;
       },
+    );
+    (qr.qrSession.requiresSignedInner as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => _tokenRequiresSignedInner,
     );
     // Force idle via stop
     const stop = captureHandler("remote-pi stop");
@@ -366,6 +376,36 @@ describe("state machine + pair_request flow", () => {
     const sent = relayRef.current!.send.mock.calls.map((c) => c[0] as string);
     const pairOks = sent.map(decodeSentCt).filter((d) => d.inner.type === "pair_ok");
     expect(pairOks[0]!.inner["capabilities"]).toEqual(["signed_inner_v1"]);
+  });
+
+  test("QR-required signed-inner rejects stripped capability before consuming token", async () => {
+    _tokenRequiresSignedInner = true;
+    const { generateEd25519Keypair } = await import("./pairing/crypto.js");
+    const APP_PEER_ID = Buffer.from(generateEd25519Keypair().publicKey).toString("base64");
+
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx());
+
+    relayRef.current!.emit("message", makeInnerLine(APP_PEER_ID, {
+      type: "pair_request",
+      id: "req-downgrade",
+      token: "test-token",
+      device_name: "Downgraded Phone",
+    }));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(_getState()).toBe("started");
+    expect(_addedPeers).toHaveLength(0);
+    expect(_consumeCalls).toHaveLength(0);
+    const sent = relayRef.current!.send.mock.calls.map((c) => c[0] as string);
+    const errs = sent.map(decodeSentCt).filter((d) => d.inner.type === "pair_error");
+    expect(errs).toHaveLength(1);
+    expect(errs[0]!.inner).toMatchObject({
+      type: "pair_error",
+      in_reply_to: "req-downgrade",
+      code: "capability_downgrade",
+    });
   });
 
   test("expired token → pair_error{token_expired} + state stays started", async () => {
@@ -489,11 +529,11 @@ describe("state machine + pair_request flow", () => {
 
   test("known signed-inner peer reconnect routes only after verification", async () => {
     const { generateEd25519Keypair } = await import("./pairing/crypto.js");
-    const { signInnerV1 } = await import("./protocol/signed_inner.js");
+    const { SignedInnerReplayCache, signInnerV1, verifyInnerV1 } = await import("./protocol/signed_inner.js");
     const { roomIdForCwd } = await import("./rooms.js");
     const app = generateEd25519Keypair();
     const APP_PEER_ID = Buffer.from(app.publicKey).toString("base64");
-    const piPk = Buffer.from(new Uint8Array(32)).toString("base64");
+    const piPk = Buffer.from(_piKeypair.publicKey).toString("base64");
     _knownPeers.push({
       name: "Signed App",
       remote_epk: APP_PEER_ID,
@@ -515,8 +555,14 @@ describe("state machine + pair_request flow", () => {
     const sent = relayRef.current!.send.mock.calls.map((c) => c[0] as string);
     const signedReplies = sent.map(decodeSentCt).filter((d) => d.inner.type === "signed_inner_v1");
     expect(signedReplies).toHaveLength(1);
-    expect(signedReplies[0]!.inner["payload_type"]).toBe("pong");
-    expect((signedReplies[0]!.inner["payload"] as Record<string, unknown>)["in_reply_to"]).toBe("signed-ping");
+    const verified = verifyInnerV1({
+      frame: signedReplies[0]!.inner as never,
+      expectedSenderPk: piPk,
+      expectedRecipientPk: APP_PEER_ID,
+      expectedRoomId: roomIdForCwd("/home/user/projects/remote_pi"),
+      replay: new SignedInnerReplayCache(),
+    });
+    expect(verified).toMatchObject({ ok: true, payload: { type: "pong", in_reply_to: "signed-ping" } });
   });
 
   test("known signed-inner peer reconnect rejects unsigned first message", async () => {
@@ -576,6 +622,41 @@ describe("state machine + pair_request flow", () => {
       type: "error",
       code: "unknown_peer",
     });
+  });
+
+  test("unknown signed peer receives signed unknown_peer error", async () => {
+    const { generateEd25519Keypair } = await import("./pairing/crypto.js");
+    const { SignedInnerReplayCache, signInnerV1, verifyInnerV1 } = await import("./protocol/signed_inner.js");
+    const { roomIdForCwd } = await import("./rooms.js");
+    const app = generateEd25519Keypair();
+    const APP_PEER_ID = Buffer.from(app.publicKey).toString("base64");
+    const piPk = Buffer.from(_piKeypair.publicKey).toString("base64");
+    const roomId = roomIdForCwd("/home/user/projects/remote_pi");
+
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx());
+
+    relayRef.current!.emit("message", makeInnerLine(APP_PEER_ID, signInnerV1({
+      payload: { type: "ping", id: "revoked-signed" },
+      sender: app,
+      recipientPk: piPk,
+      roomId,
+    })));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(_getState()).toBe("started");
+    expect(_addedPeers).toHaveLength(0);
+    const sent = relayRef.current!.send.mock.calls.map((c) => c[0] as string);
+    const replies = sent.map(decodeSentCt).filter((d) => d.inner.type === "signed_inner_v1");
+    expect(replies).toHaveLength(1);
+    const verified = verifyInnerV1({
+      frame: replies[0]!.inner as never,
+      expectedSenderPk: piPk,
+      expectedRecipientPk: APP_PEER_ID,
+      expectedRoomId: roomId,
+      replay: new SignedInnerReplayCache(),
+    });
+    expect(verified).toMatchObject({ ok: true, payload: { type: "error", code: "unknown_peer" } });
   });
 
   test("unknown peer + pair_request → NOT replied with error{unknown_peer}", async () => {
@@ -662,7 +743,7 @@ describe("contract fixtures: pair_*", () => {
     const lines = readFileSync(`${fixtureDir}/pair_error.jsonl`, "utf8")
       .split("\n").filter(Boolean);
     expect(lines.length).toBeGreaterThan(0);
-    const validCodes = new Set(["token_expired", "token_consumed", "token_unknown", "internal_error"]);
+    const validCodes = new Set(["token_expired", "token_consumed", "token_unknown", "capability_downgrade", "internal_error"]);
     for (const line of lines) {
       const obj = JSON.parse(line) as { type: string; in_reply_to: string; code: string; message: string };
       expect(obj.type).toBe("pair_error");

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -705,16 +705,30 @@ export function _onPeerDisconnect(appPeerId?: string): void {
  * channel and installs a fresh one — covers reconnect from the same
  * device without leaking listeners).
  */
+function _isCanonicalBase64Ed25519Key(value: string): boolean {
+  try {
+    const bytes = Buffer.from(value, "base64");
+    return bytes.length === 32 && bytes.toString("base64") === value;
+  } catch {
+    return false;
+  }
+}
+
 function _attachOwner(
   relay: RelayClient,
   appPeerId: string,
   peerName: string,
   firstInner?: ClientMessage,
+  supportsSignedInnerV1 = false,
 ): PlainPeerChannel {
   const peerShort = appPeerId.slice(0, 8);
 
   // Drop any stale channel for this owner before re-attaching.
   if (_activePeers.has(appPeerId)) _detachPeerChannel(appPeerId);
+
+  if (supportsSignedInnerV1 && (!_cachedEd25519 || !_myRoomId || !_isCanonicalBase64Ed25519Key(appPeerId))) {
+    throw new Error("signed_inner_v1 was negotiated but channel signing prerequisites are unavailable");
+  }
 
   const channel = new PlainPeerChannel(
     relay,
@@ -722,6 +736,14 @@ function _attachOwner(
     _myRoomId ?? undefined,
     (msg) => _routeClientMessageFrom(channel, msg, _lastCtx ?? _noopCtx),
     () => _onPeerDisconnect(appPeerId),
+    supportsSignedInnerV1
+      ? {
+          localKeypair: _cachedEd25519!,
+          expectedRemotePubkey: appPeerId,
+          roomId: _myRoomId!,
+          requireSigned: true,
+        }
+      : undefined,
   );
 
   _attachPeerChannel(appPeerId, channel);
@@ -792,11 +814,17 @@ function _installAutoListener(relay: RelayClient): () => void {
     // See pairing.md §Reconexão.
     const known = await _findKnownPeer(appPeerId);
     if (known) {
-      const channel = _attachOwner(relay, appPeerId, known.name);
+      let channel: PlainPeerChannel;
+      try {
+        channel = _attachOwner(relay, appPeerId, known.name, undefined, known.supports_signed_inner_v1 === true);
+      } catch {
+        return;
+      }
       // The PlainPeerChannel listener for this owner won't have seen the
-      // line that triggered the attach (we already consumed it); route
-      // it explicitly via the new channel so the sender gets a reply.
-      _routeClientMessageFrom(channel, inner, _lastCtx ?? _noopCtx);
+      // line that triggered the attach (we already consumed it); feed the
+      // original relay line through the channel so signed_inner_v1
+      // verification/replay checks are applied before routing.
+      channel.acceptRelayLine(line);
       return;
     }
 
@@ -869,11 +897,18 @@ async function _handlePairRequest(
     return;
   }
 
+  const supportsSignedInnerV1 = Array.isArray(inner.capabilities) && inner.capabilities.includes("signed_inner_v1");
+  if (supportsSignedInnerV1 && (!_cachedEd25519 || !_myRoomId || !_isCanonicalBase64Ed25519Key(appPeerId))) {
+    sendError("internal_error", "signed_inner_v1 was negotiated but channel signing prerequisites are unavailable.");
+    return;
+  }
+
   try {
     await addPeer({
       name: inner.device_name,
       remote_epk: appPeerId,
       paired_at: new Date().toISOString(),
+      supports_signed_inner_v1: supportsSignedInnerV1,
     });
     _refreshPairingsCache();
   } catch (err) {
@@ -889,8 +924,11 @@ async function _handlePairRequest(
   // in the terminal title and in /remote-pi status.
   const sessionName = _displayName(cwd);
 
-  _attachOwner(relay, appPeerId, inner.device_name);
+  _attachOwner(relay, appPeerId, inner.device_name, undefined, supportsSignedInnerV1);
 
+  // Pairing bootstrap remains unsigned: signed_inner_v1 is negotiated in this
+  // pair_ok and enforced only for subsequent paired traffic. Pair-token
+  // hardening is handled separately by owner-signed pairing.
   sendInner({
     type: "pair_ok",
     in_reply_to: inner.id,
@@ -906,6 +944,7 @@ async function _handlePairRequest(
     // two PCs apart even when nicknames collide).
     harness: _HARNESS,
     hostname: _HOSTNAME,
+    ...(supportsSignedInnerV1 ? { capabilities: ["signed_inner_v1"] } : {}),
   });
 }
 

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -57,6 +57,12 @@ import type {
 } from "./protocol/types.js";
 import { RelayClient, RoomAlreadyOpenError } from "./transport/relay_client.js";
 import { PlainPeerChannel } from "./transport/peer_channel.js";
+import {
+  isSignedInnerV1,
+  signInnerV1,
+  SignedInnerReplayCache,
+  type SignedInnerV1,
+} from "./protocol/signed_inner.js";
 import { roomIdForCwd } from "./rooms.js";
 import { SessionPeer } from "./session/peer.js";
 import { registerAgentTools } from "./session/tools.js";
@@ -129,6 +135,7 @@ let _relayUrl: string | null = null;  // URL used by current _relay connection
  *     `/remote-pi status` output both derive from this.
  */
 const _activePeers = new Map<string, PlainPeerChannel>();
+const _signedReplayCaches = new Map<string, SignedInnerReplayCache>();
 let _peerShort = "";  // shortid of the most recently attached peer (UX hint only)
 
 let _myRoomId: string | null = null;   // this Pi's room id (derived from cwd)
@@ -714,11 +721,20 @@ function _isCanonicalBase64Ed25519Key(value: string): boolean {
   }
 }
 
+function _signedReplayCacheFor(appPeerId: string, roomId: string): SignedInnerReplayCache {
+  const key = `${appPeerId}\u0000${roomId}`;
+  let cache = _signedReplayCaches.get(key);
+  if (!cache) {
+    cache = new SignedInnerReplayCache();
+    _signedReplayCaches.set(key, cache);
+  }
+  return cache;
+}
+
 function _attachOwner(
   relay: RelayClient,
   appPeerId: string,
   peerName: string,
-  firstInner?: ClientMessage,
   supportsSignedInnerV1 = false,
 ): PlainPeerChannel {
   const peerShort = appPeerId.slice(0, 8);
@@ -742,6 +758,7 @@ function _attachOwner(
           expectedRemotePubkey: appPeerId,
           roomId: _myRoomId!,
           requireSigned: true,
+          replayCache: _signedReplayCacheFor(appPeerId, _myRoomId!),
         }
       : undefined,
   );
@@ -755,12 +772,6 @@ function _attachOwner(
     "info",
   );
 
-  if (firstInner) {
-    // The PlainPeerChannel listener fired on the same line that triggered
-    // attachment in some flows; we route explicitly here too to ensure the
-    // inner reaches the handler exactly once.
-    void firstInner;
-  }
   return channel;
 }
 
@@ -790,7 +801,7 @@ function _installAutoListener(relay: RelayClient): () => void {
     if (_activePeers.has(outer.peer)) return;
 
     // Decode inner envelope (base64 JSON)
-    let inner: ClientMessage;
+    let inner: ClientMessage | SignedInnerV1;
     try {
       const plaintext = Buffer.from(outer.ct, "base64").toString("utf8");
       const parsed = JSON.parse(plaintext) as unknown;
@@ -799,7 +810,7 @@ function _installAutoListener(relay: RelayClient): () => void {
         typeof parsed !== "object" ||
         typeof (parsed as Record<string, unknown>).type !== "string"
       ) return;
-      inner = parsed as ClientMessage;
+      inner = parsed as ClientMessage | SignedInnerV1;
     } catch { return; }
 
     const appPeerId = outer.peer;
@@ -813,10 +824,15 @@ function _installAutoListener(relay: RelayClient): () => void {
     // sends a non-pair message → attach + route through the new channel.
     // See pairing.md §Reconexão.
     const known = await _findKnownPeer(appPeerId);
+    const existing = _activePeers.get(appPeerId);
+    if (existing) {
+      existing.acceptRelayLine(line);
+      return;
+    }
     if (known) {
       let channel: PlainPeerChannel;
       try {
-        channel = _attachOwner(relay, appPeerId, known.name, undefined, known.supports_signed_inner_v1 === true);
+        channel = _attachOwner(relay, appPeerId, known.name, known.supports_signed_inner_v1 === true);
       } catch {
         return;
       }
@@ -837,7 +853,15 @@ function _installAutoListener(relay: RelayClient): () => void {
       code: "unknown_peer",
       message: "Peer not paired — re-scan QR",
     };
-    const errCt = Buffer.from(JSON.stringify(errReply)).toString("base64");
+    const errInner = isSignedInnerV1(inner) && _cachedEd25519 && _myRoomId && _isCanonicalBase64Ed25519Key(appPeerId)
+      ? signInnerV1({
+          payload: errReply as Record<string, unknown>,
+          sender: _cachedEd25519,
+          recipientPk: appPeerId,
+          roomId: typeof inner.room_id === "string" ? inner.room_id : _myRoomId,
+        })
+      : errReply;
+    const errCt = Buffer.from(JSON.stringify(errInner)).toString("base64");
     relay.send(JSON.stringify({ peer: appPeerId, ct: errCt }));
   };
 
@@ -883,6 +907,12 @@ async function _handlePairRequest(
     sendInner({ type: "pair_error", in_reply_to: inner.id, code, message });
   };
 
+  const supportsSignedInnerV1 = Array.isArray(inner.capabilities) && inner.capabilities.includes("signed_inner_v1");
+  if (qrSession.requiresSignedInner(inner.token) && !supportsSignedInnerV1) {
+    sendError("capability_downgrade", "Signed inner-message support was advertised in the QR but not requested by the app.");
+    return;
+  }
+
   const status = qrSession.consumeToken(inner.token);
   if (status !== "ok") {
     const code: PairErrorCode =
@@ -897,7 +927,6 @@ async function _handlePairRequest(
     return;
   }
 
-  const supportsSignedInnerV1 = Array.isArray(inner.capabilities) && inner.capabilities.includes("signed_inner_v1");
   if (supportsSignedInnerV1 && (!_cachedEd25519 || !_myRoomId || !_isCanonicalBase64Ed25519Key(appPeerId))) {
     sendError("internal_error", "signed_inner_v1 was negotiated but channel signing prerequisites are unavailable.");
     return;
@@ -924,7 +953,7 @@ async function _handlePairRequest(
   // in the terminal title and in /remote-pi status.
   const sessionName = _displayName(cwd);
 
-  _attachOwner(relay, appPeerId, inner.device_name, undefined, supportsSignedInnerV1);
+  _attachOwner(relay, appPeerId, inner.device_name, supportsSignedInnerV1);
 
   // Pairing bootstrap remains unsigned: signed_inner_v1 is negotiated in this
   // pair_ok and enforced only for subsequent paired traffic. Pair-token

--- a/pi-extension/src/pairing/qr.test.ts
+++ b/pi-extension/src/pairing/qr.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { buildQRUri } from "./qr.js";
+
+describe("buildQRUri", () => {
+  test("advertises signed_inner_v1 support with si=1", () => {
+    const uri = new URL(buildQRUri("AAAAAAAAAAAAAAAAAAAAAA", new Uint8Array(32), "Pi", "room-1"));
+    expect(uri.protocol).toBe("remotepi:");
+    expect(uri.searchParams.get("si")).toBe("1");
+    expect(uri.searchParams.get("rm")).toBe("room-1");
+  });
+});

--- a/pi-extension/src/pairing/qr.ts
+++ b/pi-extension/src/pairing/qr.ts
@@ -75,6 +75,10 @@ export function buildQRUri(
     n: sessionName.slice(0, 80),
   });
   if (roomId) params.set("rm", roomId);
+  // Capability advertised in QR so a relay cannot silently strip the
+  // pair_request capability and downgrade a new app/Pi pair to unsigned
+  // inner traffic. Legacy QRs omit this and remain compatible.
+  params.set("si", "1");
   return `remotepi://pair?${params.toString()}`;
 }
 

--- a/pi-extension/src/pairing/qr.ts
+++ b/pi-extension/src/pairing/qr.ts
@@ -7,6 +7,7 @@ interface ActiveToken {
   token: string;
   expiresAt: number;
   consumed: boolean;
+  signedInnerRequired: boolean;
 }
 
 /** Encapsulates the single active QR token. One instance per Pi process. */
@@ -22,11 +23,24 @@ export class QRSession {
    * Issues a new active token, invalidating any previous one.
    * Returns the token and its expiry timestamp.
    */
-  issueToken(): { token: string; expiresAt: number } {
+  issueToken(options: { signedInnerRequired?: boolean } = {}): { token: string; expiresAt: number } {
     const token = this.generateToken();
     const expiresAt = Date.now() + TOKEN_TTL_MS;
-    this.active = { token, expiresAt, consumed: false };
+    this.active = {
+      token,
+      expiresAt,
+      consumed: false,
+      signedInnerRequired: options.signedInnerRequired ?? true,
+    };
     return { token, expiresAt };
+  }
+
+  requiresSignedInner(token: string): boolean {
+    return !!this.active &&
+      this.active.token === token &&
+      !this.active.consumed &&
+      Date.now() <= this.active.expiresAt &&
+      this.active.signedInnerRequired;
   }
 
   /** Validates and atomically consumes a token. */

--- a/pi-extension/src/pairing/storage.ts
+++ b/pi-extension/src/pairing/storage.ts
@@ -182,6 +182,7 @@ export interface PeerRecord {
   name: string;
   remote_epk: string; // base64 standard, 32B Ed25519
   paired_at: string;  // ISO-8601
+  supports_signed_inner_v1?: boolean;
 }
 
 export async function listPeers(): Promise<PeerRecord[]> {

--- a/pi-extension/src/protocol/signed_inner.test.ts
+++ b/pi-extension/src/protocol/signed_inner.test.ts
@@ -60,6 +60,57 @@ describe("signed_inner_v1", () => {
     })).toMatchObject({ ok: true, payload: { type: "user_message", id: "u-vector" } });
   });
 
+  test("canonicalization follows JSON semantics for undefined and sparse arrays", () => {
+    const unsigned = {
+      type: "signed_inner_v1" as const,
+      sender_pk: "sender",
+      recipient_pk: "recipient",
+      room_id: "room-1",
+      msg_id: "msg-1",
+      issued_at: 1,
+      payload_type: "tool_result",
+      payload: {
+        type: "tool_result",
+        keep: true,
+        omitted: undefined,
+        values: Object.assign(["a", undefined, "c"], { 4: "e" }),
+      } as Record<string, unknown>,
+    };
+
+    expect(canonicalSignedInnerV1(unsigned)).toBe(
+      '{"type":"signed_inner_v1","sender_pk":"sender","recipient_pk":"recipient",' +
+      '"room_id":"room-1","msg_id":"msg-1","issued_at":1,"payload_type":"tool_result",' +
+      '"payload":{"keep":true,"type":"tool_result","values":["a",null,"c",null,"e"]}}',
+    );
+  });
+
+  test("signed frames with JSON-normalized payloads verify after wire round-trip", () => {
+    const sender = generateEd25519Keypair();
+    const recipient = generateEd25519Keypair();
+    const recipientPk = Buffer.from(recipient.publicKey).toString("base64");
+    const frame = signInnerV1({
+      sender,
+      recipientPk,
+      roomId: "room-1",
+      now: 1_700_000_000_000,
+      msgId: "msg-json",
+      payload: {
+        type: "tool_result",
+        result: { omitted: undefined, values: Object.assign(["a"], { 2: "c" }) },
+      } as Record<string, unknown>,
+    });
+    const roundTripped = JSON.parse(JSON.stringify(frame)) as typeof frame;
+
+    expect(verifyInnerV1({
+      frame: roundTripped,
+      expectedSenderPk: frame.sender_pk,
+      expectedRecipientPk: recipientPk,
+      expectedRoomId: "room-1",
+      replay: new SignedInnerReplayCache(),
+      now: 1_700_000_000_100,
+    })).toMatchObject({ ok: true, payload: { type: "tool_result" } });
+  });
+
   test("canonical payload is deterministic and excludes sig", () => {
     const unsigned = {
       type: "signed_inner_v1" as const,

--- a/pi-extension/src/protocol/signed_inner.test.ts
+++ b/pi-extension/src/protocol/signed_inner.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { generateEd25519Keypair } from "../pairing/crypto.js";
+import {
+  SignedInnerReplayCache,
+  canonicalSignedInnerV1,
+  signInnerV1,
+  verifyInnerV1,
+} from "./signed_inner.js";
+
+describe("signed_inner_v1", () => {
+  test("signs and verifies a payload", () => {
+    const sender = generateEd25519Keypair();
+    const recipient = generateEd25519Keypair();
+    const recipientPk = Buffer.from(recipient.publicKey).toString("base64");
+    const frame = signInnerV1({
+      sender,
+      recipientPk,
+      roomId: "room-1",
+      now: 1_700_000_000_000,
+      msgId: "msg-1",
+      payload: { type: "user_message", id: "u1", text: "hello" },
+    });
+
+    expect(verifyInnerV1({
+      frame,
+      expectedSenderPk: frame.sender_pk,
+      expectedRecipientPk: recipientPk,
+      expectedRoomId: "room-1",
+      replay: new SignedInnerReplayCache(),
+      now: 1_700_000_000_100,
+    })).toMatchObject({ ok: true, payload: { type: "user_message", id: "u1", text: "hello" } });
+  });
+
+  test("cross-runtime vector stays stable", () => {
+    const senderPk = "ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=";
+    const recipientPk = "ZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4Q=";
+    const unsigned = {
+      type: "signed_inner_v1" as const,
+      sender_pk: senderPk,
+      recipient_pk: recipientPk,
+      room_id: "room-vector",
+      msg_id: "msg-vector",
+      issued_at: 1700000000123,
+      payload_type: "user_message",
+      payload: { type: "user_message", id: "u-vector", text: "hello", nested: { b: 2, a: 1 } },
+    };
+    expect(canonicalSignedInnerV1(unsigned)).toBe(
+      '{"type":"signed_inner_v1","sender_pk":"ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=",' +
+      '"recipient_pk":"ZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4Q=","room_id":"room-vector",' +
+      '"msg_id":"msg-vector","issued_at":1700000000123,"payload_type":"user_message",' +
+      '"payload":{"id":"u-vector","nested":{"a":1,"b":2},"text":"hello","type":"user_message"}}',
+    );
+    expect(verifyInnerV1({
+      frame: { ...unsigned, sig: "GxWRHj92N2l5IW1ApzmyE+5cfeWJAoLRoaqRhC5M40aV1rW13GYQ4pLI0ZMcIvbgOsfQwvwpMyQ4F/A972LxCA==" },
+      expectedSenderPk: senderPk,
+      expectedRecipientPk: recipientPk,
+      expectedRoomId: "room-vector",
+      replay: new SignedInnerReplayCache(),
+      now: 1700000000200,
+    })).toMatchObject({ ok: true, payload: { type: "user_message", id: "u-vector" } });
+  });
+
+  test("canonical payload is deterministic and excludes sig", () => {
+    const unsigned = {
+      type: "signed_inner_v1" as const,
+      sender_pk: "sender",
+      recipient_pk: "recipient",
+      room_id: "room-1",
+      msg_id: "msg-1",
+      issued_at: 1,
+      payload_type: "tool_request",
+      payload: { z: 1, type: "tool_request", args: { b: true, a: false } },
+    };
+    expect(canonicalSignedInnerV1(unsigned)).toBe(
+      '{"type":"signed_inner_v1","sender_pk":"sender","recipient_pk":"recipient",' +
+      '"room_id":"room-1","msg_id":"msg-1","issued_at":1,"payload_type":"tool_request",' +
+      '"payload":{"args":{"a":false,"b":true},"type":"tool_request","z":1}}',
+    );
+  });
+
+  test("rejects tamper, wrong recipient, wrong room, replay, and stale timestamp", () => {
+    const sender = generateEd25519Keypair();
+    const recipient = generateEd25519Keypair();
+    const other = generateEd25519Keypair();
+    const recipientPk = Buffer.from(recipient.publicKey).toString("base64");
+    const otherPk = Buffer.from(other.publicKey).toString("base64");
+    const frame = signInnerV1({
+      sender,
+      recipientPk,
+      roomId: "room-1",
+      now: 1_700_000_000_000,
+      msgId: "msg-1",
+      payload: { type: "ping", id: "p1" },
+    });
+
+    const replay = new SignedInnerReplayCache();
+    expect(verifyInnerV1({ frame: { ...frame, payload: { type: "ping", id: "p2" } }, expectedSenderPk: frame.sender_pk, expectedRecipientPk: recipientPk, expectedRoomId: "room-1", replay, now: 1_700_000_000_000 }))
+      .toMatchObject({ ok: false, code: "signature_invalid" });
+    expect(verifyInnerV1({ frame, expectedSenderPk: frame.sender_pk, expectedRecipientPk: otherPk, expectedRoomId: "room-1", replay, now: 1_700_000_000_000 }))
+      .toMatchObject({ ok: false, code: "wrong_recipient" });
+    expect(verifyInnerV1({ frame, expectedSenderPk: frame.sender_pk, expectedRecipientPk: recipientPk, expectedRoomId: "room-2", replay, now: 1_700_000_000_000 }))
+      .toMatchObject({ ok: false, code: "wrong_room" });
+    expect(verifyInnerV1({ frame, expectedSenderPk: frame.sender_pk, expectedRecipientPk: recipientPk, expectedRoomId: "room-1", replay, now: 1_700_000_000_000 }))
+      .toMatchObject({ ok: true });
+    expect(verifyInnerV1({ frame, expectedSenderPk: frame.sender_pk, expectedRecipientPk: recipientPk, expectedRoomId: "room-1", replay, now: 1_700_000_000_000 }))
+      .toMatchObject({ ok: false, code: "replay" });
+    expect(verifyInnerV1({ frame, expectedSenderPk: frame.sender_pk, expectedRecipientPk: recipientPk, expectedRoomId: "room-1", replay: new SignedInnerReplayCache(), now: 1_700_001_000_000 }))
+      .toMatchObject({ ok: false, code: "replay" });
+  });
+});

--- a/pi-extension/src/protocol/signed_inner.ts
+++ b/pi-extension/src/protocol/signed_inner.ts
@@ -46,10 +46,32 @@ export class SignedInnerReplayCache {
 }
 
 function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value === null) return "null";
+  const valueType = typeof value;
+  if (valueType !== "object") {
+    if (valueType === "undefined" || valueType === "function" || valueType === "symbol") return "null";
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    const items: string[] = [];
+    for (let i = 0; i < value.length; i += 1) {
+      const entry = Object.prototype.hasOwnProperty.call(value, i) ? value[i] : undefined;
+      const entryType = typeof entry;
+      items.push(
+        entryType === "undefined" || entryType === "function" || entryType === "symbol"
+          ? "null"
+          : stableJson(entry),
+      );
+    }
+    return `[${items.join(",")}]`;
+  }
   const obj = value as Record<string, unknown>;
-  return `{${Object.keys(obj).sort().map((key) => `${JSON.stringify(key)}:${stableJson(obj[key])}`).join(",")}}`;
+  return `{${Object.keys(obj).sort().flatMap((key) => {
+    const entry = obj[key];
+    const entryType = typeof entry;
+    if (entryType === "undefined" || entryType === "function" || entryType === "symbol") return [];
+    return [`${JSON.stringify(key)}:${stableJson(entry)}`];
+  }).join(",")}}`;
 }
 
 export function canonicalSignedInnerV1(frame: Omit<SignedInnerV1, "sig">): string {

--- a/pi-extension/src/protocol/signed_inner.ts
+++ b/pi-extension/src/protocol/signed_inner.ts
@@ -1,0 +1,141 @@
+import { randomBytes } from "node:crypto";
+import { ed25519Sign, ed25519Verify, type Ed25519Keypair } from "../pairing/crypto.js";
+
+export interface SignedInnerV1 {
+  type: "signed_inner_v1";
+  sender_pk: string;
+  recipient_pk: string;
+  room_id: string;
+  msg_id: string;
+  issued_at: number;
+  payload_type: string;
+  payload: Record<string, unknown>;
+  sig: string;
+}
+
+export type VerifySignedInnerResult =
+  | { ok: true; payload: Record<string, unknown> }
+  | { ok: false; code: string; message: string };
+
+export class SignedInnerReplayCache {
+  private readonly seen = new Map<string, number>();
+
+  constructor(
+    private readonly maxAgeMs = 5 * 60_000,
+    private readonly maxEntries = 2048,
+  ) {}
+
+  accept(senderPk: string, roomId: string, msgId: string, issuedAt: number, now = Date.now()): boolean {
+    this.prune(now);
+    if (Math.abs(now - issuedAt) > this.maxAgeMs) return false;
+    const key = `${senderPk}\u0000${roomId}\u0000${msgId}`;
+    if (this.seen.has(key)) return false;
+    this.seen.set(key, issuedAt);
+    if (this.seen.size > this.maxEntries) {
+      const first = this.seen.keys().next().value as string | undefined;
+      if (first) this.seen.delete(first);
+    }
+    return true;
+  }
+
+  private prune(now: number): void {
+    for (const [key, issuedAt] of this.seen) {
+      if (Math.abs(now - issuedAt) > this.maxAgeMs) this.seen.delete(key);
+    }
+  }
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj).sort().map((key) => `${JSON.stringify(key)}:${stableJson(obj[key])}`).join(",")}}`;
+}
+
+export function canonicalSignedInnerV1(frame: Omit<SignedInnerV1, "sig">): string {
+  return JSON.stringify({
+    type: frame.type,
+    sender_pk: frame.sender_pk,
+    recipient_pk: frame.recipient_pk,
+    room_id: frame.room_id,
+    msg_id: frame.msg_id,
+    issued_at: frame.issued_at,
+    payload_type: frame.payload_type,
+    payload: JSON.parse(stableJson(frame.payload)) as Record<string, unknown>,
+  });
+}
+
+function decodeB64(value: string, expectedLength: number): Buffer | null {
+  try {
+    const bytes = Buffer.from(value, "base64");
+    return bytes.length === expectedLength ? bytes : null;
+  } catch {
+    return null;
+  }
+}
+
+export function signInnerV1(args: {
+  payload: Record<string, unknown>;
+  sender: Ed25519Keypair;
+  recipientPk: string;
+  roomId: string;
+  now?: number;
+  msgId?: string;
+}): SignedInnerV1 {
+  const senderPk = Buffer.from(args.sender.publicKey).toString("base64");
+  const payloadType = String(args.payload["type"] ?? "");
+  const unsigned: Omit<SignedInnerV1, "sig"> = {
+    type: "signed_inner_v1",
+    sender_pk: senderPk,
+    recipient_pk: args.recipientPk,
+    room_id: args.roomId,
+    msg_id: args.msgId ?? randomBytes(16).toString("base64"),
+    issued_at: args.now ?? Date.now(),
+    payload_type: payloadType,
+    payload: args.payload,
+  };
+  const sig = ed25519Sign(args.sender.secretKey, Buffer.from(canonicalSignedInnerV1(unsigned), "utf8"));
+  return { ...unsigned, sig: Buffer.from(sig).toString("base64") };
+}
+
+export function verifyInnerV1(args: {
+  frame: SignedInnerV1;
+  expectedSenderPk: string;
+  expectedRecipientPk: string;
+  expectedRoomId: string;
+  replay: SignedInnerReplayCache;
+  now?: number;
+}): VerifySignedInnerResult {
+  const { frame } = args;
+  if (frame.sender_pk !== args.expectedSenderPk) {
+    return { ok: false, code: "wrong_sender", message: "Signed inner sender does not match paired peer." };
+  }
+  if (frame.recipient_pk !== args.expectedRecipientPk) {
+    return { ok: false, code: "wrong_recipient", message: "Signed inner recipient does not match local peer." };
+  }
+  if (frame.room_id !== args.expectedRoomId) {
+    return { ok: false, code: "wrong_room", message: "Signed inner room does not match active room." };
+  }
+  if (!frame.payload || typeof frame.payload !== "object" || Array.isArray(frame.payload)) {
+    return { ok: false, code: "bad_payload", message: "Signed inner payload is invalid." };
+  }
+  if (frame.payload_type !== frame.payload["type"]) {
+    return { ok: false, code: "payload_type_mismatch", message: "Signed inner payload type mismatch." };
+  }
+  const senderPk = decodeB64(frame.sender_pk, 32);
+  const sig = decodeB64(frame.sig, 64);
+  if (!senderPk || !sig) return { ok: false, code: "bad_signature", message: "Signed inner key or signature is invalid." };
+  const { sig: _sig, ...unsigned } = frame;
+  void _sig;
+  if (!ed25519Verify(senderPk, Buffer.from(canonicalSignedInnerV1(unsigned), "utf8"), sig)) {
+    return { ok: false, code: "signature_invalid", message: "Signed inner signature verification failed." };
+  }
+  if (!args.replay.accept(frame.sender_pk, frame.room_id, frame.msg_id, frame.issued_at, args.now)) {
+    return { ok: false, code: "replay", message: "Signed inner message was replayed or is outside the freshness window." };
+  }
+  return { ok: true, payload: frame.payload };
+}
+
+export function isSignedInnerV1(value: unknown): value is SignedInnerV1 {
+  return !!value && typeof value === "object" && (value as Record<string, unknown>).type === "signed_inner_v1";
+}

--- a/pi-extension/src/protocol/types.ts
+++ b/pi-extension/src/protocol/types.ts
@@ -2,6 +2,7 @@ export type PairErrorCode =
   | "token_expired"
   | "token_consumed"
   | "token_unknown"
+  | "capability_downgrade"
   | "internal_error";
 
 export type ClientMessage =

--- a/pi-extension/src/protocol/types.ts
+++ b/pi-extension/src/protocol/types.ts
@@ -5,7 +5,7 @@ export type PairErrorCode =
   | "internal_error";
 
 export type ClientMessage =
-  | { type: "pair_request"; id: string; token: string; device_name: string }
+  | { type: "pair_request"; id: string; token: string; device_name: string; capabilities?: string[] }
   | { type: "user_message"; id: string; text: string }
   | { type: "approve_tool"; id: string; tool_call_id: string; decision: "allow" | "deny" }
   | { type: "cancel"; id: string; target_id: string }
@@ -81,6 +81,7 @@ export type ServerMessage =
        * same project folder.
        */
       hostname?: string;
+      capabilities?: string[];
     }
   | { type: "pair_error"; in_reply_to: string; code: PairErrorCode; message: string }
   | { type: "user_input"; id: string; text: string }

--- a/pi-extension/src/transport/peer_channel.ts
+++ b/pi-extension/src/transport/peer_channel.ts
@@ -53,6 +53,7 @@ export interface SignedInnerOptions {
 export class PlainPeerChannel implements PeerChannel {
   private readonly _unsubscribe: () => void;
   private readonly _signed?: Required<SignedInnerOptions>;
+  private readonly _signedDropLogAt = new Map<string, number>();
 
   constructor(
     private readonly relay: RelayClient,
@@ -102,6 +103,14 @@ export class PlainPeerChannel implements PeerChannel {
     this.relay.send(JSON.stringify(outer));
   }
 
+  private _logSignedDrop(reason: string): void {
+    const now = Date.now();
+    const last = this._signedDropLogAt.get(reason) ?? 0;
+    if (now - last < 30_000) return;
+    this._signedDropLogAt.set(reason, now);
+    console.warn(`[remote-pi] signed_inner_v1 drop: reason=${reason} peer=${this.remotePeerId.slice(0, 8)}`);
+  }
+
   /** Routes an already-received relay line through this channel's verifier. */
   acceptRelayLine(line: string): void {
     this._onLine(line);
@@ -148,7 +157,10 @@ export class PlainPeerChannel implements PeerChannel {
     }
 
     if (isSignedInnerV1(msg)) {
-      if (!this._signed) return;
+      if (!this._signed) {
+        this._logSignedDrop("unexpected_signed");
+        return;
+      }
       const localPk = Buffer.from(this._signed.localKeypair.publicKey).toString("base64");
       let verified: ReturnType<typeof verifyInnerV1>;
       try {
@@ -160,14 +172,21 @@ export class PlainPeerChannel implements PeerChannel {
           replay: this._signed.replayCache,
         });
       } catch {
+        this._logSignedDrop("malformed");
         return;
       }
-      if (!verified.ok) return;
+      if (!verified.ok) {
+        this._logSignedDrop(verified.code);
+        return;
+      }
       this.onMessage(verified.payload as ClientMessage);
       return;
     }
 
-    if (this._signed?.requireSigned) return;
+    if (this._signed?.requireSigned) {
+      this._logSignedDrop("unsigned_required");
+      return;
+    }
     this.onMessage(msg as ClientMessage);
   }
 }

--- a/pi-extension/src/transport/peer_channel.ts
+++ b/pi-extension/src/transport/peer_channel.ts
@@ -1,4 +1,11 @@
 import type { ClientMessage, ServerMessage } from "../protocol/types.js";
+import {
+  isSignedInnerV1,
+  signInnerV1,
+  SignedInnerReplayCache,
+  verifyInnerV1,
+} from "../protocol/signed_inner.js";
+import type { Ed25519Keypair } from "../pairing/crypto.js";
 import type { RelayClient } from "./relay_client.js";
 
 /** Sink for ServerMessage outbound to the remote app. */
@@ -35,8 +42,17 @@ interface OuterEnvelope {
  * `myRoomId` is the *local* Pi's room id — sent on every outbound envelope
  * so the app can correlate which Pi sent it (multi-pi support, plano 17).
  */
+export interface SignedInnerOptions {
+  localKeypair: Ed25519Keypair;
+  expectedRemotePubkey: string;
+  roomId: string;
+  requireSigned?: boolean;
+  replayCache?: SignedInnerReplayCache;
+}
+
 export class PlainPeerChannel implements PeerChannel {
   private readonly _unsubscribe: () => void;
+  private readonly _signed?: Required<SignedInnerOptions>;
 
   constructor(
     private readonly relay: RelayClient,
@@ -50,10 +66,18 @@ export class PlainPeerChannel implements PeerChannel {
     private readonly onMessage: (msg: ClientMessage) => void,
     /** Called when this specific peer connection is considered lost. */
     _onDisconnect?: () => void,
+    signed?: SignedInnerOptions,
   ) {
     const listener = (line: string) => this._onLine(line);
     relay.on("message", listener);
     this._unsubscribe = () => relay.off("message", listener);
+    if (signed) {
+      this._signed = {
+        ...signed,
+        requireSigned: signed.requireSigned ?? true,
+        replayCache: signed.replayCache ?? new SignedInnerReplayCache(),
+      };
+    }
     void _onDisconnect;
     void myRoomId;  // intentionally unused — see send() comment
   }
@@ -61,13 +85,26 @@ export class PlainPeerChannel implements PeerChannel {
   // ── PeerChannel interface ──────────────────────────────────────────────────
 
   send(msg: ServerMessage): void {
-    const ct = Buffer.from(JSON.stringify(msg)).toString("base64");
+    const inner = this._signed
+      ? signInnerV1({
+          payload: msg as Record<string, unknown>,
+          sender: this._signed.localKeypair,
+          recipientPk: this._signed.expectedRemotePubkey,
+          roomId: this._signed.roomId,
+        })
+      : msg;
+    const ct = Buffer.from(JSON.stringify(inner)).toString("base64");
     // NOTE: `room` removed from the outer envelope until relay (W1.A) + app
     // (W1.C) accept the field. Multi-Pi multiplexing already works via
     // `room_id`/`room_meta` in the WS-level `hello` — outer routing stays by
     // `peer` alone. Re-add the field once downstream is ready.
     const outer: OuterEnvelope = { peer: this.remotePeerId, ct };
     this.relay.send(JSON.stringify(outer));
+  }
+
+  /** Routes an already-received relay line through this channel's verifier. */
+  acceptRelayLine(line: string): void {
+    this._onLine(line);
   }
 
   /** Detaches from relay (does not close the relay itself). */
@@ -110,6 +147,27 @@ export class PlainPeerChannel implements PeerChannel {
       return;
     }
 
+    if (isSignedInnerV1(msg)) {
+      if (!this._signed) return;
+      const localPk = Buffer.from(this._signed.localKeypair.publicKey).toString("base64");
+      let verified: ReturnType<typeof verifyInnerV1>;
+      try {
+        verified = verifyInnerV1({
+          frame: msg,
+          expectedSenderPk: this._signed.expectedRemotePubkey,
+          expectedRecipientPk: localPk,
+          expectedRoomId: this._signed.roomId,
+          replay: this._signed.replayCache,
+        });
+      } catch {
+        return;
+      }
+      if (!verified.ok) return;
+      this.onMessage(verified.payload as ClientMessage);
+      return;
+    }
+
+    if (this._signed?.requireSigned) return;
     this.onMessage(msg as ClientMessage);
   }
 }

--- a/pi-extension/src/transport/peer_channel_signed.test.ts
+++ b/pi-extension/src/transport/peer_channel_signed.test.ts
@@ -1,0 +1,112 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, test, vi } from "vitest";
+import { generateEd25519Keypair } from "../pairing/crypto.js";
+import { signInnerV1 } from "../protocol/signed_inner.js";
+import { PlainPeerChannel } from "./peer_channel.js";
+
+class MockRelay extends EventEmitter {
+  send = vi.fn();
+}
+
+function outerLine(peer: string, inner: unknown): string {
+  return JSON.stringify({
+    peer,
+    ct: Buffer.from(JSON.stringify(inner)).toString("base64"),
+  });
+}
+
+describe("PlainPeerChannel signed_inner_v1", () => {
+  test("wraps outbound ServerMessage when negotiated", () => {
+    const relay = new MockRelay();
+    const pi = generateEd25519Keypair();
+    const app = generateEd25519Keypair();
+    const appPk = Buffer.from(app.publicKey).toString("base64");
+    const channel = new PlainPeerChannel(
+      relay as never,
+      appPk,
+      "room-1",
+      () => undefined,
+      undefined,
+      {
+        localKeypair: pi,
+        expectedRemotePubkey: appPk,
+        roomId: "room-1",
+        requireSigned: true,
+      },
+    );
+
+    channel.send({ type: "pong", in_reply_to: "p1" });
+
+    const raw = relay.send.mock.calls[0]![0] as string;
+    const outer = JSON.parse(raw) as { peer: string; ct: string };
+    expect(outer.peer).toBe(appPk);
+    const inner = JSON.parse(Buffer.from(outer.ct, "base64").toString("utf8")) as Record<string, unknown>;
+    expect(inner["type"]).toBe("signed_inner_v1");
+    expect(inner["sender_pk"]).toBe(Buffer.from(pi.publicKey).toString("base64"));
+    expect(inner["recipient_pk"]).toBe(appPk);
+    expect(inner["room_id"]).toBe("room-1");
+    expect(inner["payload_type"]).toBe("pong");
+    expect(inner["payload"]).toEqual({ type: "pong", in_reply_to: "p1" });
+  });
+
+  test("drops malformed relay frames without throwing", () => {
+    const relay = new MockRelay();
+    const app = generateEd25519Keypair();
+    const appPk = Buffer.from(app.publicKey).toString("base64");
+    const messages: unknown[] = [];
+    new PlainPeerChannel(
+      relay as never,
+      appPk,
+      "room-1",
+      (msg) => messages.push(msg),
+    );
+
+    expect(() => relay.emit("message", "not-json")).not.toThrow();
+    expect(() => relay.emit("message", JSON.stringify({ peer: appPk }))).not.toThrow();
+    expect(() => relay.emit("message", JSON.stringify({ peer: appPk, ct: Buffer.from("not-json").toString("base64") }))).not.toThrow();
+    expect(() => relay.emit("message", outerLine(appPk, { id: "no-type" }))).not.toThrow();
+    expect(messages).toEqual([]);
+  });
+
+  test("unwraps signed inbound and drops unsigned/replayed frames in strict mode", () => {
+    const relay = new MockRelay();
+    const pi = generateEd25519Keypair();
+    const app = generateEd25519Keypair();
+    const appPk = Buffer.from(app.publicKey).toString("base64");
+    const piPk = Buffer.from(pi.publicKey).toString("base64");
+    const messages: unknown[] = [];
+    new PlainPeerChannel(
+      relay as never,
+      appPk,
+      "room-1",
+      (msg) => messages.push(msg),
+      undefined,
+      {
+        localKeypair: pi,
+        expectedRemotePubkey: appPk,
+        roomId: "room-1",
+        requireSigned: true,
+      },
+    );
+
+    relay.emit("message", outerLine(appPk, { type: "ping", id: "unsigned" }));
+    expect(messages).toEqual([]);
+
+    relay.emit("message", outerLine(appPk, { type: "signed_inner_v1", payload: null }));
+    expect(messages).toEqual([]);
+
+    const signed = signInnerV1({
+      payload: { type: "ping", id: "p1" },
+      sender: app,
+      recipientPk: piPk,
+      roomId: "room-1",
+      now: Date.now(),
+      msgId: "msg-1",
+    });
+    relay.emit("message", outerLine(appPk, signed));
+    expect(messages).toEqual([{ type: "ping", id: "p1" }]);
+
+    relay.emit("message", outerLine(appPk, signed));
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/pi-extension/test/ping.test.ts
+++ b/pi-extension/test/ping.test.ts
@@ -63,6 +63,7 @@ vi.mock("../src/pairing/qr.js", async (importOriginal) => {
     qrSession: {
       issueToken: vi.fn().mockReturnValue({ token: "test-token", expiresAt: Date.now() + 60_000 }),
       consumeToken: vi.fn().mockReturnValue("ok"),
+      requiresSignedInner: vi.fn().mockReturnValue(false),
       clear: vi.fn(),
       generateToken: vi.fn().mockReturnValue("test-token"),
     },


### PR DESCRIPTION
## Summary

Adds signed `signed_inner_v1` wrappers and an in-memory replay cache for normal app ↔ Pi inner messages. The relay still routes plaintext frames, but paired endpoints can detect forged, modified, cross-room, wrong-recipient, stale, or replayed inner messages.

## Protocol

New app/Pi builds advertise `signed_inner_v1` in `pair_request` / `pair_ok`. The Pi QR also carries `si=1`; the app treats that QR-level capability as non-downgradeable and rejects pairing if the relay strips capability negotiation from `pair_request` or `pair_ok`.

Wrapped inner frame shape:

```json
{
  "type": "signed_inner_v1",
  "sender_pk": "...",
  "recipient_pk": "...",
  "room_id": "...",
  "msg_id": "...",
  "issued_at": 1234567890,
  "payload_type": "user_message",
  "payload": { "...": "..." },
  "sig": "ed25519(sender_sk, canonical_signed_inner_without_sig)"
}
```

Receivers verify sender, recipient, room, payload type, canonical signature, freshness, and replay (`sender_pk + room_id + msg_id`) before dispatching the existing payload.

## Compatibility

- Legacy QRs without `si=1` remain compatible and do not force signed-inner mode.
- Pairing bootstrap (`pair_request`, `pair_ok`, `pair_error`) remains unsigned in this PR; signed-inner enforcement starts after capability negotiation.
- Existing peers without persisted signed-inner capability continue using legacy plaintext inner frames until re-paired/renegotiated.

## Tests

Pi extension:

```sh
cd pi-extension
corepack pnpm typecheck
corepack pnpm test
corepack pnpm build
```

App:

```sh
cd app
flutter analyze
flutter test
```

Coverage includes app/Pi helper canonicalization, cross-runtime signature vector, production channel wrap/unwrap/replay rejection, wrong recipient/room/tamper/stale cases, malformed frame drop behavior, capability persistence/negotiation, QR downgrade rejection, and signed/unsigned reconnect behavior.
