### PR TITLE
Fix stuck chat stop button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # cmux / claude
 .fresh/
+.*
 
 # orchestration: results são efêmeros (logs de execução de cada task);
 # INSTRUCTIONS.md e contracts/ ficam versionados (contrato compartilhado).

--- a/app/lib/data/sync/sync_service.dart
+++ b/app/lib/data/sync/sync_service.dart
@@ -782,6 +782,10 @@ class SyncService extends Service {
       on ? SessionActivity.working : SessionActivity.idle,
       preview: preview,
     );
+    final epk = _activeEpk;
+    if (epk != null) {
+      _conn.markRoomWorking(epk, _activeRoomId, on);
+    }
     if (on) {
       if (replyTo != null) _workingReplyTo = replyTo;
     } else {

--- a/app/lib/data/sync/sync_service.dart
+++ b/app/lib/data/sync/sync_service.dart
@@ -292,16 +292,18 @@ class SyncService extends Service {
   Future<void> clearActiveSession() async {
     final epk = _activeEpk;
     if (epk == null) return;
+    final room = _activeRoomId;
     // Session wiped → any optimistic sends are moot; disarm their backstops.
     _cancelAllSendTimers();
     await _enqueue(() async {
-      final box = await _boxes.msgsBox(epk, _activeRoomId);
+      if (_activeEpk != epk || _activeRoomId != room) return;
+      final box = await _boxes.msgsBox(epk, room);
       await box.clear();
       _idToSeq.clear();
       _nextSeq = 0;
       _indexLoaded = true;
       final idx = _boxes.sessionsIndexBox();
-      await idx.delete(LocalBoxes.sessionKey(epk, _activeRoomId));
+      await idx.delete(LocalBoxes.sessionKey(epk, room));
     });
   }
 
@@ -549,10 +551,11 @@ class SyncService extends Service {
   Future<void> _applyHistory(SessionHistory h) async {
     final epk = _activeEpk;
     if (epk == null) return;
+    final room = _activeRoomId;
     final rows = _convertHistory(h.events);
     final historyIds = {for (final r in rows) _key(r.role, r.id)};
     await _enqueue(() async {
-      final box = await _boxes.msgsBox(epk, _activeRoomId);
+      final box = await _boxes.msgsBox(epk, room);
       // Preserve local pending user rows the Pi hasn't echoed yet.
       final preserved = <MessageRecord>[];
       for (final v in box.values) {
@@ -596,21 +599,25 @@ class SyncService extends Service {
           await box.put(i, newJson);
         }
       }
-      _idToSeq
-        ..clear()
-        ..addEntries([
-          for (var i = 0; i < desired.length; i++)
-            MapEntry(_key(desired[i].role, desired[i].id), i),
-        ]);
-      _nextSeq = desired.length;
-      _indexLoaded = true;
+      if (_activeEpk == epk && _activeRoomId == room) {
+        _idToSeq
+          ..clear()
+          ..addEntries([
+            for (var i = 0; i < desired.length; i++)
+              MapEntry(_key(desired[i].role, desired[i].id), i),
+          ]);
+        _nextSeq = desired.length;
+        _indexLoaded = true;
+      }
     });
-    final started = h.sessionStartedAt;
-    _updateIndex(
-      (cur) => cur.copyWith(
-        sessionStartedAt: DateTime.fromMillisecondsSinceEpoch(started),
-      ),
-    );
+    if (_activeEpk == epk && _activeRoomId == room) {
+      final started = h.sessionStartedAt;
+      _updateIndex(
+        (cur) => cur.copyWith(
+          sessionStartedAt: DateTime.fromMillisecondsSinceEpoch(started),
+        ),
+      );
+    }
   }
 
   List<MessageRecord> _convertHistory(List<SessionHistoryEvent> events) {
@@ -710,10 +717,12 @@ class SyncService extends Service {
   String _key(MsgRole role, String id) => '${role.name}:$id';
 
   Future<void> _loadIndex() {
+    final epk = _activeEpk;
+    if (epk == null) return Future<void>.value();
+    final room = _activeRoomId;
     return _enqueue(() async {
-      final epk = _activeEpk;
-      if (epk == null) return;
-      final box = await _boxes.msgsBox(epk, _activeRoomId);
+      if (_activeEpk != epk || _activeRoomId != room) return;
+      final box = await _boxes.msgsBox(epk, room);
       _idToSeq.clear();
       _nextSeq = 0;
       for (final k in box.keys) {
@@ -736,10 +745,13 @@ class SyncService extends Service {
     String id,
     MessageRecord Function(int seq, MessageRecord? existing) build,
   ) {
+    final epk = _activeEpk;
+    if (epk == null) return Future<void>.value();
+    final room = _activeRoomId;
     return _enqueue(() async {
-      final epk = _activeEpk;
-      if (epk == null) return;
-      final box = await _boxes.msgsBox(epk, _activeRoomId);
+      final active = _activeEpk == epk && _activeRoomId == room;
+      if (!active) return;
+      final box = await _boxes.msgsBox(epk, room);
       final mapKey = _key(role, id);
       final existingSeq = _idToSeq[mapKey];
       if (existingSeq != null) {
@@ -754,10 +766,12 @@ class SyncService extends Service {
   }
 
   Future<void> _removeById(String id) {
+    final epk = _activeEpk;
+    if (epk == null) return Future<void>.value();
+    final room = _activeRoomId;
     return _enqueue(() async {
-      final epk = _activeEpk;
-      if (epk == null) return;
-      final box = await _boxes.msgsBox(epk, _activeRoomId);
+      if (_activeEpk != epk || _activeRoomId != room) return;
+      final box = await _boxes.msgsBox(epk, room);
       for (final role in MsgRole.values) {
         final seq = _idToSeq.remove(_key(role, id));
         if (seq != null) await box.delete(seq);
@@ -782,6 +796,7 @@ class SyncService extends Service {
       on ? SessionActivity.working : SessionActivity.idle,
       preview: preview,
     );
+    // Snapshot nullable field once; Dart won't promote mutable fields safely.
     final epk = _activeEpk;
     if (epk != null) {
       _conn.markRoomWorking(epk, _activeRoomId, on);

--- a/app/lib/data/transport/connection_manager.dart
+++ b/app/lib/data/transport/connection_manager.dart
@@ -844,6 +844,24 @@ class ConnectionManager extends Service {
     return false;
   }
 
+  /// App-side correction for the connected room's working flag.
+  ///
+  /// The relay remains the source for non-active rooms, but the active channel
+  /// also sees the actual `user_input` / `agent_done` frames. Use that local
+  /// observation as a backstop so a missed or delayed `meta.working=false`
+  /// broadcast cannot leave the active chat/Home tile stuck as working.
+  void markRoomWorking(String epk, String roomId, bool working) {
+    final key = toStandardB64(epk);
+    final list = _roomsByPeer[key];
+    if (list == null) return;
+    final idx = list.indexWhere((r) => r.roomId == roomId);
+    if (idx < 0 || list[idx].working == working) return;
+    list[idx] = list[idx].copyWith(working: working);
+    _scheduleRoomsEmit();
+    // ignore: unawaited_futures
+    _persistRoomsForPeer(key);
+  }
+
   /// Plan-17 follow-up — hydrate `_roomsByPeer` from disk on boot so
   /// Home tiles persist across cold starts even before the relay
   /// pushes a fresh snapshot. Idempotent.

--- a/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
+++ b/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
@@ -122,8 +122,19 @@ class ChatViewModel extends ViewModel<ChatState> {
       emit(const ChatNoPeer());
       return;
     }
-    _activePeer = peer;
+    final sessionPeer = peer.copyWith(roomId: roomId);
+    _activePeer = sessionPeer;
     _activeRoomId = roomId;
+
+    // Bind transport before the singleton writer. Otherwise a same-peer room
+    // switch can briefly accept old-room frames while SyncService already
+    // writes to the new room.
+    _conn.switchRoom(roomId);
+    if (_conn.activePeer?.remoteEpk != sessionPeer.remoteEpk) {
+      await _conn.switchTo(sessionPeer);
+      if (_disposed) return;
+      _conn.switchRoom(roomId);
+    }
 
     // Bind the writer + watch the DB for this (peer, room).
     await _sync.activate(epk, roomId);
@@ -134,16 +145,9 @@ class ChatViewModel extends ViewModel<ChatState> {
     // the constructor avoids inheriting the previous chat's bubble/pill.
     _streaming = _sync.streaming;
     _working = _sync.isWorking;
-    _conn.switchRoom(roomId);
     _msgsSub = _read.watchMessages(epk, roomId).listen(_onMessages);
     _runtimeSub = _read.watchRuntime(epk, roomId).listen(_onRuntime);
 
-    // Drive the connection lifecycle (plano 12/13): connect to this peer if
-    // the manager isn't already on it.
-    if (_conn.activePeer?.remoteEpk != peer.remoteEpk) {
-      await _conn.switchTo(peer);
-      if (_disposed) return;
-    }
     _bootstrapping = false;
     _sync.requestSync();
     _recompute();

--- a/app/test/ui/chat/chat_viewmodel_test.dart
+++ b/app/test/ui/chat/chat_viewmodel_test.dart
@@ -248,7 +248,15 @@ void main() {
       expect((vm.state as ChatReady).isWorking, isTrue,
           reason: 'state carries isWorking so the flip rebuilds the UI');
 
-      // turn_end → working=false.
+      // If the app sees agent_done but the relay's meta.working=false
+      // broadcast is delayed/missed, the active chat must not stay stuck on
+      // the stop button. The local channel observation clears the room flag.
+      ch.push(AgentDone(inReplyTo: 'u1'));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(vm.isWorking, isFalse);
+      expect((vm.state as ChatReady).isWorking, isFalse);
+
+      // A later turn_end broadcast remains idempotent.
       ch.pushControl(const RoomMetaUpdated(
         peer: 'epk_chat',
         roomId: 'main',

--- a/scripts/docker-build-apk.sh
+++ b/scripts/docker-build-apk.sh
@@ -2,9 +2,12 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Share Docker caches from the primary worktree, not each linked worktree.
+MAIN_ROOT="$(git -C "$ROOT" worktree list --porcelain 2>/dev/null | awk '/^worktree / { sub(/^worktree /, ""); print; exit }')"
+MAIN_ROOT="${MAIN_ROOT:-$ROOT}"
 IMAGE="${FLUTTER_DOCKER_IMAGE:-ghcr.io/cirruslabs/flutter:stable}"
 MODE="${1:-debug}"
-CACHE_DIR="$ROOT/dockercache"
+CACHE_DIR="$MAIN_ROOT/dockercache"
 PUB_CACHE="$CACHE_DIR/pub"
 GRADLE_CACHE="$CACHE_DIR/gradle"
 ANDROID_CACHE="$CACHE_DIR/android-sdk"


### PR DESCRIPTION
## What / Why

Fix chat composer sometimes staying in stop mode after the bot is done.

The app cleared local working state on `agent_done`, but `ChatViewModel.isWorking` also reads relay room metadata. If relay `meta.working=false` was delayed or missed, cached room state stayed `working=true`, so the input bar kept showing the stop button.

## How

Use the active channel as a backstop for active-room working state.

### App data / sync

- Mirrors `SyncService._setWorking(...)` into active room metadata
- Clears cached active-room `working` when `agent_done` clears local working
- Keeps local active chat state from being overridden by stale relay metadata

### Transport / rooms

- Adds `ConnectionManager.markRoomWorking(...)`
- Updates cached `RoomInfo.working` for the active room
- Emits rooms update so chat/home listeners rebuild
- Keeps relay metadata as source for non-active rooms

### Test

- installed patched apk with fixes
- observed that previous cases where rooms will get stuck in "working..." will resolve itself without having to click on the stop btn to "reset the state" on app UI
- also fixed some race condition for rendering that causes panels to be loaded into the wrong room.