### PR TITLE
Sync the mesh name from the pi session name (+ fix the documented /remote-pi rename command)

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -276,16 +276,26 @@ describe("extension default export", () => {
     const { pi, registeredCommands } = makeMockPi();
     (extension as ExtensionFactory)(pi);
     // 8 plan-25 + 2 daemon registry (W1) + 6 fleet ops (W2) + 2 install (W3)
-    // + 1 cross-PC inventory (plan-25 W D) + 1 cron (plan-39).
-    expect(registeredCommands).toHaveLength(20);
+    // + 1 cross-PC inventory (plan-25 W D) + 1 cron (plan-39) + 1 rename (plan/41).
+    expect(registeredCommands).toHaveLength(21);
     for (const removed of [
-      "remote-pi join", "remote-pi leave", "remote-pi rename", "remote-pi sessions",
+      "remote-pi join", "remote-pi leave", "remote-pi sessions",
       "remote-pi relay", "remote-pi relay start", "remote-pi relay stop",
       "remote-pi relay status", "remote-pi relay url",
       "remote-pi config", "remote-pi start", "remote-pi list", "remote-pi add-relay",
     ]) {
       expect(registeredCommands).not.toContain(removed);
     }
+  });
+
+  // README documents `/remote-pi rename <new>` but the verb had been dropped
+  // from the TUI dispatcher (only the Cockpit `rename:` control path worked).
+  // Re-adding it aligns the implementation with the documented surface.
+  test("/remote-pi rename is registered and dispatches to _renameAgent", async () => {
+    const rename = captureHandler("remote-pi rename");
+    expect(typeof rename).toBe("function");
+    // Empty arg → _renameAgent no-ops (same contract as the control channel).
+    await expect(rename("", makeMockCtx())).resolves.toBeUndefined();
   });
 });
 

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -4,7 +4,7 @@
  * Post plano 06: no Noise XX. Pairing is `pair_request → pair_ok|pair_error`
  * over an opaque outer envelope whose `ct` is base64(JSON.stringify(inner)).
  */
-import { describe, expect, test, vi, beforeEach } from "vitest";
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -163,6 +163,7 @@ const {
   _getLockedNameForTest,
   _resetCwdLockForTest,
   _handleControl,
+  _syncNameFromPiForTest,
   CTRL_PREFIX,
 } = await import("./index.js");
 const { acquireCwdLock } = await import("./session/cwd_lock.js");
@@ -2876,6 +2877,95 @@ describe("remote-pi:name-assigned event", () => {
     expect(typeof ev!.details!["requested"]).toBe("string");
     // No collision in this isolated broker → assigned === requested.
     expect(ev!.details!["assigned"]).toBe(ev!.details!["requested"]);
+  });
+});
+
+// ── Pi → remote-pi name sync (pi --name / /name drives the mesh name) ────────
+describe("pi session name → remote-pi mesh name sync", () => {
+  // Spy pi whose getSessionName() returns a fixed value (undefined by default).
+  function makeSyncSpyPi(sendMessage: ReturnType<typeof vi.fn>, sessionName?: string) {
+    return {
+      on: () => undefined, registerCommand: () => undefined,
+      registerTool: () => undefined, registerShortcut: () => undefined,
+      registerFlag: () => undefined, getFlag: () => undefined,
+      registerMessageRenderer: () => undefined,
+      sendMessage, sendUserMessage: () => undefined,
+      getSessionName: () => sessionName,
+    } as unknown as ExtensionAPI;
+  }
+  // Use a real temp cwd so config.json writes are isolated + cleanable.
+  let syncCwd: string;
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    _knownPeers.length = 0;
+    _addedPeers.length = 0;
+    _removedPeers.length = 0;
+    _consumeCalls.length = 0;
+    _setRelayCalls.length = 0;
+    _savedRelayUrl = null;
+    _tokenStatus = "ok";
+    relayRef.current = null;
+    relayInstances.length = 0;
+    _defaultConnectImpl = async () => undefined;
+    _setDisposedForTest(false);
+    _resetCwdLockForTest();
+    syncCwd = `/tmp/remote-pi-namesync-${process.pid}-${Date.now()}`;
+    delete process.env["REMOTE_PI_DIRECT_CONFIG"];
+    const stop = captureHandler("remote-pi stop");
+    await stop("", makeMockCtx(syncCwd));
+  });
+  afterEach(() => {
+    try { rmSync(syncCwd, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  test("join requestedName prefers pi.getSessionName() over config", async () => {
+    // Config says "crow" but pi session name says "remotepi" → join as "remotepi".
+    process.env["REMOTE_PI_DIRECT_CONFIG"] = JSON.stringify({
+      agent_name: "crow", auto_start_relay: false,
+    });
+    const root = captureHandler("remote-pi");
+    _setPiForTest(makeSyncSpyPi(vi.fn(), "remotepi")); // after capture so it isn't clobbered
+    await root("", makeMockCtx(syncCwd));
+    // The cwd-lock reserves (cwd, requestedName); the suffix-stripped base must
+    // be the pi session name, not the config name.
+    expect(_getLockedNameForTest()?.replace(/#\d+$/, "")).toBe("remotepi");
+    const stop = captureHandler("remote-pi stop");
+    await stop("", makeMockCtx(syncCwd));
+    _resetCwdLockForTest();
+  });
+
+  test("session_start persists the pi session name to agent_name (before join)", async () => {
+    // No config on disk yet; no mesh node up. The session_start hook runs
+    // _syncNameFromPi, which persists the pi name so the next join uses it.
+    // _syncNameFromPi + _renameAgent key persistence off process.cwd() (the same
+    // cwd axis the live agent uses), so chdir into the isolated temp cwd.
+    delete process.env["REMOTE_PI_DIRECT_CONFIG"];
+    const prevCwd = process.cwd();
+    mkdirSync(syncCwd, { recursive: true });
+    process.chdir(syncCwd);
+    try {
+      captureEventHandler("session_start"); // ensure the handler is registered
+      _setPiForTest(makeSyncSpyPi(vi.fn(), "frompiname"));
+      await _syncNameFromPiForTest();
+      const cfg = JSON.parse(readFileSync(`${syncCwd}/.pi/remote-pi/config.json`, "utf8"));
+      expect(cfg.agent_name).toBe("frompiname");
+    } finally {
+      process.chdir(prevCwd);
+      _resetCwdLockForTest();
+    }
+  });
+
+  test("unset pi session name does NOT clobber an existing agent_name", async () => {
+    process.env["REMOTE_PI_DIRECT_CONFIG"] = JSON.stringify({
+      agent_name: "crow", auto_start_relay: false,
+    });
+    const root = captureHandler("remote-pi");
+    _setPiForTest(makeSyncSpyPi(vi.fn(), undefined)); // pi name unset → keep config
+    await root("", makeMockCtx(syncCwd));
+    expect(_getLockedNameForTest()?.replace(/#\d+$/, "")).toBe("crow");
+    const stop = captureHandler("remote-pi stop");
+    await stop("", makeMockCtx(syncCwd));
+    _resetCwdLockForTest();
   });
 });
 

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -1502,6 +1502,7 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
       return [
         "setup", "status", "stop",
         "pair", "devices", "revoke",
+        "rename",
         "set-relay",
         "peers",  // plan/25 Wave D — local + cross-PC inventory
         "create", "remove", "daemons",  // daemon registry (plan/26 W1)
@@ -1526,6 +1527,7 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
       else if (sub === "devices")                { await _cmdList(ctx); }
       else if (sub.startsWith("revoke"))         { await _cmdRevoke(sub.slice("revoke".length).trim(), ctx); }
       else if (sub.startsWith("set-relay"))      { _cmdSetRelay(sub.slice("set-relay".length).trim(), ctx); }
+      else if (sub === "rename" || sub.startsWith("rename ")) { await _renameAgent(sub.slice("rename".length).trim()); }
       else if (sub === "peers")                  { await _cmdPeers(ctx); }
       else if (sub.startsWith("create"))         { await _cmdCreate(sub.slice("create".length).trim(), ctx); }
       else if (sub.startsWith("remove"))         { await _cmdRemove(sub.slice("remove".length).trim(), ctx); }
@@ -1550,6 +1552,7 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   pi.registerCommand("remote-pi stop",     { description: "Stop everything (leave local mesh + disconnect relay)", handler: async (_, ctx) => { _lastCtx = ctx; await _cmdStop(ctx); } });
   pi.registerCommand("remote-pi pair",     { description: "Show a QR code to pair a new mobile device (optional: --ttl <seconds>)", handler: async (args, ctx) => { _lastCtx = ctx; await _cmdPair(ctx, args.trim()); } });
   pi.registerCommand("remote-pi devices",  { description: "List paired mobile devices", handler: async (_, ctx) => { _lastCtx = ctx; await _cmdList(ctx); } });
+  pi.registerCommand("remote-pi rename",  { description: "Rename this agent in the current session (updates mesh + relay room)", handler: async (args, ctx) => { _lastCtx = ctx; await _renameAgent(args.trim()); } });
   pi.registerCommand("remote-pi revoke", {
     description: "Revoke a paired device by its shortid",
     getArgumentCompletions: async (prefix) => _shortidCompletions(prefix),

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -93,6 +93,7 @@ import {
   loadLocalConfig,
   localConfigExists,
   saveLocalConfig,
+  sanitizeSegment,
 } from "./session/local_config.js";
 import { runSetupWizard, type WizardUI } from "./session/setup_wizard.js";
 import { updateFooter, type FooterState } from "./ui/footer.js";
@@ -408,6 +409,11 @@ export function _setPiForTest(pi: unknown): void {
   _pi = pi as typeof _pi;
 }
 
+/** Test-only: drive the pi → remote-pi name sync once and await it. */
+export async function _syncNameFromPiForTest(): Promise<void> {
+  await _syncNameFromPi();
+}
+
 /**
  * Persist a model change to the PROJECT settings (`<cwd>/.pi/settings.json`) so
  * a model picked from the app survives a Pi/daemon restart. `pi.setModel` only
@@ -585,6 +591,39 @@ function _displayName(cwd: string): string {
   if (_meshNode) return _meshNode.name();
   const local = loadLocalConfig(cwd);
   return local.agent_name || defaultAgentName(cwd);
+}
+
+// ── Pi → remote-pi name sync ───────────────────────────────────────────────────
+/**
+ * Mirror the pi session display name (`pi --name` / `/name`) into remote-pi's
+ * mesh identity. Pi is the source of truth: when the user sets a session name,
+ * it becomes agent_name (persisted, so it survives restarts) AND the live mesh
+ * peer name (broker re-register + relay room swap via _renameAgent).
+ *
+ * No-op when the pi session name is unset/blank — we never clobber a configured
+ * identity with a missing one. Re-entrancy guard + diff check mean this only
+ * does real work when the name actually changed, so calling it on every
+ * turn_start is cheap and never thrashes the relay.
+ */
+let _syncingName = false;
+async function _syncNameFromPi(): Promise<void> {
+  if (_disposed || _syncingName) return;
+  const piName = _pi?.getSessionName?.();
+  if (!piName || !piName.trim()) return;
+  const requested = sanitizeSegment(piName.trim());
+  if (!requested) return;
+  const cwd = process.cwd();
+  if (loadLocalConfig(cwd).agent_name !== requested)
+    saveLocalConfig(cwd, { agent_name: requested });
+  if (!_meshNode) return;
+  const base = _meshNode.name().replace(/#\d+$/, "");
+  if (base === requested) return;
+  _syncingName = true;
+  try {
+    await _renameAgent(requested);
+  } finally {
+    _syncingName = false;
+  }
 }
 
 // ── Peer lookup helpers ───────────────────────────────────────────────────────
@@ -1337,6 +1376,10 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // room_meta over the relay (plan/32) below — that's independent of the
   // broker and drives the app's working indicator.
   pi.on("turn_start", (_event, ctx) => {
+    // Pi → remote-pi name sync: the pi session name can change between turns
+    // (`/name X`) and the SDK has no event for it, so re-check every turn.
+    // Cheap diff guard — only does real work when the name actually changed.
+    void _syncNameFromPi();
     // Late model hydration: if the model was still unknown at connect (resolved
     // lazily by the SDK), grab it on the first turn and fan it out — so a daemon
     // whose model only materialises at turn 1 still reports it to the app.
@@ -1390,6 +1433,11 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // bound to the current session.
   pi.on("session_start", (_event, ctx) => {
     _lastEventCtx = ctx;
+    // Pi → remote-pi name sync: persist the pi session name (if set) BEFORE
+    // _cmdRoot/_cmdJoin reads config, so the first mesh join already uses it.
+    // Only persists here (no _meshNode yet); the live rename happens later via
+    // the turn_start hook once the mesh is up.
+    void _syncNameFromPi();
     // Rearm a reused-but-disposed instance. The session_shutdown teardown (below)
     // sets _disposed=true assuming the host re-evaluates THIS module fresh for the
     // replacement session, yielding a new instance with _disposed=false. Some hosts
@@ -1685,7 +1733,14 @@ async function _cmdRoot(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void
   // Lock identity is (cwd, name). Several agents may run in the SAME folder; the
   // requested name just has to be made unique. Derive the name the same way
   // `_cmdJoin` does so the lock and the mesh registration agree on identity.
-  const requestedName = loadLocalConfig(cwd).agent_name || defaultAgentName(cwd);
+  // Pi session name (`pi --name` / `/name`) is the source of truth — when set,
+  // it wins over the persisted agent_name so the mesh identity follows the pi
+  // session label. Falls back to config, then to basename(cwd).
+  const _piSessionName = _pi?.getSessionName?.();
+  const requestedName =
+    (_piSessionName && _piSessionName.trim() && sanitizeSegment(_piSessionName.trim()))
+    || loadLocalConfig(cwd).agent_name
+    || defaultAgentName(cwd);
 
   // Per-(cwd,name) lock, but COLLISION DOESN'T REFUSE — it auto-suffixes. If
   // `(cwd, "Backoffice")` is already held by a live agent, try


### PR DESCRIPTION
## What

Two related changes to the pi extension's agent-name handling:

1. **feat: sync the mesh name from the pi session display name** — `pi --name X` / `/name X` now drives the remote-pi mesh identity.
2. **fix: wire the documented `/remote-pi rename <new>` into the TUI** — the README documents it, but the verb had been dropped from the dispatcher (only the Cockpit `rename:` control path worked), so typing it in the pi TUI silently no-op'd.

They're separate commits; happy to split into two PRs if you prefer.

## Why

A pi session has a display name (`pi --name`, `/name`) and remote-pi has a separate, persistent `agent_name` (the mesh identity other peers address you by). They don't sync, so the name the mobile app / other agents see stays frozen on the wizard/default name even after you rename the session. Meanwhile the README still advertises `/remote-pi rename <new>` as a slash command, but it isn't registered — typing it falls through to `_cmdRoot` (a silent connect/status no-op), so you can't rename from the TUI at all.

## How (name sync)

Pi → remote-pi (not the reverse): remote-pi's `agent_name` is the only *persistent* name of the two; pi has no global name, only a per-session display name. The SDK has no "name changed" event, so the sync hooks:
- `session_start` — persist the pi session name to `agent_name` *before* `_cmdRoot`/`_cmdJoin` read config, so the first join already uses it.
- `turn_start` — catch `/name X` between turns. A cheap diff guard means it only does real work when the name actually changed (no relay thrash).

`_cmdJoin`'s `requestedName` now prefers `pi.getSessionName()` (sanitized) → config → `basename(cwd)`, so `pi --name remotepi` joins as `remotepi` (no `#N` suffix for a unique name) instead of falling back to the configured/default name.

When the pi session name is **unset**, the configured `agent_name` is left untouched — the sync never clobbers an existing identity with a missing one. `_syncNameFromPi` has a re-entrancy guard so concurrent hooks can't thrash a relay rename.

## How (rename fix)

Re-adds `rename` to the `/remote-pi` dispatcher, the argument-completion list, and a nested `registerCommand` (for the command palette). It reuses the existing `_renameAgent`, so the live broker re-register + relay room swap + `name-assigned` event all flow unchanged. The "no deprecated commands leak" test is updated (count 20 → 21, `rename` removed from the removed-list).

## Tests

Added to `extension.test.ts`:
- `/remote-pi rename` is registered and dispatches (empty arg → no-op, matching the control-channel contract).
- join `requestedName` prefers `pi.getSessionName()` over config.
- `session_start` persists the pi session name to `agent_name` before join.
- unset pi session name does not clobber an existing `agent_name`.

`pnpm typecheck` + `pnpm test` pass (576 passed, 3 pre-existing skips).

## Scope notes

- No change to the on-wire protocol, the relay, or the broker. Purely client-side in the pi extension.
- The "auto-start on session_start" behavior merged in #34 is untouched.
- This is my first contribution here; happy to rework anything that doesn't match the project's conventions.