### PR TITLE
Fix: Issue #24 - Starting a new session from a mobile device kills Pi / Session restore doesn't work.

### DIFF
--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -1383,6 +1383,19 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // bound to the current session.
   pi.on("session_start", (_event, ctx) => {
     _lastEventCtx = ctx;
+    // Rearm a reused-but-disposed instance. The session_shutdown teardown (below)
+    // sets _disposed=true assuming the host re-evaluates THIS module fresh for the
+    // replacement session, yielding a new instance with _disposed=false. Some hosts
+    // instead REUSE the same module instance across ctx.newSession() — then the
+    // _disposed latch is never cleared (nothing else resets it), so the relay never
+    // reconnects and /remote-pi (via _cmdRoot) silently early-returns until a full
+    // Pi restart. Clearing the latch + re-running the idempotent connect path
+    // restores the relay automatically. No-op when a fresh instance IS created
+    // (_disposed=false there → never fires) and at first boot.
+    if (_disposed) {
+      _disposed = false;
+      void _cmdRoot(ctx);
+    }
   });
 
   // Tear down THIS instance's live handles when the SDK replaces the session

--- a/pi-extension/src/transport/peer_channel.ts
+++ b/pi-extension/src/transport/peer_channel.ts
@@ -67,7 +67,19 @@ export class PlainPeerChannel implements PeerChannel {
     // `room_id`/`room_meta` in the WS-level `hello` — outer routing stays by
     // `peer` alone. Re-add the field once downstream is ready.
     const outer: OuterEnvelope = { peer: this.remotePeerId, ct };
-    this.relay.send(JSON.stringify(outer));
+    // Best-effort delivery. The relay WS can be mid-reconnect (idle/NAT drop, or
+    // a session_new/session-replacement teardown) when we push a server→app frame
+    // — notably the action_ok/action_error ack a handler emits right after
+    // newSession. `relay.send` throws "relay: not connected" in that window; since
+    // this runs inside an async SDK event callback, letting it propagate becomes an
+    // uncaughtException that kills the whole pi process. The relay auto-reconnects
+    // and the app re-syncs via session_sync, so a dropped frame is recoverable — a
+    // crash is not. Mirrors RelayClient.sendControl's no-op-when-closed policy.
+    try {
+      this.relay.send(JSON.stringify(outer));
+    } catch {
+      /* relay down — drop this frame; reconnect + session_sync will recover */
+    }
   }
 
   /** Detaches from relay (does not close the relay itself). */


### PR DESCRIPTION
## What

Fixes two bugs around starting a New Session from a remote. Full root-cause analysis in #24.

### 1. Crash on New Session — `transport/peer_channel.ts`
The `action_ok`/`action_error` reply emitted right after `ctx.newSession()` could throw `"relay: not connected"` inside an async SDK callback (the relay is mid-teardown) → uncaughtException → Pi process exit.

`PlainPeerChannel.send` is now best-effort (try/catch), consistent with `RelayClient.sendControl`. Dropped frames self-heal via relay reconnect + `session_sync`.

### 2. Permanent disconnect after New Session — `index.ts`
`session_shutdown` sets `_disposed = true` assuming the host re-evaluates the module fresh per session. On hosts that reuse the same module instance across `ctx.newSession()`, `_disposed` is never reset → the relay never reconnects and `/remote-pi` silently early-returns until a full Pi restart.

The `session_start` handler now rearms:
```ts
if (_disposed) { _disposed = false; void _cmdRoot(ctx); }
```
No-op when a fresh instance is created, and at first boot.

### Testing
pnpm typecheck and pnpm build pass clean.
Tests covering the changed code pass (transport / actions / extension lifecycle).
Verified manually: New Session from an iPad/Android remote no longer crashes Pi, the session resets, and the remote stays connected without a restart.

Closes #24