### PR TITLE
Add selectable font options in Settings

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -99,7 +99,6 @@
 				D6AB042482B946463A8C5786 /* Pods-RunnerTests.release.xcconfig */,
 				02631AF8A127D9643BCF6C49 /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -493,14 +492,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = U843T2P7A2;
+				DEVELOPMENT_TEAM = 8TB6GA346H;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = work.jacobmoura.remotepi.app;
+				PRODUCT_BUNDLE_IDENTIFIER = work.hyunhwan.remotepi.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -515,6 +514,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8TB6GA346H;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = work.jacobmoura.remotepi.app.RunnerTests;
@@ -533,6 +533,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8TB6GA346H;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = work.jacobmoura.remotepi.app.RunnerTests;
@@ -549,6 +550,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8TB6GA346H;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = work.jacobmoura.remotepi.app.RunnerTests;
@@ -676,14 +678,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = U843T2P7A2;
+				DEVELOPMENT_TEAM = 8TB6GA346H;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = work.jacobmoura.remotepi.app;
+				PRODUCT_BUNDLE_IDENTIFIER = work.hyunhwan.remotepi.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -699,14 +701,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = U843T2P7A2;
+				DEVELOPMENT_TEAM = 8TB6GA346H;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = work.jacobmoura.remotepi.app;
+				PRODUCT_BUNDLE_IDENTIFIER = work.hyunhwan.remotepi.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -2,26 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCameraUsageDescription</key>
-	<string>Camera is used to scan the QR code shown on your Mac terminal.</string>
-	<!-- Public relays must use TLS (https/wss). NSAllowsLocalNetworking permits
-	     cleartext (http/ws) only to local/private-network self-hosted relays,
-	     which is the supported use case. Arbitrary public cleartext is blocked,
-	     so no App Review justification is required. -->
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
-	</dict>
-	<!-- Required for iOS 14+ to connect to devices on the local network (LAN relay). -->
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Remote Pi connects to a relay on your local network to communicate with your Mac.</string>
-	<!-- App uses only standard TLS transport + Ed25519 signatures (digital
-	     signature is exempt). Qualifies for the standard export-compliance
-	     exemption; set to false so uploads don't require manual compliance
-	     answers in App Store Connect. -->
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
@@ -44,8 +24,19 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera is used to scan the QR code shown on your Mac terminal.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Remote Pi connects to a relay on your local network to communicate with your Mac.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/app/lib/data/preferences/preferences.dart
+++ b/app/lib/data/preferences/preferences.dart
@@ -1,3 +1,4 @@
+import 'package:app/domain/app_font_choice.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -13,14 +14,16 @@ class Preferences extends ChangeNotifier {
   String? _selectedPeerEpk;
   String? _relayUrl;
   bool _onboardingCompleted = false;
+  AppFontChoice _appFont = AppFontChoice.mono;
 
   Preferences([FlutterSecureStorage? store])
-      : _store = store ?? const FlutterSecureStorage();
+    : _store = store ?? const FlutterSecureStorage();
 
   static const _kHideToolCallsKey = 'prefs.hide_tool_calls';
   static const _kSelectedPeerEpkKey = 'prefs.selected_peer_epk';
   static const _kRelayUrlKey = 'prefs.relay_url';
   static const _kOnboardingCompletedKey = 'prefs.onboarding_completed';
+  static const _kAppFontKey = 'prefs.app_font';
 
   /// True → chat hides `ToolEvent` rows (only user/assistant text remain).
   bool get hideToolCalls => _hideToolCalls;
@@ -67,6 +70,9 @@ class Preferences extends ChangeNotifier {
   /// once. Drives `/boot` redirect: false → `/onboarding`, true → `/home`.
   bool get onboardingCompleted => _onboardingCompleted;
 
+  /// Selected typography profile used by the global theme.
+  AppFontChoice get appFont => _appFont;
+
   /// Hydrate from secure storage. Safe to call multiple times.
   Future<void> load() async {
     var changed = false;
@@ -99,16 +105,21 @@ class Preferences extends ChangeNotifier {
       changed = true;
     }
 
+    final appFont = AppFontChoice.fromStorage(
+      await _store.read(key: _kAppFontKey),
+    );
+    if (appFont != _appFont) {
+      _appFont = appFont;
+      changed = true;
+    }
+
     if (changed) notifyListeners();
   }
 
   Future<void> setHideToolCalls(bool value) async {
     if (_hideToolCalls == value) return;
     _hideToolCalls = value;
-    await _store.write(
-      key: _kHideToolCallsKey,
-      value: value.toString(),
-    );
+    await _store.write(key: _kHideToolCallsKey, value: value.toString());
     notifyListeners();
   }
 
@@ -131,9 +142,7 @@ class Preferences extends ChangeNotifier {
     if (epk == null || epk.isEmpty) {
       return setSelectedPeerEpk(null);
     }
-    final composite = (roomId == null || roomId.isEmpty)
-        ? epk
-        : '$epk:$roomId';
+    final composite = (roomId == null || roomId.isEmpty) ? epk : '$epk:$roomId';
     return setSelectedPeerEpk(composite);
   }
 
@@ -155,10 +164,14 @@ class Preferences extends ChangeNotifier {
   Future<void> setOnboardingCompleted(bool value) async {
     if (_onboardingCompleted == value) return;
     _onboardingCompleted = value;
-    await _store.write(
-      key: _kOnboardingCompletedKey,
-      value: value.toString(),
-    );
+    await _store.write(key: _kOnboardingCompletedKey, value: value.toString());
+    notifyListeners();
+  }
+
+  Future<void> setAppFont(AppFontChoice value) async {
+    if (_appFont == value) return;
+    _appFont = value;
+    await _store.write(key: _kAppFontKey, value: value.storageKey);
     notifyListeners();
   }
 }

--- a/app/lib/domain/app_font_choice.dart
+++ b/app/lib/domain/app_font_choice.dart
@@ -1,0 +1,19 @@
+enum AppFontChoice {
+  systemDefault('system_default'),
+  robotoMono('roboto_mono'),
+  jetBrainsMono('jetbrains_mono'),
+  sans('sans'),
+  serif('serif'),
+  mono('mono');
+
+  const AppFontChoice(this.storageKey);
+
+  final String storageKey;
+
+  static AppFontChoice fromStorage(String? raw) {
+    for (final value in AppFontChoice.values) {
+      if (value.storageKey == raw) return value;
+    }
+    return AppFontChoice.mono;
+  }
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -87,11 +87,16 @@ class _RemotePiAppState extends State<RemotePiApp> with WidgetsBindingObserver {
           value: injector.get<ShellLayout>(),
         ),
       ],
-      child: MaterialApp.router(
-        title: 'Remote Pi',
-        theme: buildAppTheme(),
-        routerConfig: _router,
-        debugShowCheckedModeBanner: false,
+      child: Builder(
+        builder: (context) {
+          final prefs = context.watch<Preferences>();
+          return MaterialApp.router(
+            title: 'Remote Pi',
+            theme: buildAppTheme(font: prefs.appFont),
+            routerConfig: _router,
+            debugShowCheckedModeBanner: false,
+          );
+        },
       ),
     );
   }

--- a/app/lib/ui/app_theme.dart
+++ b/app/lib/ui/app_theme.dart
@@ -1,4 +1,6 @@
+import 'package:app/domain/app_font_choice.dart';
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 // Design tokens from app/wareframe/screens.jsx
 // All widgets MUST use these constants for visual consistency.
@@ -11,7 +13,7 @@ const kMuted = Color(0xFF6B6B6B);
 const kMuted2 = Color(0xFF8A8A8A);
 const kAccent = Color(0xFF00D4FF);
 const kHighlight = Color(0xFF9FE6FF); // code/file paths in agent messages
-const kSuccess = Color(0xFF6CD28A);  // ✓ in tool results
+const kSuccess = Color(0xFF6CD28A); // ✓ in tool results
 const kCodeBg = Color(0xFF050505);
 const kUserBubble = Color(0xFF1A1A1A);
 const kModelBadgeBg = Color(0xFF161616);
@@ -40,8 +42,41 @@ const kSansBody = TextStyle(
   letterSpacing: -0.1,
 );
 
+TextStyle _applyFontChoice(AppFontChoice font, TextStyle base) {
+  switch (font) {
+    case AppFontChoice.systemDefault:
+      return base.copyWith(fontFamily: null);
+    case AppFontChoice.robotoMono:
+      return GoogleFonts.robotoMono(textStyle: base);
+    case AppFontChoice.jetBrainsMono:
+      return GoogleFonts.jetBrainsMono(textStyle: base);
+    case AppFontChoice.sans:
+      return base.copyWith(fontFamily: 'Arial');
+    case AppFontChoice.serif:
+      return base.copyWith(fontFamily: 'Times New Roman');
+    case AppFontChoice.mono:
+      return base.copyWith(fontFamily: 'Courier');
+  }
+}
+
 // Shared ThemeData — used in MaterialApp
-ThemeData buildAppTheme() {
+ThemeData buildAppTheme({AppFontChoice font = AppFontChoice.mono}) {
+  final titleStyle = _applyFontChoice(
+    font,
+    const TextStyle(
+      fontSize: 17,
+      fontWeight: FontWeight.w600,
+      color: kText,
+      letterSpacing: -0.2,
+    ),
+  );
+  final bodyMedium = _applyFontChoice(font, kSansBody);
+  final bodySmall = _applyFontChoice(font, kMonoSmall);
+  final hint = _applyFontChoice(
+    font,
+    const TextStyle(color: kMuted, fontFamily: kMono, fontSize: 13),
+  );
+
   return ThemeData(
     brightness: Brightness.dark,
     scaffoldBackgroundColor: kBg,
@@ -52,22 +87,14 @@ ThemeData buildAppTheme() {
       secondary: kMuted,
       onSecondary: kText,
     ),
-    appBarTheme: const AppBarTheme(
+    appBarTheme: AppBarTheme(
       backgroundColor: kBg,
       foregroundColor: kText,
       elevation: 0,
-      titleTextStyle: TextStyle(
-        fontSize: 17,
-        fontWeight: FontWeight.w600,
-        color: kText,
-        letterSpacing: -0.2,
-      ),
+      titleTextStyle: titleStyle,
     ),
     dividerColor: kBorder,
-    textTheme: const TextTheme(
-      bodyMedium: kSansBody,
-      bodySmall: kMonoSmall,
-    ),
+    textTheme: TextTheme(bodyMedium: bodyMedium, bodySmall: bodySmall),
     inputDecorationTheme: InputDecorationTheme(
       filled: true,
       fillColor: const Color(0xFF0E0E0E),
@@ -83,7 +110,7 @@ ThemeData buildAppTheme() {
         borderRadius: BorderRadius.circular(19),
         borderSide: const BorderSide(color: kAccent, width: 1.2),
       ),
-      hintStyle: const TextStyle(color: kMuted, fontFamily: kMono, fontSize: 13),
+      hintStyle: hint,
       contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
     ),
   );

--- a/app/lib/ui/chat/widgets/tool_request_card.dart
+++ b/app/lib/ui/chat/widgets/tool_request_card.dart
@@ -24,7 +24,8 @@ class ToolRequestCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isRunning = tool.status == ToolEventStatus.pending ||
+    final isRunning =
+        tool.status == ToolEventStatus.pending ||
         tool.status == ToolEventStatus.allowed;
     final opacity = isRunning ? 1.0 : 0.65;
 
@@ -48,18 +49,18 @@ class ToolRequestCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            _buildHeader(),
+            _buildHeader(context),
             const SizedBox(height: 10),
-            _buildCodeBlock(),
+            _buildCodeBlock(context),
             const SizedBox(height: 8),
-            _buildOutcome(),
+            _buildOutcome(context),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(BuildContext context) {
     final statusLabel = switch (tool.status) {
       ToolEventStatus.pending => 'RUNNING',
       ToolEventStatus.allowed => 'RUNNING',
@@ -77,28 +78,20 @@ class ToolRequestCard extends StatelessWidget {
         const SizedBox(width: 8),
         Text(
           tool.tool.toUpperCase(),
-          style: const TextStyle(
-            fontFamily: kMono,
-            fontSize: 11.5,
-            color: kAccent,
-            letterSpacing: 0.6,
-          ),
+          style: (Theme.of(context).textTheme.bodySmall ?? const TextStyle())
+              .copyWith(fontSize: 11.5, color: kAccent, letterSpacing: 0.6),
         ),
         const Spacer(),
         Text(
           statusLabel,
-          style: const TextStyle(
-            fontFamily: kMono,
-            fontSize: 10,
-            color: kMuted,
-            letterSpacing: 0.4,
-          ),
+          style: (Theme.of(context).textTheme.bodySmall ?? const TextStyle())
+              .copyWith(fontSize: 10, color: kMuted, letterSpacing: 0.4),
         ),
       ],
     );
   }
 
-  Widget _buildCodeBlock() {
+  Widget _buildCodeBlock(BuildContext context) {
     final commandText = _formatArgs(tool.tool, tool.args);
     return Container(
       decoration: BoxDecoration(
@@ -110,16 +103,24 @@ class ToolRequestCard extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(r'$ ', style: kMonoStyle.copyWith(color: kMuted)),
+          Text(
+            r'$ ',
+            style: (Theme.of(context).textTheme.bodySmall ?? kMonoStyle)
+                .copyWith(color: kMuted, fontSize: 12.5),
+          ),
           Expanded(
-            child: Text(commandText, style: kMonoStyle),
+            child: Text(
+              commandText,
+              style: (Theme.of(context).textTheme.bodySmall ?? kMonoStyle)
+                  .copyWith(color: const Color(0xFFE6E6E6), fontSize: 12.5),
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildOutcome() {
+  Widget _buildOutcome(BuildContext context) {
     final text = switch (tool.status) {
       ToolEventStatus.pending || ToolEventStatus.allowed => '⏳ Running…',
       ToolEventStatus.completed => '✓ Done',
@@ -132,11 +133,8 @@ class ToolRequestCard extends StatelessWidget {
     };
     return Text(
       text,
-      style: TextStyle(
-        fontFamily: kMono,
-        fontSize: 12,
-        color: color,
-      ),
+      style: (Theme.of(context).textTheme.bodySmall ?? const TextStyle())
+          .copyWith(fontSize: 12, color: color),
     );
   }
 
@@ -146,9 +144,7 @@ class ToolRequestCard extends StatelessWidget {
       return switch (tool) {
         'Bash' => (args['command'] as String?) ?? '',
         'Edit' || 'Write' => (args['file_path'] as String?) ?? '',
-        _ => args.entries
-            .map((e) => '${e.key}=${e.value}')
-            .join(' '),
+        _ => args.entries.map((e) => '${e.key}=${e.value}').join(' '),
       };
     }
     return args.toString();

--- a/app/lib/ui/settings/settings_page.dart
+++ b/app/lib/ui/settings/settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:app/data/preferences/preferences.dart';
 import 'package:app/data/transport/relay_config.dart';
+import 'package:app/domain/app_font_choice.dart';
 import 'package:app/pairing/storage.dart';
 import 'package:app/ui/app_theme.dart';
 import 'package:app/ui/settings/states/settings_state.dart';
@@ -135,10 +136,7 @@ class _RelaySectionState extends State<_RelaySection> {
     if (err == null) {
       messenger.showSnackBar(
         const SnackBar(
-          content: Text(
-            'Relay updated',
-            style: TextStyle(fontFamily: kMono),
-          ),
+          content: Text('Relay updated', style: TextStyle(fontFamily: kMono)),
           duration: Duration(seconds: 2),
         ),
       );
@@ -167,8 +165,11 @@ class _RelaySectionState extends State<_RelaySection> {
                 decoration: InputDecoration(
                   isDense: true,
                   hintText: 'Default Relay ($kDefaultRelayUrl)',
-                  hintStyle:
-                      const TextStyle(fontFamily: kMono, color: kMuted, fontSize: 12),
+                  hintStyle: const TextStyle(
+                    fontFamily: kMono,
+                    color: kMuted,
+                    fontSize: 12,
+                  ),
                   helperText:
                       'http(s) only — the app converts to WebSocket '
                       'internally.',
@@ -184,7 +185,9 @@ class _RelaySectionState extends State<_RelaySection> {
                     color: Colors.redAccent,
                   ),
                   contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 10, vertical: 10),
+                    horizontal: 10,
+                    vertical: 10,
+                  ),
                   enabledBorder: const OutlineInputBorder(
                     borderSide: BorderSide(color: kBorder),
                   ),
@@ -211,7 +214,9 @@ class _RelaySectionState extends State<_RelaySection> {
                     backgroundColor: kAccent,
                     foregroundColor: Colors.black,
                     padding: const EdgeInsets.symmetric(
-                        horizontal: 18, vertical: 10),
+                      horizontal: 18,
+                      vertical: 10,
+                    ),
                     shape: const RoundedRectangleBorder(
                       borderRadius: BorderRadius.all(Radius.circular(6)),
                     ),
@@ -253,6 +258,45 @@ class _DisplaySection extends StatelessWidget {
           ),
           value: prefs.hideToolCalls,
           onChanged: (v) => prefs.setHideToolCalls(v),
+        ),
+        const Divider(color: kBorder, height: 1),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(18, 8, 18, 0),
+          child: Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  'Font',
+                  style: TextStyle(color: kText, fontSize: 14),
+                ),
+              ),
+              DropdownButton<AppFontChoice>(
+                value: prefs.appFont,
+                dropdownColor: kSurface,
+                style: const TextStyle(color: kText, fontSize: 13),
+                items: AppFontChoice.values
+                    .map(
+                      (font) => DropdownMenuItem<AppFontChoice>(
+                        value: font,
+                        child: Text(switch (font) {
+                          AppFontChoice.systemDefault => 'System default',
+                          AppFontChoice.robotoMono => 'Roboto Mono',
+                          AppFontChoice.jetBrainsMono => 'JetBrains Mono',
+                          AppFontChoice.sans => 'Sans',
+                          AppFontChoice.serif => 'Serif',
+                          AppFontChoice.mono => 'Monospace',
+                        }),
+                      ),
+                    )
+                    .toList(growable: false),
+                onChanged: (v) {
+                  if (v != null) {
+                    prefs.setAppFont(v);
+                  }
+                },
+              ),
+            ],
+          ),
         ),
         const SizedBox(height: 8),
       ],

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -224,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.1"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
   hive:
     dependency: "direct main"
     description:
@@ -248,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -348,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -552,10 +568,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
 
   # Plan 24 — HTTP client for the mesh_versions endpoint on the relay.
   dio: ^5.7.0
+  google_fonts: ^6.3.2
 
 dev_dependencies:
   flutter_test:

--- a/app/test/data/preferences/preferences_test.dart
+++ b/app/test/data/preferences/preferences_test.dart
@@ -1,4 +1,5 @@
 import 'package:app/data/preferences/preferences.dart';
+import 'package:app/domain/app_font_choice.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -86,16 +87,17 @@ void main() {
       expect(notifs, 2);
     });
 
-    test('relayUrl defaults to null and round-trips via setRelayUrl',
-        () async {
+    test('relayUrl defaults to null and round-trips via setRelayUrl', () async {
       final store = _FakeSecureStorage();
       final p = Preferences(store);
       expect(p.relayUrl, isNull);
 
       await p.setRelayUrl('wss://custom.example.com');
       expect(p.relayUrl, 'wss://custom.example.com');
-      expect(await store.read(key: 'prefs.relay_url'),
-          'wss://custom.example.com');
+      expect(
+        await store.read(key: 'prefs.relay_url'),
+        'wss://custom.example.com',
+      );
 
       // Reload from cold start → value survives.
       final p2 = Preferences(store);
@@ -113,29 +115,22 @@ void main() {
       expect(p.relayUrl, isNull);
     });
 
-    test(
-      'onboardingCompleted defaults to false and round-trips via '
-      'setOnboardingCompleted',
-      () async {
-        final store = _FakeSecureStorage();
-        final p = Preferences(store);
-        expect(p.onboardingCompleted, isFalse);
+    test('onboardingCompleted defaults to false and round-trips via '
+        'setOnboardingCompleted', () async {
+      final store = _FakeSecureStorage();
+      final p = Preferences(store);
+      expect(p.onboardingCompleted, isFalse);
 
-        await p.setOnboardingCompleted(true);
-        expect(p.onboardingCompleted, isTrue);
-        expect(
-          await store.read(key: 'prefs.onboarding_completed'),
-          'true',
-        );
+      await p.setOnboardingCompleted(true);
+      expect(p.onboardingCompleted, isTrue);
+      expect(await store.read(key: 'prefs.onboarding_completed'), 'true');
 
-        final p2 = Preferences(store);
-        await p2.load();
-        expect(p2.onboardingCompleted, isTrue);
-      },
-    );
+      final p2 = Preferences(store);
+      await p2.load();
+      expect(p2.onboardingCompleted, isTrue);
+    });
 
-    test('selectedRoom round-trips epk + roomId composite (plan 17)',
-        () async {
+    test('selectedRoom round-trips epk + roomId composite (plan 17)', () async {
       final store = _FakeSecureStorage();
       final p = Preferences(store);
       await p.setSelectedRoom(epk: 'abc123', roomId: 'room-xyz');
@@ -150,22 +145,16 @@ void main() {
       expect(p2.selectedRoomId, 'room-xyz');
     });
 
-    test(
-      'backward-compat: legacy value (no `:room` suffix) returns epk '
-      'and null roomId so caller defaults to "main"',
-      () async {
-        final store = _FakeSecureStorage();
-        // Pre-populate with legacy format (just the epk, no suffix).
-        await store.write(
-          key: 'prefs.selected_peer_epk',
-          value: 'legacy_epk',
-        );
-        final p = Preferences(store);
-        await p.load();
-        expect(p.selectedPeerEpk, 'legacy_epk');
-        expect(p.selectedRoomId, isNull);
-      },
-    );
+    test('backward-compat: legacy value (no `:room` suffix) returns epk '
+        'and null roomId so caller defaults to "main"', () async {
+      final store = _FakeSecureStorage();
+      // Pre-populate with legacy format (just the epk, no suffix).
+      await store.write(key: 'prefs.selected_peer_epk', value: 'legacy_epk');
+      final p = Preferences(store);
+      await p.load();
+      expect(p.selectedPeerEpk, 'legacy_epk');
+      expect(p.selectedRoomId, isNull);
+    });
 
     test('setSelectedRoom with null epk clears the selection', () async {
       final store = _FakeSecureStorage();
@@ -176,5 +165,27 @@ void main() {
       expect(p.selectedPeerEpk, isNull);
       expect(p.selectedRoomRaw, isNull);
     });
+
+    test(
+      'appFont round-trips and falls back when storage is invalid',
+      () async {
+        final store = _FakeSecureStorage();
+        final p = Preferences(store);
+        expect(p.appFont, AppFontChoice.mono);
+
+        await p.setAppFont(AppFontChoice.serif);
+        expect(p.appFont, AppFontChoice.serif);
+        expect(await store.read(key: 'prefs.app_font'), 'serif');
+
+        final p2 = Preferences(store);
+        await p2.load();
+        expect(p2.appFont, AppFontChoice.serif);
+
+        await store.write(key: 'prefs.app_font', value: 'bad_value');
+        final p3 = Preferences(store);
+        await p3.load();
+        expect(p3.appFont, AppFontChoice.mono);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- add persisted app font preference
- add Settings selector with multiple font options
- apply selected font globally through app theme
- include Roboto Mono and JetBrains Mono via google_fonts
- update tool-call card text to follow theme font

## Validation
- flutter test test/data/preferences/preferences_test.dart
- flutter run --release on physical iPhone
