### PR TITLE
App UI: Show edit tool calls as numbered diff previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ out/
 .vercel/
 
 # Flutter / Dart
+dockercache/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/app/lib/ui/chat/widgets/tool_request_card.dart
+++ b/app/lib/ui/chat/widgets/tool_request_card.dart
@@ -39,7 +39,8 @@ class ToolRequestCard extends StatelessWidget {
     final color = _statusColor(context);
     // Dim only the inert states (denied/expired); keep done/failed at full
     // opacity so their green/red read clearly.
-    final dimmed = tool.status == ToolEventStatus.denied ||
+    final dimmed =
+        tool.status == ToolEventStatus.denied ||
         tool.status == ToolEventStatus.expired;
 
     return Opacity(
@@ -115,7 +116,7 @@ class ToolRequestCard extends StatelessWidget {
   Widget _buildCodeBlock(BuildContext context) {
     final colors = context.colors;
     final typo = context.typo;
-    final commandText = _formatArgs(tool.tool, tool.args);
+    final content = _buildToolSummary(context);
     return Container(
       decoration: BoxDecoration(
         color: colors.codeBg,
@@ -127,9 +128,32 @@ class ToolRequestCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(r'$ ', style: typo.mono.copyWith(color: colors.muted)),
-          Expanded(
-            child: Text(commandText, style: typo.mono),
-          ),
+          Expanded(child: content),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToolSummary(BuildContext context) {
+    final colors = context.colors;
+    final typo = context.typo;
+    final display = _formatToolDisplay(tool.tool, tool.args);
+    if (display == null) {
+      return Text(_formatArgs(tool.tool, tool.args), style: typo.mono);
+    }
+
+    return Text.rich(
+      TextSpan(
+        style: typo.mono,
+        children: [
+          TextSpan(text: display.command),
+          for (final line in display.lines) ...[
+            const TextSpan(text: '\n'),
+            TextSpan(
+              text: line.text,
+              style: TextStyle(color: line.color(colors)),
+            ),
+          ],
         ],
       ),
     );
@@ -145,27 +169,102 @@ class ToolRequestCard extends StatelessWidget {
     };
     return Text(
       text,
-      style: TextStyle(
-        fontFamily: kMonoFamily,
-        fontSize: 12,
-        color: color,
-      ),
+      style: TextStyle(fontFamily: kMonoFamily, fontSize: 12, color: color),
     );
   }
 
   static String _formatArgs(String tool, dynamic args) {
     if (args == null) return '';
+    final normalizedTool = tool.toLowerCase();
     if (args is Map) {
-      return switch (tool) {
-        'Bash' => (args['command'] as String?) ?? '',
-        'Edit' || 'Write' => (args['file_path'] as String?) ?? '',
-        _ => args.entries
-            .map((e) => '${e.key}=${e.value}')
-            .join(' '),
+      return switch (normalizedTool) {
+        'bash' => (args['command'] as String?) ?? '',
+        'edit' || 'write' =>
+          '$normalizedTool ${_stringArg(args, const ['file_path', 'path'])}',
+        _ => args.entries.map((e) => '${e.key}=${e.value}').join(' '),
       };
     }
     return args.toString();
   }
+
+  static _ToolDisplay? _formatToolDisplay(String tool, dynamic args) {
+    if (args is! Map) return null;
+    return switch (tool.toLowerCase()) {
+      'edit' => _formatEditDisplay(args),
+      _ => null,
+    };
+  }
+
+  static _ToolDisplay? _formatEditDisplay(Map args) {
+    final filePath = _stringArg(args, const ['file_path', 'path']);
+    final lines = <_DiffLine>[];
+    final hunks = args['hunks'];
+    if (hunks is! Iterable) return null;
+
+    for (final hunk in hunks) {
+      if (hunk is! Map || hunk['lines'] is! Iterable) continue;
+      if (lines.isNotEmpty) lines.add(_DiffLine.context('      ...'));
+      for (final rawLine in hunk['lines'] as Iterable) {
+        if (rawLine is! Map) continue;
+        final text = _lineText(rawLine);
+        switch (rawLine['kind']) {
+          case 'context':
+            lines.add(_DiffLine.context(text));
+          case 'remove':
+            lines.add(_DiffLine.removed(text));
+          case 'add':
+            lines.add(_DiffLine.added(text));
+          case 'ellipsis':
+            lines.add(_DiffLine.context('      ...'));
+        }
+      }
+    }
+
+    if (lines.isEmpty) return null;
+    return _ToolDisplay(command: 'edit $filePath', lines: lines);
+  }
+
+  static String _lineText(Map rawLine) {
+    final sign = switch (rawLine['kind']) {
+      'remove' => '-',
+      'add' => '+',
+      _ => ' ',
+    };
+    final lineNumber = rawLine['oldLine'] ?? rawLine['newLine'];
+    final number = lineNumber is int ? lineNumber.toString().padLeft(3) : '   ';
+    return '$sign $number ${rawLine['text'] ?? ''}';
+  }
+
+  static String _stringArg(Map args, List<String> keys) {
+    for (final key in keys) {
+      final value = args[key];
+      if (value is String) return value;
+    }
+    return '';
+  }
+}
+
+class _ToolDisplay {
+  final String command;
+  final List<_DiffLine> lines;
+
+  const _ToolDisplay({required this.command, required this.lines});
+}
+
+class _DiffLine {
+  final String text;
+  final Color Function(AppColors colors) color;
+
+  const _DiffLine._(this.text, this.color);
+
+  factory _DiffLine.removed(String text) =>
+      _DiffLine._(text, (colors) => colors.error);
+
+  factory _DiffLine.added(String text) =>
+      _DiffLine._(text, (colors) => colors.success);
+
+  factory _DiffLine.context(String text) =>
+      _DiffLine._(text, (colors) => colors.text);
 }
 
 // Minimal terminal icon (rectangle + > and —)

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -564,10 +564,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -808,10 +808,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   tuple:
     dependency: transitive
     description:

--- a/app/test/ui/chat/tool_request_card_test.dart
+++ b/app/test/ui/chat/tool_request_card_test.dart
@@ -13,21 +13,60 @@ const _bashTool = ToolEvent(
   args: {'command': 'ls -la'},
 );
 
+const _editToolWithHunk = ToolEvent(
+  id: 'tc2',
+  toolCallId: 'tc4',
+  tool: 'edit',
+  args: {
+    'path': 'app/test/ui/chat/tool_request_card_test.dart',
+    'hunks': [
+      {
+        'lines': [
+          {'kind': 'context', 'oldLine': 16, 'newLine': 16, 'text': 'args: {'},
+          {'kind': 'remove', 'oldLine': 17, 'text': "  tool: 'Edit',"},
+          {'kind': 'add', 'newLine': 17, 'text': "  tool: 'edit',"},
+          {'kind': 'context', 'oldLine': 18, 'newLine': 18, 'text': '},'},
+        ],
+      },
+    ],
+  },
+);
+
 void main() {
   group('ToolRequestCard (informational)', () {
     testWidgets('shows tool name and command', (tester) async {
-      await tester.pumpWidget(_wrap(
-        const ToolRequestCard(tool: _bashTool),
-      ));
+      await tester.pumpWidget(_wrap(const ToolRequestCard(tool: _bashTool)));
       expect(find.text('BASH'), findsOneWidget);
       expect(find.text('ls -la'), findsOneWidget);
     });
 
-    testWidgets('pending state shows RUNNING and no Allow/Deny buttons',
-        (tester) async {
-      await tester.pumpWidget(_wrap(
-        const ToolRequestCard(tool: _bashTool),
-      ));
+    testWidgets('edit renders rich hunks with context lines', (tester) async {
+      await tester.pumpWidget(
+        _wrap(const ToolRequestCard(tool: _editToolWithHunk)),
+      );
+
+      expect(
+        find.textContaining('   16 args: {', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining("-  17   tool: 'Edit',", findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining("+  17   tool: 'edit',", findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('   18 },', findRichText: true),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('pending state shows RUNNING and no Allow/Deny buttons', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(const ToolRequestCard(tool: _bashTool)));
       expect(find.text('RUNNING'), findsOneWidget);
       expect(find.text('Allow'), findsNothing);
       expect(find.text('Deny'), findsNothing);
@@ -61,8 +100,9 @@ void main() {
       expect(find.text('DENIED'), findsOneWidget);
     });
 
-    testWidgets('allowed state shows RUNNING (still in flight)',
-        (tester) async {
+    testWidgets('allowed state shows RUNNING (still in flight)', (
+      tester,
+    ) async {
       const allowed = ToolEvent(
         id: 'tc1',
         toolCallId: 'tc1',
@@ -104,7 +144,10 @@ void main() {
       );
       await tester.pumpWidget(_wrap(const ToolRequestCard(tool: failed)));
       expect(find.text('FAILED'), findsOneWidget);
-      expect(outcomeColor(tester, '✗ command failed: exit 1'), AppColors.dark.error);
+      expect(
+        outcomeColor(tester, '✗ command failed: exit 1'),
+        AppColors.dark.error,
+      );
     });
 
     testWidgets('running → blue "⏳ Running…"', (tester) async {

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -1268,6 +1268,123 @@ describe("tool visibility", () => {
     });
   });
 
+  test("tool_execution_start enriches edit args with numbered context hunks", async () => {
+    await _pairForTest("peer-edit");
+    const cwd = mkdtempSync(join(tmpdir(), "remote-pi-edit-"));
+    const file = join(cwd, "sample.dart");
+    writeFileSync(
+      file,
+      [
+        "line 1",
+        "line 2",
+        "line 3",
+        "line 4",
+        "line 5",
+        "  tool: 'Edit',",
+        "  args: {",
+        "    'file_path': 'x',",
+        "  },",
+        "line 10",
+      ].join("\n"),
+    );
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    try {
+      const onToolStart = captureEventHandler("tool_execution_start");
+      onToolStart({
+        type: "tool_execution_start",
+        toolCallId: "tc_edit",
+        toolName: "edit",
+        args: {
+          path: file,
+          edits: [
+            {
+              oldText: "  tool: 'Edit',\n  args: {\n    'file_path': 'x',",
+              newText: "  tool: 'edit',\n  args: {\n    'path': 'x',",
+            },
+          ],
+        },
+      });
+
+      const requests = relayRef.current!.send.mock.calls
+        .slice(sendsBefore)
+        .map((c) => c[0] as string)
+        .map(decodeSentCt)
+        .filter((d) => d.inner.type === "tool_request");
+      const args = requests[0]!.inner.args as {
+        hunks: Array<{ lines: Array<{ kind: string; oldLine?: number; newLine?: number; text?: string }> }>;
+      };
+      expect(args.hunks[0]!.lines).toEqual(
+        expect.arrayContaining([
+          { kind: "context", oldLine: 5, newLine: 5, text: "line 5" },
+          { kind: "remove", oldLine: 6, text: "  tool: 'Edit'," },
+          { kind: "add", newLine: 6, text: "  tool: 'edit'," },
+          { kind: "context", oldLine: 9, newLine: 9, text: "  }," },
+        ]),
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  test("tool_execution_start keeps unchanged edit lines as context", async () => {
+    await _pairForTest("peer-edit-context");
+    const cwd = mkdtempSync(join(tmpdir(), "remote-pi-edit-context-"));
+    const file = join(cwd, "README.md");
+    writeFileSync(
+      file,
+      [
+        "<p align=\"center\">",
+        "  Control your Pi from your phone.",
+        "  Pair with a one-time QR code.",
+        "</p>",
+      ].join("\n"),
+    );
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    try {
+      const onToolStart = captureEventHandler("tool_execution_start");
+      onToolStart({
+        type: "tool_execution_start",
+        toolCallId: "tc_edit_context",
+        toolName: "edit",
+        args: {
+          path: file,
+          edits: [
+            {
+              oldText: "  Pair with a one-time QR code.",
+              newText: "  Pair with a one-time QR code.\n  Test note: edit preview smoke test.",
+            },
+          ],
+        },
+      });
+
+      const requests = relayRef.current!.send.mock.calls
+        .slice(sendsBefore)
+        .map((c) => c[0] as string)
+        .map(decodeSentCt)
+        .filter((d) => d.inner.type === "tool_request");
+      const args = requests[0]!.inner.args as {
+        hunks: Array<{ lines: Array<{ kind: string; oldLine?: number; newLine?: number; text?: string }> }>;
+      };
+      expect(args.hunks[0]!.lines).toEqual(
+        expect.arrayContaining([
+          { kind: "context", oldLine: 3, newLine: 3, text: "  Pair with a one-time QR code." },
+          { kind: "add", newLine: 4, text: "  Test note: edit preview smoke test." },
+          { kind: "context", oldLine: 4, newLine: 5, text: "</p>" },
+        ]),
+      );
+      expect(args.hunks[0]!.lines).not.toEqual(
+        expect.arrayContaining([
+          { kind: "remove", oldLine: 3, text: "  Pair with a one-time QR code." },
+        ]),
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   test("tool_execution_start ignored when _peerChannel is null (idle state)", () => {
     expect(_getState()).toBe("idle");
 

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -1042,7 +1042,7 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
       type: "tool_request",
       tool_call_id: event.toolCallId,
       tool: event.toolName,
-      args: event.args as Record<string, unknown>,
+      args: _enrichToolArgs(event.toolName, event.args),
     });
   });
 
@@ -2618,6 +2618,152 @@ function _resetSessionForNew(inReplyTo: string): void {
     eos: true,
     truncated: false,
   });
+}
+
+type ToolArgs = Record<string, unknown>;
+type DiffLine =
+  | { kind: "context"; oldLine?: number; newLine?: number; text: string }
+  | { kind: "remove"; oldLine?: number; text: string }
+  | { kind: "add"; newLine?: number; text: string }
+  | { kind: "ellipsis" };
+
+function _enrichToolArgs(tool: string, args: unknown): ToolArgs {
+  if (!args || typeof args !== "object") return {};
+  const base = args as ToolArgs;
+
+  switch (tool.toLowerCase()) {
+    case "edit":
+      return _enrichEditToolArgs(base);
+    default:
+      return base;
+  }
+}
+
+function _enrichEditToolArgs(base: ToolArgs): ToolArgs {
+  const filePath = _stringArg(base, ["path", "file_path"]);
+  const rawEdits = base["edits"];
+  const edits = Array.isArray(rawEdits) ? rawEdits : [base];
+  const text = _readToolFile(filePath);
+  const hunks: { lines: DiffLine[] }[] = [];
+  let searchFrom = 0;
+  for (const rawEdit of edits) {
+    if (!rawEdit || typeof rawEdit !== "object") continue;
+    const edit = rawEdit as ToolArgs;
+    const oldText = _stringArg(edit, ["oldText", "old_text", "old_string", "oldString"]);
+    const newText = _stringArg(edit, ["newText", "new_text", "new_string", "newString"]);
+    if (!oldText && !newText) continue;
+
+    const matchAt = oldText && text !== null ? text.indexOf(oldText, searchFrom) : -1;
+    const fallbackAt = oldText && matchAt < 0 && text !== null ? text.indexOf(oldText) : matchAt;
+    const startOffset = fallbackAt >= 0 ? fallbackAt : searchFrom;
+    if (text === null) continue;
+    const hunk = _buildEditHunk(text, startOffset, oldText, newText);
+    if (hunk.length > 0) hunks.push({ lines: hunk });
+    searchFrom = startOffset + Math.max(oldText.length, 1);
+  }
+
+  return hunks.length === 0 ? base : { ...base, hunks };
+}
+
+function _readToolFile(filePath: string): string | null {
+  if (!filePath) return null;
+  const cwd = _lastCtx && "cwd" in _lastCtx ? _lastCtx.cwd : process.cwd();
+  const homePath = filePath.startsWith("~/") && process.env.HOME
+    ? resolve(process.env.HOME, filePath.slice(2))
+    : null;
+  const candidates = [filePath, resolve(cwd, filePath), resolve(process.cwd(), filePath), homePath]
+    .filter((p): p is string => typeof p === "string");
+  for (const candidate of candidates) {
+    try {
+      return readFileSync(candidate, "utf8");
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+
+function _buildEditHunk(
+  fileText: string,
+  startOffset: number,
+  oldText: string,
+  newText: string,
+): DiffLine[] {
+  const context = 4;
+  const fileLines = fileText.split("\n");
+  const oldLines = _splitPreviewLines(oldText);
+  const newLines = _splitPreviewLines(newText);
+  const oldStart = _lineNumberAt(fileText, startOffset);
+  const newStart = oldStart;
+  const startIndex = oldStart - 1;
+  const beforeStart = Math.max(0, startIndex - context);
+  const afterStart = startIndex + oldLines.length;
+  const afterEnd = Math.min(fileLines.length, afterStart + context);
+  const out: DiffLine[] = [];
+
+  if (beforeStart > 0) out.push({ kind: "ellipsis" });
+  for (let i = beforeStart; i < startIndex; i++) {
+    out.push({ kind: "context", oldLine: i + 1, newLine: i + 1, text: fileLines[i] ?? "" });
+  }
+  let commonPrefix = 0;
+  while (
+    commonPrefix < oldLines.length &&
+    commonPrefix < newLines.length &&
+    oldLines[commonPrefix] === newLines[commonPrefix]
+  ) {
+    commonPrefix++;
+  }
+
+  let commonSuffix = 0;
+  while (
+    commonSuffix < oldLines.length - commonPrefix &&
+    commonSuffix < newLines.length - commonPrefix &&
+    oldLines[oldLines.length - 1 - commonSuffix] === newLines[newLines.length - 1 - commonSuffix]
+  ) {
+    commonSuffix++;
+  }
+
+  for (let i = 0; i < commonPrefix; i++) {
+    out.push({ kind: "context", oldLine: oldStart + i, newLine: newStart + i, text: oldLines[i] ?? "" });
+  }
+  for (let i = commonPrefix; i < oldLines.length - commonSuffix; i++) {
+    out.push({ kind: "remove", oldLine: oldStart + i, text: oldLines[i] ?? "" });
+  }
+  for (let i = commonPrefix; i < newLines.length - commonSuffix; i++) {
+    out.push({ kind: "add", newLine: newStart + i, text: newLines[i] ?? "" });
+  }
+  for (let i = oldLines.length - commonSuffix; i < oldLines.length; i++) {
+    const newLine = newStart + newLines.length - (oldLines.length - i);
+    out.push({ kind: "context", oldLine: oldStart + i, newLine, text: oldLines[i] ?? "" });
+  }
+  for (let i = afterStart; i < afterEnd; i++) {
+    const newLine = newStart + newLines.length + (i - afterStart);
+    out.push({ kind: "context", oldLine: i + 1, newLine, text: fileLines[i] ?? "" });
+  }
+  if (afterEnd < fileLines.length) out.push({ kind: "ellipsis" });
+  return out;
+}
+
+function _lineNumberAt(text: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < Math.max(0, offset); i++) if (text[i] === "\n") line++;
+  return line;
+}
+
+function _splitPreviewLines(text: string): string[] {
+  if (!text) return [];
+  const lines = text.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+function _stringArg(args: ToolArgs, keys: string[]): string {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === "string") return value;
+  }
+  return "";
 }
 
 function _stringifyContent(content: unknown): string {

--- a/scripts/docker-build-apk.sh
+++ b/scripts/docker-build-apk.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${FLUTTER_DOCKER_IMAGE:-ghcr.io/cirruslabs/flutter:stable}"
+MODE="${1:-debug}"
+CACHE_DIR="$ROOT/dockercache"
+PUB_CACHE="$CACHE_DIR/pub"
+GRADLE_CACHE="$CACHE_DIR/gradle"
+ANDROID_CACHE="$CACHE_DIR/android-sdk"
+ANDROID_PLATFORMS="$ANDROID_CACHE/platforms"
+ANDROID_BUILD_TOOLS="$ANDROID_CACHE/build-tools"
+ANDROID_NDK="$ANDROID_CACHE/ndk"
+ANDROID_CMAKE="$ANDROID_CACHE/cmake"
+ANDROID_LICENSES="$ANDROID_CACHE/licenses"
+
+case "$MODE" in
+  debug|release) ;;
+  *)
+    echo "usage: $0 [debug|release]" >&2
+    exit 2
+    ;;
+esac
+
+# Do not mount $ANDROID_CACHE over /opt/android-sdk-linux wholesale.
+# That would hide the SDK command-line tools already present in the Flutter
+# image and make Flutter report "No Android SDK found". Cache only the heavy
+# downloaded subdirs while keeping the image's base SDK/tools visible.
+mkdir -p \
+  "$PUB_CACHE" \
+  "$GRADLE_CACHE" \
+  "$ANDROID_PLATFORMS" \
+  "$ANDROID_BUILD_TOOLS" \
+  "$ANDROID_NDK" \
+  "$ANDROID_CMAKE" \
+  "$ANDROID_LICENSES"
+
+tty_args=()
+if [[ -t 0 && -t 1 ]]; then
+  tty_args=(-it)
+fi
+
+docker run --rm "${tty_args[@]}" \
+  -v "$ROOT":/work \
+  -v "$PUB_CACHE":/root/.pub-cache \
+  -v "$GRADLE_CACHE":/root/.gradle \
+  -v "$ANDROID_PLATFORMS":/opt/android-sdk-linux/platforms \
+  -v "$ANDROID_BUILD_TOOLS":/opt/android-sdk-linux/build-tools \
+  -v "$ANDROID_NDK":/opt/android-sdk-linux/ndk \
+  -v "$ANDROID_CMAKE":/opt/android-sdk-linux/cmake \
+  -v "$ANDROID_LICENSES":/opt/android-sdk-linux/licenses \
+  -w /work/app \
+  "$IMAGE" \
+  bash -lc "yes | flutter doctor --android-licenses >/dev/null && flutter pub get && flutter build apk --$MODE"


### PR DESCRIPTION
## What / Why

   Edit tool cards now show a numbered diff preview in the app instead of only `edit <file>`.

   This makes mobile edits readable before/while they run: nearby context stays plain, added lines are green, removed lines are red. Unchanged lines inside an edit stay context, not fake `-/+` noise.

## How
pi-extension will pass down patch information thru "hunks", then app will display it.

### Pi extension
   - Enriches `edit` tool requests with `args.hunks`
   - Reads the target file before the edit runs
   - Builds numbered context hunks around the edit
   - Marks lines as `context`, `add`, `remove`, or `ellipsis`
   - Keeps unchanged prefix/suffix lines as context

### App
   - Detects `args.hunks` on edit tool cards
   - Renders hunks as rich monospace text
   - Colors added lines green and removed lines red
   - Falls back to the old compact tool summary when no hunk data exists
