### PR TITLE
feat(cockpit): diálogo com instruções de notificação no macOS

### DIFF
--- a/cockpit/lib/app/cockpit/data/setup/system_permissions_impl.dart
+++ b/cockpit/lib/app/cockpit/data/setup/system_permissions_impl.dart
@@ -22,6 +22,7 @@ class SystemPermissionsImpl implements SystemPermissions {
   Future<CheckStatus> notificationStatus() async {
     if (!Platform.isMacOS) return CheckStatus.notApplicable;
     try {
+      await _ensureInitialized();
       final options = await _macNotif?.checkPermissions();
       return (options?.isEnabled ?? false)
           ? CheckStatus.ok
@@ -35,6 +36,7 @@ class SystemPermissionsImpl implements SystemPermissions {
   Future<CheckStatus> requestNotifications() async {
     if (!Platform.isMacOS) return CheckStatus.notApplicable;
     try {
+      await _ensureInitialized();
       final granted =
           await _macNotif?.requestPermissions(
             alert: true,

--- a/cockpit/lib/app/cockpit/ui/viewmodels/setup_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/setup_viewmodel.dart
@@ -27,10 +27,7 @@ class SetupViewModel extends ChangeNotifier {
 
   /// Todas as checagens satisfeitas → habilita "Criar Workspace".
   bool get canCreate =>
-      pi.satisfied &&
-      extension.satisfied &&
-      supervisor.satisfied &&
-      notifications.satisfied;
+      pi.satisfied && extension.satisfied && supervisor.satisfied;
 
   /// Roda as 5 ao montar a tela.
   Future<void> recheckAll() async {

--- a/cockpit/lib/app/cockpit/ui/widgets/macos_notification_instructions_dialog.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/macos_notification_instructions_dialog.dart
@@ -1,0 +1,215 @@
+import 'package:cockpit/app/core/ui/themes/themes.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+const Color _barrier = Color(0x99000000);
+
+/// Widget do dialog contendo as instruções para ativar as notificações no macOS.
+class MacosNotificationInstructionsDialog extends StatelessWidget {
+  const MacosNotificationInstructionsDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return AlertDialog(
+      title: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.notifications_active, color: colors.accentText, size: 20),
+          const SizedBox(width: 10),
+          Text(
+            'Enable Notifications on macOS',
+            style: context.typo.title.copyWith(
+              fontSize: 15,
+              color: colors.text,
+            ),
+          ),
+        ],
+      ),
+      content: SizedBox(
+        width: 420,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Notifications are currently disabled in your system settings. Follow the steps below to enable them:',
+              style: context.typo.body.copyWith(
+                fontSize: 13,
+                color: colors.text2,
+              ),
+            ),
+            const SizedBox(height: 14),
+            _InstructionStep(
+              step: '1',
+              content: Text.rich(
+                TextSpan(
+                  children: [
+                    const TextSpan(text: 'Open '),
+                    TextSpan(
+                      text: 'System Settings',
+                      style: context.typo.body.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colors.text,
+                      ),
+                    ),
+                    const TextSpan(text: ' on your Mac.'),
+                  ],
+                ),
+                style: context.typo.body.copyWith(
+                  fontSize: 13,
+                  color: colors.text2,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            _InstructionStep(
+              step: '2',
+              content: Text.rich(
+                TextSpan(
+                  children: [
+                    const TextSpan(text: 'Navigate to the '),
+                    TextSpan(
+                      text: 'Notifications',
+                      style: context.typo.body.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colors.text,
+                      ),
+                    ),
+                    const TextSpan(text: ' section in the left sidebar.'),
+                  ],
+                ),
+                style: context.typo.body.copyWith(
+                  fontSize: 13,
+                  color: colors.text2,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            _InstructionStep(
+              step: '3',
+              content: Text.rich(
+                TextSpan(
+                  children: [
+                    const TextSpan(text: 'Find and select the '),
+                    TextSpan(
+                      text: 'Cockpit',
+                      style: context.typo.body.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colors.text,
+                      ),
+                    ),
+                    const TextSpan(text: ' application from the list.'),
+                  ],
+                ),
+                style: context.typo.body.copyWith(
+                  fontSize: 13,
+                  color: colors.text2,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            _InstructionStep(
+              step: '4',
+              content: Text.rich(
+                TextSpan(
+                  children: [
+                    const TextSpan(text: 'Toggle the '),
+                    TextSpan(
+                      text: 'Allow Notifications',
+                      style: context.typo.body.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colors.text,
+                      ),
+                    ),
+                    const TextSpan(text: ' switch on.'),
+                  ],
+                ),
+                style: context.typo.body.copyWith(
+                  fontSize: 13,
+                  color: colors.text2,
+                ),
+              ),
+            ),
+            const SizedBox(height: 14),
+            Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: colors.panel3,
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: colors.border),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.info_outline, size: 16, color: colors.accentText),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Tip: If the app does not appear in the list, close and reopen it to trigger its registration in the system.',
+                      style: context.typo.label.copyWith(
+                        color: colors.text3,
+                        fontSize: 11.5,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        PrimaryButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Got it'),
+        ),
+      ],
+    );
+  }
+
+  static Future<void> show(BuildContext context) {
+    return showDialog<void>(
+      context: context,
+      barrierColor: _barrier,
+      builder: (context) => const MacosNotificationInstructionsDialog(),
+    );
+  }
+}
+
+/// Widget privado para renderizar cada linha de instrução com o número do passo.
+class _InstructionStep extends StatelessWidget {
+  const _InstructionStep({required this.step, required this.content});
+
+  final String step;
+  final Widget content;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 20,
+          height: 20,
+          margin: const EdgeInsets.only(top: 1),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: colors.accentText.withValues(alpha: 0.15),
+            shape: BoxShape.circle,
+          ),
+          child: Text(
+            step,
+            style: context.typo.label.copyWith(
+              color: colors.accentText,
+              fontWeight: FontWeight.bold,
+              fontSize: 11,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(child: content),
+      ],
+    );
+  }
+}

--- a/cockpit/lib/app/cockpit/ui/widgets/onboarding_view.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/onboarding_view.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:cockpit/app/cockpit/domain/entities/install_result.dart';
 import 'package:cockpit/app/cockpit/domain/entities/setup_check.dart';
 import 'package:cockpit/app/cockpit/ui/viewmodels/setup_viewmodel.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/macos_notification_instructions_dialog.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/hover_tap.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -152,7 +155,15 @@ class _OnboardingViewState extends State<OnboardingView>
                   onRecheck: vm.recheckNotifications,
                   action: _StepAction(
                     label: 'Test',
-                    onTap: vm.requestNotifications,
+                    onTap: () async {
+                      await vm.requestNotifications();
+                      if (Platform.isMacOS &&
+                          vm.notifications == CheckStatus.missing) {
+                        if (context.mounted) {
+                          MacosNotificationInstructionsDialog.show(context);
+                        }
+                      }
+                    },
                   ),
                 ),
                 const SizedBox(height: 22),
@@ -203,7 +214,12 @@ class _StepCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final showAction = action != null && status == CheckStatus.missing;
+    // Exibe a ação quando:
+    // - missing: precisa instalar/conceder
+    // - checking: pode pular a espera e já pedir ação diretamente
+    final showAction =
+        action != null &&
+        (status == CheckStatus.missing || status == CheckStatus.checking);
 
     return Container(
       margin: const EdgeInsets.only(bottom: 10),

--- a/cockpit/test/widget_test.dart
+++ b/cockpit/test/widget_test.dart
@@ -280,16 +280,14 @@ void main() {
       expect(vm.canCreate, isTrue);
     });
 
-    test('requestNotifications muda missing → ok e libera o gate', () async {
+    test('requestNotifications muda missing → ok', () async {
       final perms = _FakePerms(notif: CheckStatus.missing);
       final vm = SetupViewModel(_FakeEnv(), perms, _FakeInstaller());
       await vm.recheckAll();
       expect(vm.notifications, CheckStatus.missing);
-      expect(vm.canCreate, isFalse);
       await vm.requestNotifications();
       expect(perms.requested, 1);
       expect(vm.notifications, CheckStatus.ok);
-      expect(vm.canCreate, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Motivação

No macOS, o sistema operacional exibe o prompt de permissão de notificações apenas uma vez. Se o usuário negar na primeira vez, o botão de "Test" no onboarding falha silenciosamente. Este PR introduz um modal explicativo ensinando o usuário a ativar as notificações manualmente nos Ajustes do Sistema do macOS.

Também foi removida a obrigatoriedade de notificações para começar a usar o cockpit.

O que foi feito:

- Interface: Criado o widget `MacosNotificationInstructionsDialog` com o passo a passo de ativação.

- Onboarding: Integrado o disparo do diálogo caso a permissão esteja ausente (`CheckStatus.missing`) ao clicar em "Test" no macOS.

- Core & Infra: Ajustada a inicialização de permissões em `SystemPermissionsImpl` e corrigidos os testes unitários afetados no `widget_test.dart`.

## screenshot

<img width="699" height="583" alt="Captura de Tela 2026-06-26 às 18 29 09" src="https://github.com/user-attachments/assets/cc05d127-e912-4168-b7d0-140820561cb4" />
