### PR TITLE
fix(site): fix mobile layout overflow on docs page

### DIFF
--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -108,6 +108,11 @@ a {
   margin: 0 auto;
   padding: 0 28px;
 }
+@media (max-width: 480px) {
+  .wrap {
+    padding: 0 16px;
+  }
+}
 
 /* content sits above the ambient glow */
 .app {
@@ -882,6 +887,11 @@ a {
   font-family: var(--ff-mono);
   font-size: 11.5px;
   color: var(--faint);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .copy-btn {
   font-family: var(--ff-mono);
@@ -915,19 +925,24 @@ a {
   font-family: var(--ff-mono);
   font-size: 14.5px;
   line-height: 1.7;
+  overflow-x: auto;
 }
 .term-line {
   display: flex;
   gap: 12px;
   align-items: flex-start;
+  min-width: 0;
 }
 .term-line .pr {
   color: var(--green);
   user-select: none;
+  flex-shrink: 0;
 }
 .term-line .cmd {
   color: var(--ink);
   word-break: break-all;
+  min-width: 0;
+  flex: 1;
 }
 .term-note {
   margin: 16px 0 0;
@@ -1250,9 +1265,15 @@ a {
 .page {
   position: relative;
   z-index: 1;
+  overflow-x: clip;
 }
 .page-body {
   padding: 70px 0 40px;
+}
+@media (max-width: 640px) {
+  .page-body {
+    padding: 44px 0 30px;
+  }
 }
 .page-head {
   max-width: 820px;
@@ -1372,6 +1393,19 @@ a {
   padding: 1px 7px;
   border-radius: 7px;
   white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .prose code,
+  .code-pill {
+    white-space: normal;
+    word-break: break-word;
+    overflow-wrap: break-word;
+  }
+  .ref-table td code {
+    white-space: normal;
+    word-break: break-word;
+  }
 }
 
 /* lists — custom bullets / numbered badges */
@@ -1620,7 +1654,7 @@ a {
 }
 @media (max-width: 980px) {
   .docs-layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: 0;
   }
   .toc {


### PR DESCRIPTION
- set docs-layout grid column to minmax(0,1fr) on mobile — root cause was bare 1fr expanding to content min-width, pushing the entire layout wider than the viewport
- add min-width:0 / flex:1 to .term-line flex items so <pre> can shrink
- add overflow-x:auto to .term-body so code blocks scroll horizontally on narrow screens instead of forcing wider layout
- truncate terminal label with text-overflow:ellipsis on narrow screens
- allow .code-pill to wrap (white-space:normal) on screens ≤640px
- reduce .wrap padding 28px→16px on screens ≤480px
- reduce .page-body top padding on screens ≤640px
- add overflow-x:clip to .page as safety net