### PR TITLE
fix daemon, so that new session action works

### DIFF
--- a/pi-extension/src/daemon/rpc_child.test.ts
+++ b/pi-extension/src/daemon/rpc_child.test.ts
@@ -25,6 +25,12 @@ describe("rpcSpawnArgs", () => {
       "--mode", "rpc", "--continue", "--name", "PC", "-e", "/path/to/dist/index.js",
     ]);
   });
+
+  test("can omit --continue for one daemon fresh-session restart", () => {
+    expect(rpcSpawnArgs("/path/to/dist/index.js", "PC", false)).toEqual([
+      "--mode", "rpc", "--name", "PC", "-e", "/path/to/dist/index.js",
+    ]);
+  });
 });
 
 describe("RpcChild — deliberate stop is not a crash", () => {

--- a/pi-extension/src/daemon/rpc_child.ts
+++ b/pi-extension/src/daemon/rpc_child.ts
@@ -41,6 +41,8 @@ export interface RpcChildExitEvent {
   isCrash: boolean;
 }
 
+export const EXIT_DAEMON_FRESH_SESSION = 42;
+
 /**
  * CLI args for the daemon's `pi --mode rpc` child.
  *
@@ -58,9 +60,14 @@ export interface RpcChildExitEvent {
  * daemon's name is set at registration (`remote-pi create <cwd> --name "…"`).
  * Omitted when no name resolves, so the arg list stays minimal.
  */
-export function rpcSpawnArgs(extensionPath: string, sessionName?: string): string[] {
+export function rpcSpawnArgs(
+  extensionPath: string,
+  sessionName?: string,
+  useContinue = true,
+): string[] {
   return [
-    "--mode", "rpc", "--continue",
+    "--mode", "rpc",
+    ...(useContinue ? ["--continue"] : []),
     ...(sessionName ? ["--name", sessionName] : []),
     "-e", extensionPath,
   ];
@@ -77,6 +84,8 @@ export class RpcChild extends EventEmitter {
    *  just stopped/removed. Gating `isCrash` on this makes a deliberate stop a
    *  clean exit (no restart). Reset on every `spawn()`. */
   private _stopping = false;
+  /** Next spawn should create a fresh session instead of --continue. */
+  private forceFreshSessionOnNextSpawn = false;
   /** Accumulates partial stdout lines while waiting for `\n`. */
   private stdoutBuf = "";
 
@@ -105,7 +114,9 @@ export class RpcChild extends EventEmitter {
     // so it shows up stably instead of an auto-generated name on each restart.
     const sessionName = loadLocalConfig(this.opts.cwd).agent_name
       ?? defaultAgentName(this.opts.cwd);
-    const args = rpcSpawnArgs(this.opts.extensionPath, sessionName);
+    const useContinue = !this.forceFreshSessionOnNextSpawn;
+    this.forceFreshSessionOnNextSpawn = false;
+    const args = rpcSpawnArgs(this.opts.extensionPath, sessionName, useContinue);
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       ...this.opts.env,
@@ -193,6 +204,10 @@ export class RpcChild extends EventEmitter {
   }
 
   private _onExit(code: number | null, signal: NodeJS.Signals | null): void {
+    // Daemon app-action `/new`: child exits with a private code, supervisor
+    // restarts it, and the next spawn omits --continue once to create a fresh
+    // session. Later restarts go back to --continue.
+    if (code === EXIT_DAEMON_FRESH_SESSION) this.forceFreshSessionOnNextSpawn = true;
     // A deliberate stop() kills by signal — not a crash, so the supervisor
     // must NOT auto-restart it. Only an UNexpected exit counts as a crash.
     const isCrash = !this._stopping && (code !== 0 || signal !== null);

--- a/pi-extension/src/daemon/supervisor.ts
+++ b/pi-extension/src/daemon/supervisor.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { addDaemon, listDaemons, removeDaemon } from "./registry.js";
 import { daemonIdForCwd } from "./id.js";
 import { loadLocalConfig, defaultAgentName } from "../session/local_config.js";
-import { RpcChild, type RpcChildExitEvent, type RpcChildOptions } from "./rpc_child.js";
+import { EXIT_DAEMON_FRESH_SESSION, RpcChild, type RpcChildExitEvent, type RpcChildOptions } from "./rpc_child.js";
 import {
   type ControlReply,
   type ControlRequest,
@@ -355,6 +355,15 @@ export class Supervisor {
 
     if (!evt.isCrash) {
       // Clean shutdown (e.g. via `stop_all`). Don't auto-restart.
+      return;
+    }
+
+    if (evt.code === EXIT_DAEMON_FRESH_SESSION) {
+      // App-triggered daemon `/new`: this is an intentional recycle, not a
+      // crash. Restart immediately and don't burn the crash backoff budget.
+      slot.restartAttempt = 0;
+      slot.child.noteRestart();
+      slot.child.spawn();
       return;
     }
 

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -84,6 +84,7 @@ import { acquireCwdLock, type AcquiredLock } from "./session/cwd_lock.js";
 import { addDaemon, listDaemons, removeDaemon } from "./daemon/registry.js";
 import { callSupervisor, supervisorOnline, SupervisorOfflineError } from "./daemon/client.js";
 import type { DaemonInfo } from "./daemon/control_protocol.js";
+import { EXIT_DAEMON_FRESH_SESSION } from "./daemon/rpc_child.js";
 import { installService, uninstallService, linkCliBinaries, unlinkCliBinaries } from "./daemon/install.js";
 import {
   defaultAgentName,
@@ -2486,9 +2487,20 @@ export function _routeClientMessageFrom(
       // session_start has landed yet (keeps the pre-replacement happy path).
       handleSessionCompact((_lastEventCtx ?? _lastCtx) as ActionCtx | null, sender, msg);
       break;
-    case "session_new":
+    case "session_new": {
+      const actionCtx = _lastCtx as ActionCtx | null;
+      if (process.env["REMOTE_PI_DAEMON"] === "1" && !actionCtx?.newSession) {
+        // Headless RPC daemon has no ExtensionCommandContext, so ctx.newSession
+        // is unavailable. Ack, clear remote-pi's mirror, then exit with a
+        // private code; the supervisor restarts once without --continue, which
+        // creates a fresh Pi session. Later restarts resume that fresh session.
+        sender.send({ type: "action_ok", in_reply_to: msg.id, action: "session_new" });
+        _resetSessionForNew(msg.id);
+        setTimeout(() => process.exit(EXIT_DAEMON_FRESH_SESSION), 100);
+        break;
+      }
       void handleSessionNew(
-        _lastCtx as ActionCtx | null,
+        actionCtx,
         sender,
         msg,
         (freshCtx) => {
@@ -2509,6 +2521,7 @@ export function _routeClientMessageFrom(
         if (created) _resetSessionForNew(msg.id);
       });
       break;
+    }
     case "model_set":
       void handleModelSet(_pi, ensureModelRegistry(), sender, msg, _persistModelDefault);
       break;


### PR DESCRIPTION
   ## Problem

   The app's `new_session` quick action did not work correctly for daemon/RPC sessions.

   Interactive Pi sessions can call `ctx.newSession()` because they have an `ExtensionCommandContext` from slash-command execution. Daemon sessions are headless and auto-start with a minimal fake context, so `ctx.newSession()` is unavailable.

   Result: app-triggered `new_session` on a daemon could not actually roll the daemon into a fresh Pi session.

   ## Summary

   - Fixes app `new_session` quick action for daemon/RPC sessions.
   - Adds daemon-specific fallback: ack the app action, clear remote-pi session mirror, then recycle daemon.
   - Supervisor restarts that recycle immediately.
   - The next daemon spawn omits `--continue` once, creating a fresh Pi session.
   - Later restarts resume normally.

   ## Validation

   Built and installed locally, then restarted the daemon and tested:

   1. Messages survive normal daemon restart.
   2. App `new_session` now clears history on daemon sessions.
