### PR TITLE
Use live Pi model registry for app model actions

### DIFF
--- a/pi-extension/src/actions/handlers.test.ts
+++ b/pi-extension/src/actions/handlers.test.ts
@@ -200,7 +200,7 @@ describe("handleModelSet", () => {
       setModel: async (m) => { setModelArgs.push(m as SdkModelLike); return true; },
     });
     const sender = makeSender();
-    await handleModelSet(pi, reg, sender, {
+    await handleModelSet(pi, null, reg, sender, {
       type: "model_set", id: "r4", provider: "anthropic", model_id: "claude-opus-4-7",
     });
     expect(setModelArgs).toHaveLength(1);
@@ -213,7 +213,7 @@ describe("handleModelSet", () => {
   test("unknown model → action_error", async () => {
     const reg = fakeRegistry([sampleModel]);
     const sender = makeSender();
-    await handleModelSet(fakePi(), reg, sender, {
+    await handleModelSet(fakePi(), null, reg, sender, {
       type: "model_set", id: "r4", provider: "anthropic", model_id: "nope-3",
     });
     expect(sender.sent[0]).toMatchObject({
@@ -226,7 +226,7 @@ describe("handleModelSet", () => {
     const reg = fakeRegistry([sampleModel]);
     const pi = fakePi({ setModel: async () => false });
     const sender = makeSender();
-    await handleModelSet(pi, reg, sender, {
+    await handleModelSet(pi, null, reg, sender, {
       type: "model_set", id: "r4", provider: "anthropic", model_id: "claude-opus-4-7",
     });
     expect(sender.sent[0]).toMatchObject({
@@ -241,7 +241,7 @@ describe("handleModelSet", () => {
     const sender = makeSender();
     const persisted: Array<{ provider: string; modelId: string }> = [];
     await handleModelSet(
-      pi, reg, sender,
+      pi, null, reg, sender,
       { type: "model_set", id: "r4", provider: "anthropic", model_id: "claude-opus-4-7" },
       (provider, modelId) => persisted.push({ provider, modelId }),
     );
@@ -255,7 +255,7 @@ describe("handleModelSet", () => {
     const sender = makeSender();
     let persistCalls = 0;
     await handleModelSet(
-      pi, reg, sender,
+      pi, null, reg, sender,
       { type: "model_set", id: "r4", provider: "anthropic", model_id: "claude-opus-4-7" },
       () => { persistCalls += 1; },
     );
@@ -268,7 +268,7 @@ describe("handleModelSet", () => {
     const sender = makeSender();
     let persistCalls = 0;
     await handleModelSet(
-      fakePi(), reg, sender,
+      fakePi(), null, reg, sender,
       { type: "model_set", id: "r4", provider: "anthropic", model_id: "nope-3" },
       () => { persistCalls += 1; },
     );
@@ -309,6 +309,34 @@ describe("handleListModels", () => {
     expect(reply.type).toBe("models_list");
     if (reply.type !== "models_list") throw new Error("type guard");
     expect(reply.current).toBeUndefined();
+  });
+
+  test("prefers ctx.modelRegistry over the fallback registry", () => {
+    const fallback = fakeRegistry([sampleModel]);
+    const liveModel: SdkModelLike = {
+      id: "gpt-oss-20b",
+      name: "GPT OSS 20B",
+      provider: "lemonade",
+      reasoning: false,
+      contextWindow: 131_072,
+    };
+    const live = fakeRegistry([liveModel]);
+    const ctx: ActionCtx = { modelRegistry: live };
+    const sender = makeSender();
+    handleListModels(ctx, fallback, sender, { type: "list_models", id: "r5" });
+    const reply = sender.sent[0];
+    expect(reply.type).toBe("models_list");
+    if (reply.type !== "models_list") throw new Error("type guard");
+    expect(reply.models).toEqual([
+      {
+        id: "gpt-oss-20b",
+        name: "GPT OSS 20B",
+        provider: "lemonade",
+        reasoning: false,
+        context_window: 131_072,
+        vision: false,
+      },
+    ]);
   });
 
   test("registry refresh failure surfaces as error envelope", () => {

--- a/pi-extension/src/actions/handlers.ts
+++ b/pi-extension/src/actions/handlers.ts
@@ -92,6 +92,12 @@ export interface ActionCtx {
     withSession?: (ctx: ActionCtx) => Promise<void>;
   }) => Promise<{ cancelled: boolean }>;
   getModel?: () => Model<any> | undefined;
+  /**
+   * Live session registry from Pi's extension ctx. Includes providers/models
+   * registered dynamically via `pi.registerProvider(...)`, unlike the fallback
+   * disk-backed registry remote-pi can build on its own.
+   */
+  modelRegistry?: ActionModelRegistry;
 }
 
 /**
@@ -233,15 +239,20 @@ export function handleThinkingSet(
 
 export async function handleModelSet(
   pi: ActionPi,
+  ctx: ActionCtx | null,
   reg: ActionModelRegistry,
   sender: ActionReplySender,
   msg: ModelSetMsg,
   onPersist?: (provider: string, modelId: string) => void,
 ): Promise<void> {
   await runAsync(sender, msg, "model_set", async () => {
+    // Prefer Pi's LIVE session registry when available so the app sees models
+    // registered dynamically by extensions via `pi.registerProvider(...)`.
+    // Fall back to remote-pi's own disk-backed registry when no ctx exists.
+    const liveReg = ctx?.modelRegistry ?? reg;
     // Refresh first so a model just-added via `/login` is visible.
-    reg.refresh();
-    const model = reg.find(msg.provider, msg.model_id);
+    liveReg.refresh();
+    const model = liveReg.find(msg.provider, msg.model_id);
     if (!model) {
       throw new Error(`model "${msg.provider}/${msg.model_id}" not in registry`);
     }
@@ -266,8 +277,12 @@ export function handleListModels(
   // refresh() can throw if `models.json` is malformed — wrap in try so the
   // app gets an explicit error reply instead of a silent drop.
   try {
-    reg.refresh();
-    const models = reg.getAvailable().map(wireFromModel);
+    // Prefer Pi's LIVE session registry when available so the app sees models
+    // registered dynamically by extensions via `pi.registerProvider(...)`.
+    // Fall back to remote-pi's own disk-backed registry when no ctx exists.
+    const liveReg = ctx?.modelRegistry ?? reg;
+    liveReg.refresh();
+    const models = liveReg.getAvailable().map(wireFromModel);
     const current = ctx?.getModel?.();
     sender.send({
       type: "models_list",

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -3208,13 +3208,20 @@ export function _routeClientMessageFrom(
       break;
     }
     case "model_set":
-      void handleModelSet(_pi, ensureModelRegistry(), sender, msg, _persistModelDefault);
+      void handleModelSet(
+        _pi,
+        (_lastEventCtx ?? _lastCtx) as ActionCtx | null,
+        ensureModelRegistry(),
+        sender,
+        msg,
+        _persistModelDefault,
+      );
       break;
     case "thinking_set":
       handleThinkingSet(_pi, sender, msg);
       break;
     case "list_models":
-      handleListModels(_lastCtx as ActionCtx | null, ensureModelRegistry(), sender, msg);
+      handleListModels(((_lastEventCtx ?? _lastCtx) as ActionCtx | null), ensureModelRegistry(), sender, msg);
       break;
   }
 }


### PR DESCRIPTION
## Summary
- prefer Pi's live `ctx.modelRegistry` for `list_models` and `model_set`
- keep the existing disk-backed registry as a fallback when no live ctx exists
- add a regression test covering a dynamically registered provider (for example a provider added via `pi.registerProvider(...)`)

## Why
remote-pi currently builds its own standalone `ModelRegistry` from disk sources like `models.json`. That misses providers registered dynamically by extensions at runtime, so the app model picker cannot see or select those models even though Pi itself can.

Using the live registry exposed on the extension context keeps remote-pi aligned with Pi's actual session model catalog while preserving the old fallback path for contexts where no live registry is available.
