### PR TITLE
feat(cockpit): adiciona abas de preview ao clicar em um arquivo

### DIFF
--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -406,9 +406,12 @@ class _CockpitPageState extends State<CockpitPage> {
                             width: _treeWidth,
                             rootPath: vm.selectedProject?.path ?? '',
                             revision: vm.fileTreeRevision,
+                            selectedPath: vm.selectedFileInTree,
                             listChildren: vm.listChildren,
                             gitStatusOf: vm.gitStatusForPath,
-                            onOpenFile: vm.openFile,
+                            onOpenFile: (path) => vm.openFile(path, isPreview: false),
+                            onTapFile: vm.openFile, // clique único = preview
+                            onSelectFile: vm.selectFileInTree, // atualiza highlight
                             onOpenWith: vm.openWithDefaultApp,
                             onCreateInFolder: (sub, terminal) =>
                                 vm.newTabIn(sub, terminal: terminal),

--- a/cockpit/lib/app/cockpit/ui/session/file_viewer_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/file_viewer_session.dart
@@ -9,6 +9,7 @@ class FileViewerSession extends PaneItem {
     required this.projectId,
     required this.path,
     required this.view,
+    this.isPreview = false,
   });
 
   @override
@@ -47,6 +48,9 @@ class FileViewerSession extends PaneItem {
   void setDirty(bool value) {
     if (value == dirty) return;
     dirty = value;
+    if (value && isPreview) {
+      isPreview = false;
+    }
     notifyListeners();
   }
 
@@ -54,4 +58,15 @@ class FileViewerSession extends PaneItem {
   /// enquanto montado (e limpo ao desmontar); `null` quando não há editor ativo.
   /// Usado pelo "Salvar e fechar". Retorna `true` no sucesso.
   Future<bool> Function()? saveDraft;
+
+  /// `true` se esta é uma aba de preview (VSCode-style). Preview é sobrescrito
+  /// ao clicar em outro arquivo; duplo-clique transforma em aba normal.
+  bool isPreview;
+
+  /// Transforma esta aba de preview em aba normal.
+  void pin() {
+    if (!isPreview) return;
+    isPreview = false;
+    notifyListeners();
+  }
 }

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -136,6 +136,10 @@ class CockpitViewModel extends ChangeNotifier {
   int _fileTreeRevision = 0;
   int get fileTreeRevision => _fileTreeRevision;
 
+  /// Caminho do arquivo atualmente selecionado no FileTreePanel (para highlight).
+  String? _selectedFileInTree;
+  String? get selectedFileInTree => _selectedFileInTree;
+
   bool _railVisible = true;
   bool _treeVisible = true;
   bool _ready = false;
@@ -235,8 +239,13 @@ class CockpitViewModel extends ChangeNotifier {
 
   /// Abre um arquivo num viewer. Sem [inPane], usa a pane focada (duplo-clique
   /// na árvore); com [inPane], abre naquela pane e a foca (arrastar arquivo →
-  /// pane). Binário/vídeo/grande demais → não abre. Reusa a aba se já aberta.
-  Future<void> openFile(String path, {String? inPane}) async {
+  /// pane). Binário/vídeo/grande demais → não abre.
+  ///
+  /// Se [isPreview] for `true` (padrão), usa o comportamento VSCode:
+  /// - Se já existe um preview aberto na pane, substitui o conteúdo
+  /// - Se a aba ativa é um preview, substitui em vez de criar nova aba
+  /// - Duplo-clique deve passar `isPreview: false` para criar aba normal
+  Future<void> openFile(String path, {String? inPane, bool isPreview = true}) async {
     final projectId = _selectedProjectId;
     final tree = _activeTree;
     final paneId = inPane ?? (projectId == null ? null : _focused[projectId]);
@@ -246,38 +255,86 @@ class CockpitViewModel extends ChangeNotifier {
     // Soltar um arquivo numa pane específica também a foca.
     if (inPane != null) _focused[projectId] = inPane;
 
-    // Já aberto na pane? só seleciona.
+    // Se isPreview, tenta reutilizar a aba de preview existente ou substituir a ativa.
+    // Se não é preview, cria uma aba normal (comportamento original).
+    FileViewerSession? previewCandidate;
     for (final tabId in leaf.tabs) {
       final s = _sessions[tabId];
-      if (s is FileViewerSession && s.path == path) {
-        _trees[projectId] = updateLeaf(
-          tree,
-          paneId,
-          (p) => p.copyWith(active: tabId),
-        );
-        notifyListeners();
-        return;
+      if (s is FileViewerSession) {
+        // Se já aberto, só seleciona (mas transforma preview em normal se não é preview).
+        if (s.path == path) {
+          if (!isPreview && s.isPreview) s.pin();
+          _trees[projectId] = updateLeaf(
+            tree,
+            paneId,
+            (p) => p.copyWith(active: tabId),
+          );
+          notifyListeners();
+          return;
+        }
+        // Guarda o primeiro preview encontrado para possível reutilização.
+        if (isPreview && s.isPreview && previewCandidate == null) {
+          previewCandidate = s;
+        }
       }
     }
 
     final view = await _fileReader.read(path);
     if (view is FileViewUnsupported) return; // binário/vídeo: não abre
 
+    // Se é preview e temos um candidato, reutiliza (substitui conteúdo).
+    if (isPreview && previewCandidate != null) {
+      previewCandidate.path = path;
+      previewCandidate.view = view;
+      previewCandidate.dirty = false;
+      previewCandidate.notifyListeners(); // Força rebuild do FileViewer
+      _trees[projectId] = updateLeaf(
+        tree,
+        paneId,
+        (p) => p.copyWith(active: previewCandidate!.id),
+      );
+      notifyListeners();
+      return;
+    }
+
+    // Cria nova aba (preview ou normal).
     final viewer = FileViewerSession(
       id: _nid('v'),
       projectId: projectId,
       path: path,
       view: view,
+      isPreview: isPreview,
     );
     _sessions[viewer.id] = viewer;
     _watchFileViewer(viewer);
 
     // Se a pane só tem o placeholder vazio, substitui; senão adiciona aba.
+    // Se é preview e a aba ativa é um FileViewer, substitui em vez de adicionar.
     final current = _trees[projectId] ?? tree;
     final lf = findLeaf(current, paneId);
+    final activeTabId = lf?.active;
+    final activeTab = activeTabId != null ? _sessions[activeTabId] : null;
     final only = lf?.tabs.length == 1 ? _sessions[lf!.tabs.first] : null;
-    if (only is AgentSession && only.status == AgentStatus.empty) {
-      final emptyId = lf!.tabs.first;
+
+    if (isPreview && activeTab is FileViewerSession && !activeTab.isPreview) {
+      // Preview substituiria aba normal → adiciona ao lado.
+      _trees[projectId] = updateLeaf(
+        current,
+        paneId,
+        (p) => p.copyWith(tabs: [...p.tabs, viewer.id], active: viewer.id),
+      );
+    } else if (isPreview && activeTab is FileViewerSession && activeTab.isPreview) {
+      // Preview substituir outro preview → substitui a aba ativa.
+      final oldId = activeTabId;
+      _trees[projectId] = updateLeaf(
+        current,
+        paneId,
+        (p) => p.copyWith(tabs: [...p.tabs.where((t) => t != oldId), viewer.id], active: viewer.id),
+      );
+      _disposeSession(oldId!);
+    } else if (lf != null && only is AgentSession && only.status == AgentStatus.empty) {
+      // Placeholder vazio → substitui.
+      final emptyId = lf.tabs.first;
       _trees[projectId] = updateLeaf(
         current,
         paneId,
@@ -285,12 +342,19 @@ class CockpitViewModel extends ChangeNotifier {
       );
       _disposeSession(emptyId);
     } else {
+      // Adiciona nova aba.
       _trees[projectId] = updateLeaf(
         current,
         paneId,
         (p) => p.copyWith(tabs: [...p.tabs, viewer.id], active: viewer.id),
       );
     }
+    notifyListeners();
+  }
+
+  /// Seleciona um arquivo no FileTreePanel (atualiza o highlight).
+  void selectFileInTree(String path) {
+    _selectedFileInTree = path;
     notifyListeners();
   }
 

--- a/cockpit/lib/app/cockpit/ui/widgets/file_tree_panel.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_tree_panel.dart
@@ -20,9 +20,12 @@ class FileTreePanel extends StatefulWidget {
     super.key,
     required this.rootPath,
     required this.revision,
+    this.selectedPath,
     required this.listChildren,
     required this.gitStatusOf,
     required this.onOpenFile,
+    this.onTapFile,
+    this.onSelectFile,
     required this.onOpenWith,
     required this.onCreateInFolder,
     required this.onCreate,
@@ -36,6 +39,9 @@ class FileTreePanel extends StatefulWidget {
   /// Token externo (VM) que sobe a cada mutação — força reler as pastas abertas.
   final int revision;
 
+  /// Caminho atualmente selecionado no tree (para highlight). Vindo da VM.
+  final String? selectedPath;
+
   final Future<List<FileNode>> Function(String path) listChildren;
 
   /// Status git (cor) de um caminho absoluto. `null` = limpo / fora de repo.
@@ -43,6 +49,12 @@ class FileTreePanel extends StatefulWidget {
 
   /// Duplo-clique num arquivo → abre no pane.
   final ValueChanged<String> onOpenFile;
+
+  /// Clique único → abre preview (VSCode-style).
+  final ValueChanged<String>? onTapFile;
+
+  /// Clique único → seleciona o arquivo no tree (highlight).
+  final ValueChanged<String>? onSelectFile;
 
   /// "Open with" → abre o arquivo/pasta no app/explorador padrão do SO.
   final ValueChanged<String> onOpenWith;
@@ -236,12 +248,17 @@ class _FileTreePanelState extends State<FileTreePanel> {
   Widget build(BuildContext context) {
     final colors = context.colors;
 
+    // Usa o selectedPath da VM se disponível, senão o local.
+    final effectiveSelected = widget.selectedPath ?? _selectedPath;
+
     final edit = _TreeEdit(
       pending: _pending,
       renaming: _renaming,
-      selectedPath: _selectedPath,
+      selectedPath: effectiveSelected,
       onSelect: _select,
       onOpenFile: widget.onOpenFile,
+      onTapFile: widget.onTapFile,
+      onSelectFile: widget.onSelectFile,
       onOpenWith: widget.onOpenWith,
       onCreateInFolder: widget.onCreateInFolder,
       onStartCreate: _startCreate,
@@ -345,6 +362,8 @@ class _TreeEdit {
     required this.selectedPath,
     required this.onSelect,
     required this.onOpenFile,
+    required this.onTapFile,
+    required this.onSelectFile,
     required this.onOpenWith,
     required this.onCreateInFolder,
     required this.onStartCreate,
@@ -364,6 +383,8 @@ class _TreeEdit {
 
   final ValueChanged<String> onSelect;
   final ValueChanged<String> onOpenFile;
+  final ValueChanged<String>? onTapFile;
+  final ValueChanged<String>? onSelectFile;
   final ValueChanged<String> onOpenWith;
   final void Function(String relativeSub, bool terminal) onCreateInFolder;
 
@@ -467,7 +488,11 @@ class _DirViewState extends State<_DirView> {
                 selected: node.path == edit.selectedPath,
                 renaming: edit.renaming == node.path,
                 gitStatus: edit.gitStatusOf(node.path),
-                onTap: () => edit.onSelect(node.path),
+                onTap: () {
+                  edit.onSelect(node.path);
+                  edit.onSelectFile?.call(node.path);
+                  edit.onTapFile?.call(node.path);
+                },
                 onDoubleTap: () => edit.onOpenFile(node.path),
                 onOpenWith: () => edit.onOpenWith(node.path),
                 onStartRename: () => edit.onStartRename(node.path),

--- a/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
@@ -54,6 +54,7 @@ class _FileViewerState extends State<FileViewer> {
   bool _dirty = false;
   bool _saving = false;
   String _baseline = '';
+  String? _lastObservedPath;
 
   CodeEditingController? _ctrl;
   final _focus = FocusNode();
@@ -83,6 +84,7 @@ class _FileViewerState extends State<FileViewer> {
   @override
   void initState() {
     super.initState();
+    _lastObservedPath = widget.session.path;
     final text = _editableText;
     if (text != null) {
       _baseline = text;
@@ -98,6 +100,32 @@ class _FileViewerState extends State<FileViewer> {
   @override
   void didUpdateWidget(FileViewer old) {
     super.didUpdateWidget(old);
+    
+    // Se o path mudou (preview reutilizado), força rebuild total.
+    if (widget.session.path != _lastObservedPath) {
+      _lastObservedPath = widget.session.path;
+      _editing = false;
+      _dirty = false;
+      _baseline = '';
+      _ctrl?.removeListener(_onCtrlChanged);
+      _ctrl?.dispose();
+      _ctrl = null;
+      
+      // Recria o controller com o novo conteúdo.
+      final text = _editableText;
+      if (text != null) {
+        _baseline = text;
+        _ctrl = CodeEditingController(text: text, language: _language)
+          ..addListener(_onCtrlChanged);
+        widget.session.saveDraft = _save;
+      } else {
+        widget.session.saveDraft = null;
+      }
+      // Força rebuild.
+      setState(() {});
+      return;
+    }
+    
     final text = _editableText;
     // Tipo deixou de ser editável (raro) → sai do modo edição.
     if (text == null) {
@@ -106,9 +134,14 @@ class _FileViewerState extends State<FileViewer> {
     }
     // Recarga externa (watcher) sobre conteúdo **não** sujo → sincroniza o campo.
     // Com edições pendentes, mantém o buffer do usuário (last-write-wins no save).
+    // Adia para pós-build: evitar setState durante build (setDirty -> notifyListeners).
     if (!_dirty && _ctrl != null && _ctrl!.text != text) {
-      _ctrl!.text = text;
-      _baseline = text;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && !_dirty && _ctrl != null && _ctrl!.text != text) {
+          _ctrl!.text = text;
+          _baseline = text;
+        }
+      });
     }
     // Virou a aba focada (seleção da tab) → joga o foco no editor.
     if (widget.focused && !old.focused) _focusEditorIfActive();
@@ -147,7 +180,9 @@ class _FileViewerState extends State<FileViewer> {
 
   void _toggleEditing() {
     setState(() => _editing = !_editing);
+    // Ao iniciar a edição, transforma preview em aba normal.
     if (_editing) {
+      widget.session.pin();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _focus.requestFocus();
       });

--- a/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
@@ -438,24 +438,30 @@ class _TabState extends State<_Tab> {
   }
 
   /// Tap na aba: **seleciona na hora** e detecta duplo-clique manualmente pra
-  /// renomear — sem `onDoubleTap`. Um `DoubleTapGestureRecognizer` seguraria a
-  /// arena de gestos por `kDoubleTapTimeout` (~300ms) antes de cada `onTapUp`,
-  /// atrasando a seleção. Por isso a aba de agente (única com renomear) demorava
-  /// ~meio segundo pra trocar, enquanto a de terminal (sem duplo-clique) trocava
-  /// na hora.
+  /// renomear (agentes) ou fixar (preview). Um `DoubleTapGestureRecognizer`
+  /// seguraria a arena de gestos por `kDoubleTapTimeout` (~300ms) antes de cada
+  /// `onTapUp`, atrasando a seleção.
   void _handleTap() {
     final s = widget.item;
     final agent = s is AgentSession ? s : null;
+    final viewer = s is FileViewerSession ? s : null;
     final canRename = agent != null && agent.status != AgentStatus.empty;
+    final canPin = viewer != null && viewer.isPreview;
     final now = DateTime.now();
     final last = _lastTapAt;
     _lastTapAt = now;
-    if (canRename &&
-        last != null &&
-        now.difference(last) < const Duration(milliseconds: 300)) {
+
+    // Duplo-clique: renomear agente OU fixar preview.
+    if (last != null && now.difference(last) < const Duration(milliseconds: 300)) {
       _lastTapAt = null; // consumiu o segundo clique
-      _startEditing();
-      return;
+      if (canPin) {
+        viewer.pin();
+        return;
+      }
+      if (canRename) {
+        _startEditing();
+        return;
+      }
     }
     widget.onSelect();
   }
@@ -517,11 +523,19 @@ class _TabState extends State<_Tab> {
     if (s == null) return;
     final agent = s is AgentSession ? s : null;
     final isEmpty = agent?.status == AgentStatus.empty;
+    final viewer = s is FileViewerSession ? s : null;
+    final isPreview = viewer?.isPreview ?? false;
 
     final value = await showAppMenu<String>(
       menuCtx,
       minWidth: 150,
       items: [
+        if (viewer != null && isPreview)
+          const AppMenuItem(
+            value: 'pin',
+            label: 'Pin tab',
+            icon: Icons.push_pin_outlined,
+          ),
         if (agent != null && !isEmpty) ...[
           const AppMenuItem(
             value: 'rename',
@@ -545,6 +559,8 @@ class _TabState extends State<_Tab> {
     );
     if (!mounted) return;
     switch (value) {
+      case 'pin':
+        if (viewer != null) viewer.pin();
       case 'rename':
         _startEditing();
       case 'relay':
@@ -573,6 +589,8 @@ class _TabState extends State<_Tab> {
         final icon = _tabIcon(s);
 
         // Título: texto normal ou campo inline ao renomear.
+        // Preview tabs usam itálico (estilo VSCode).
+        final isPreview = s is FileViewerSession && s.isPreview;
         final titleWidget = _editing && agent != null
             ? CallbackShortcuts(
                 bindings: {
@@ -603,6 +621,7 @@ class _TabState extends State<_Tab> {
                   color: isFocusedActive || widget.active
                       ? colors.text
                       : colors.text3,
+                  fontStyle: isPreview ? FontStyle.italic : FontStyle.normal,
                 ),
               );
 

--- a/cockpit/test/ui/file_tree_panel_test.dart
+++ b/cockpit/test/ui/file_tree_panel_test.dart
@@ -1,0 +1,71 @@
+import 'package:cockpit/app/cockpit/domain/entities/file_node.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/file_tree_panel.dart';
+import 'package:cockpit/app/core/domain/result.dart';
+import 'package:cockpit/app/core/ui/themes/themes.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+void main() {
+  group('FileTreePanel selection', () {
+    testWidgets(
+      'clicking on a file triggers onSelectFile and onTapFile callbacks',
+      (tester) async {
+        String? selectedFile;
+        String? tappedFile;
+
+        await tester.pumpWidget(
+          ShadcnApp(
+            theme: buildTheme(brightness: Brightness.dark),
+            home: Scaffold(
+              child: FileTreePanel(
+                rootPath: '/workspace',
+                revision: 1,
+                listChildren: (path) async {
+                  if (path == '/workspace') {
+                    return const [
+                      FileNode(
+                        name: 'file1.txt',
+                        path: '/workspace/file1.txt',
+                        isDirectory: false,
+                      ),
+                    ];
+                  }
+                  return const [];
+                },
+                gitStatusOf: (path) => null,
+                onOpenFile: (path) {},
+                onTapFile: (path) {
+                  tappedFile = path;
+                },
+                onSelectFile: (path) {
+                  selectedFile = path;
+                },
+                onOpenWith: (path) {},
+                onCreateInFolder: (sub, terminal) {},
+                onCreate: (parentDir, name, isFolder) async =>
+                    const Success(null),
+                onRename: (path, newName) async => const Success(null),
+                onDelete: (path) async => const Success(null),
+              ),
+            ),
+          ),
+        );
+
+        // Wait for lazy-loading to complete and rebuild
+        await tester.pumpAndSettle();
+
+        // Find the file node in the tree
+        final fileFinder = find.text('file1.txt');
+        expect(fileFinder, findsOneWidget);
+
+        // Click on the file
+        await tester.tap(fileFinder);
+        await tester.pumpAndSettle();
+
+        // Verify that callbacks were invoked with the correct file path
+        expect(selectedFile, '/workspace/file1.txt');
+        expect(tappedFile, '/workspace/file1.txt');
+      },
+    );
+  });
+}

--- a/cockpit/test/ui/file_viewer_session_test.dart
+++ b/cockpit/test/ui/file_viewer_session_test.dart
@@ -1,0 +1,47 @@
+import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
+import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FileViewerSession auto-pinning', () {
+    test('setting dirty to true on a preview session turns off isPreview', () {
+      final session = FileViewerSession(
+        id: 's1',
+        projectId: 'p1',
+        path: '/workspace/file.txt',
+        view: const FileViewUnsupported(),
+        isPreview: true,
+      );
+
+      expect(session.isPreview, isTrue);
+      expect(session.dirty, isFalse);
+
+      // Mark the session dirty (simulate user typing/editing)
+      session.setDirty(true);
+
+      // Verify it is now dirty and no longer a preview tab
+      expect(session.dirty, isTrue);
+      expect(session.isPreview, isFalse);
+    });
+
+    test('setting dirty to false does not restore isPreview', () {
+      final session = FileViewerSession(
+        id: 's1',
+        projectId: 'p1',
+        path: '/workspace/file.txt',
+        view: const FileViewUnsupported(),
+        isPreview: true,
+      );
+
+      session.setDirty(true);
+      expect(session.isPreview, isFalse);
+
+      // Revert dirty status (simulate undo/save)
+      session.setDirty(false);
+
+      expect(session.dirty, isFalse);
+      // Should remain pinned (isPreview remains false)
+      expect(session.isPreview, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Descrição
Este PR implementa o destaque visual (highlight) na seleção de arquivos e o comportamento de fixar (pin) abas de preview automaticamente ao iniciar uma edição.

## O que foi feito?
- **Destaque na Seleção:** O clique simples em um arquivo no `FileTreePanel` agora aciona os callbacks corretos na ViewModel para destacar a linha do arquivo ativo (`colors.panel2`) e abrir a visualização em modo preview.

- **Auto-Pin ao Editar:** Ao digitar e modificar um arquivo aberto em modo preview (tornando o estado `dirty`), a aba é automaticamente convertida em uma aba definitiva (`isPreview = false`), seguindo o padrão de comportamento do VS Code.

- **Novos Testes:** Adicionados testes de widget para o clique de seleção no explorador e testes unitários para validar a lógica de auto-pin da sessão de arquivo.

## screenshot

<img width="400" height="243" alt="Gravação de Tela 2026-06-26 às 19 42 25" src="https://github.com/user-attachments/assets/eca241d6-c5bd-4bfc-8c15-a0e6862ae8c9" />
