### PR TITLE
fix(pi-extension): dedupe extension load and preserve file identity

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -287,6 +287,39 @@ describe("extension default export", () => {
       expect(registeredCommands).not.toContain(removed);
     }
   });
+
+  test("idempotent: a second load on the SAME pi registers nothing twice (daemon -e + auto-discovery double-load)", () => {
+    // A daemon child is launched as `pi -e <dist>/index.js`; if remote-pi is
+    // ALSO installed as a pi-package, Pi auto-discovers it and loads the SAME
+    // extension a second time for the same session, on the same `pi`. Both
+    // loads would otherwise re-run registerTool/registerCommand for identical
+    // names → a duplicate-registration conflict that crashes the daemon.
+    const registeredCommands: string[] = [];
+    const registeredTools: string[] = [];
+    const pi = {
+      on: () => undefined,
+      registerCommand(name: string) { registeredCommands.push(name); },
+      registerTool(spec: { name: string }) { registeredTools.push(spec.name); },
+      registerShortcut: () => undefined,
+      registerFlag: () => undefined, getFlag: () => undefined,
+      registerMessageRenderer: () => undefined,
+      sendMessage: () => undefined, sendUserMessage: () => undefined,
+    } as unknown as ExtensionAPI;
+
+    (extension as ExtensionFactory)(pi);
+    const commandsAfterFirst = registeredCommands.length;
+    const toolsAfterFirst = registeredTools.length;
+    expect(commandsAfterFirst).toBeGreaterThan(0);
+    expect(toolsAfterFirst).toBeGreaterThan(0);  // agent_send / list_peers / agent_request
+
+    // Second load on the SAME pi object must be an inert no-op.
+    (extension as ExtensionFactory)(pi);
+    expect(registeredCommands.length).toBe(commandsAfterFirst);
+    expect(registeredTools.length).toBe(toolsAfterFirst);
+    // And no single name was registered more than once.
+    expect(new Set(registeredCommands).size).toBe(registeredCommands.length);
+    expect(new Set(registeredTools).size).toBe(registeredTools.length);
+  });
 });
 
 // ── State machine + pair_request flow ─────────────────────────────────────────

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -1179,7 +1179,37 @@ let _lastCtx: Pick<ExtensionContext, "ui" | "abort" | "cwd"> | null = null;
 let _lastEventCtx: Pick<ExtensionContext, "compact" | "abort"> | null = null;
 const _noopCtx = { ui: { notify: () => undefined }, abort: () => undefined };
 
+// A single Pi process can load this extension TWICE in the SAME session:
+// pi-supervisord launches each daemon child as `pi -e <dist>/index.js`, but if
+// remote-pi is ALSO installed as a pi-package (auto-discovered from
+// ~/.pi/agent/extensions or <cwd>/.pi/extensions), Pi loads it a second time
+// for that same session. Both loads receive the same session-scoped `pi` and
+// would re-run registerTool/registerCommand for identical names — a hard
+// duplicate-registration conflict that crashes the daemon child on boot (see
+// daemon/rpc_child.ts). Idempotent, first-load-wins: whichever load runs first
+// does all the wiring; the duplicate is an inert no-op. A genuine session
+// REPLACEMENT gets a FRESH `pi`, so re-registration for the new session still
+// happens.
+//
+// We track "already wired" in a process-global WeakSet keyed by `pi` rather
+// than by mutating the host SDK object. The two loads are DISTINCT module
+// instances (the SDK's jiti loader uses moduleCache:false, and the `-e` path vs
+// the installed path resolve to different files), so a module-level Set can't
+// dedupe them; the WeakSet lives on `globalThis` under a `Symbol.for` key so
+// both module instances resolve the SAME set. Keying weakly by `pi` records the
+// fact without adding a foreign property to the API object and lets each `pi`
+// be GC'd when its session ends (no leak).
+const _APPLIED_REGISTRY_KEY = Symbol.for("remote-pi.extension.appliedRegistry");
+function _appliedRegistry(): WeakSet<object> {
+  const g = globalThis as typeof globalThis & { [_APPLIED_REGISTRY_KEY]?: WeakSet<object> };
+  return (g[_APPLIED_REGISTRY_KEY] ??= new WeakSet<object>());
+}
+
 const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
+  const applied = _appliedRegistry();
+  if (applied.has(pi)) return;  // this session's pi was already wired
+  applied.add(pi);
+
   _pi = pi;
 
   // Plano 19: ensure ~/.pi/remote/{sessions,skills}/ exist and deploy the

--- a/pi-extension/src/pairing/storage.test.ts
+++ b/pi-extension/src/pairing/storage.test.ts
@@ -305,3 +305,70 @@ describe("getOrCreateEd25519Keypair — locked keyring does NOT regenerate", () 
     expect(existsSync(_IDENTITY_FILE_FOR_TEST)).toBe(true);
   });
 });
+
+// ── File identity wins over a READABLE keyring (masking bug) ─────────────────
+//
+// A file-backed/headless install pairs the mobile against the key in
+// `~/.pi/remote/identity.json`. If the platform keyring later becomes readable
+// (D-Bus/libsecret installed, a desktop session, a stale entry from another
+// install), consulting it FIRST would mask the file identity — returning a
+// different key, or minting a fresh one over an empty keyring — and break the
+// existing pairing. The file must win. (These cases differ from the
+// "locked keyring" ones above: here the keyring READS FINE, it just isn't the
+// paired identity.)
+
+describe("getOrCreateEd25519Keypair — file identity wins over a readable keyring", () => {
+  /** Seed a file-backed identity via the headless path and return its key. */
+  async function seedFileIdentity() {
+    const seed = new InMemoryBackend();
+    seed.failAll("read");
+    _setKeyStoreBackendForTest(seed);
+    _setKeyringExpectedForTest(false);  // headless Linux → writes identity.json
+    const fileKp = await getOrCreateEd25519Keypair();
+    expect(existsSync(_IDENTITY_FILE_FOR_TEST)).toBe(true);
+    return fileKp;
+  }
+
+  test("readable keyring holding a DIFFERENT entry → file identity still wins", async () => {
+    const fileKp = await seedFileIdentity();
+
+    // A fully-readable keyring now holds a DIFFERENT identity.
+    const keyring = new InMemoryBackend();
+    const otherPk = Buffer.from(new Uint8Array(32).fill(42)).toString("base64");
+    keyring.store.set(`${NEW_SERVICE}|${ACCOUNT}`, JSON.stringify({
+      pk: otherPk,
+      sk: Buffer.from(new Uint8Array(64).fill(43)).toString("base64"),
+    }));
+    _setKeyStoreBackendForTest(keyring);
+    _setKeyringExpectedForTest(true);  // even on a core-keyring platform
+
+    const kp = await getOrCreateEd25519Keypair();
+    // File identity wins — the mobile is paired against it.
+    expect(Buffer.from(kp.publicKey).toString("base64")).toBe(
+      Buffer.from(fileKp.publicKey).toString("base64"),
+    );
+    expect(Buffer.from(kp.publicKey).toString("base64")).not.toBe(otherPk);
+    // The keyring is never consulted — the file short-circuits ahead of it.
+    expect(keyring.reads.length).toBe(0);
+    expect(keyring.writes.length).toBe(0);
+    expect(keyring.deletes.length).toBe(0);
+  });
+
+  test("readable but EMPTY keyring → does NOT mint a fresh key over identity.json", async () => {
+    const fileKp = await seedFileIdentity();
+
+    // A readable but EMPTY keyring appears (e.g. libsecret installed later).
+    const keyring = new InMemoryBackend();
+    _setKeyStoreBackendForTest(keyring);
+    _setKeyringExpectedForTest(true);
+
+    const kp = await getOrCreateEd25519Keypair();
+    expect(Buffer.from(kp.publicKey).toString("base64")).toBe(
+      Buffer.from(fileKp.publicKey).toString("base64"),
+    );
+    // Critically: no fresh keypair was generated + written into the keyring
+    // (that write is exactly what masked the file identity and broke pairing).
+    expect(keyring.reads.length).toBe(0);
+    expect(keyring.writes.length).toBe(0);
+  });
+});

--- a/pi-extension/src/pairing/storage.ts
+++ b/pi-extension/src/pairing/storage.ts
@@ -188,25 +188,46 @@ async function _writeKeypairToFile(kp: Ed25519Keypair): Promise<void> {
 /**
  * Returns the Pi-secret Ed25519 keypair, generating + persisting one on
  * first call. Resolution order:
- *   1. New keyring service `dev.remotepi.pi` (read retried — a transiently
+ *   1. Existing file `~/.pi/remote/identity.json`, if present — it WINS over
+ *      the keyring. A file identity is only ever written by the headless/
+ *      degraded fallback (step 4) or an explicit `REMOTE_PI_ALLOW_FILE_IDENTITY`
+ *      opt-in, so its mere presence means this machine established its identity
+ *      as a file and the mobile device paired against THAT pubkey. If the
+ *      platform keyring later becomes readable (D-Bus/libsecret installed, a
+ *      desktop session, or a stale/other entry from another install), reading
+ *      it first would mask the file identity — returning a DIFFERENT key, or
+ *      (when the keyring is empty) minting a fresh one and persisting it —
+ *      silently breaking the existing pairing. So when both exist, file wins.
+ *   2. New keyring service `dev.remotepi.pi` (read retried — a transiently
  *      locked Keychain throws; we don't treat that as "no key")
- *   2. Old keyring service `dev.remotepi.mac` (migrate → step 1, delete old)
- *   3. File `~/.pi/remote/identity.json` (use if present — never regenerate
- *      over an existing one)
+ *   3. Old keyring service `dev.remotepi.mac` (migrate → step 2, delete old)
  *   4. Generate a fresh keypair, BUT only when it's safe to: either both
  *      keyring reads succeeded and returned nothing (genuine first run), or
  *      the keyring is genuinely unavailable on a platform without a core one
- *      (headless Linux). On macOS/Windows a persistent read failure with no
- *      file identity throws `KeyringUnavailableError` instead of minting a new
- *      key — generating there silently breaks existing pairing (the "lost
- *      pairing after idle" bug). `REMOTE_PI_ALLOW_FILE_IDENTITY=1` opts back
- *      into a file identity for headless macOS/Windows hosts.
+ *      (headless Linux → a file identity is minted here). On macOS/Windows a
+ *      persistent read failure with no file identity throws
+ *      `KeyringUnavailableError` instead of minting a new key — generating
+ *      there silently breaks existing pairing (the "lost pairing after idle"
+ *      bug). `REMOTE_PI_ALLOW_FILE_IDENTITY=1` opts back into a file identity
+ *      for headless macOS/Windows hosts.
  *
  * Idempotent: subsequent calls return the same identity. The migration
  * runs at most once per machine (the old entry is deleted after copy).
  */
 export async function getOrCreateEd25519Keypair(): Promise<Ed25519Keypair> {
   const backend = _getBackend();
+
+  // ── Path 0: an existing file-backed identity wins ──────────────────────
+  // `~/.pi/remote/identity.json` is only ever written by the headless/degraded
+  // fallback below (or an operator who set REMOTE_PI_ALLOW_FILE_IDENTITY=1) —
+  // never on a keyring-backed install. So its presence means THIS machine
+  // paired against the file key, and the keyring (readable or not, matching or
+  // not) must not be allowed to mask it. Short-circuit before touching the
+  // keyring so a keyring that later comes online can't return a different key,
+  // nor mint a fresh one over the file identity. No file → normal keyring
+  // resolution below; a headless first run still reaches Path B and mints one.
+  const existingFile = await _readKeypairFromFile();
+  if (existingFile) return existingFile;
 
   // ── Path A: keyring (retried) ──────────────────────────────────────────
   // A throw here means the keyring op FAILED — but on macOS/Windows that is
@@ -248,8 +269,9 @@ export async function getOrCreateEd25519Keypair(): Promise<Ed25519Keypair> {
   }
 
   // ── Path B: keyring threw on every attempt ─────────────────────────────
-  // If a file identity already exists, this machine is in file mode
-  // (headless, or previously degraded) — use it, never regenerate.
+  // Path 0 already returned any pre-existing file identity; this defensive
+  // re-check catches a file written concurrently by another Pi process during
+  // the keyring-retry window (still: use it, never regenerate).
   const fromFile = await _readKeypairFromFile();
   if (fromFile) return fromFile;
 


### PR DESCRIPTION
## Summary

Fixes two pi-extension edge cases that can break daemon startup or existing mobile pairing:

1. **Idempotent extension load for daemon double-loads**
   - `pi-supervisord` starts daemon children with `pi -e <remote-pi>/dist/index.js`.
   - If `remote-pi` is also installed as a Pi package, Pi can auto-discover and load the same extension again for the same session.
   - The second load re-registers identical tools/commands (`agent_send`, `list_peers`, `agent_request`, slash commands), causing duplicate-registration failures.
   - This PR adds a first-load-wins guard backed by a process-global `WeakSet` keyed by the session `pi` object. It avoids mutating the SDK object and still allows fresh sessions with fresh `pi` objects to register normally.

2. **Existing file-backed identity wins over keyring**
   - A headless/file-backed install pairs mobile devices against `~/.pi/remote/identity.json`.
   - If a keyring later becomes readable (or contains a stale/different identity), reading keyring first can mask the file identity and break existing pairing.
   - This PR resolves an existing file identity before touching keyring, preserving file-backed/headless pairing. Keyring-only installs and legacy keyring migration still follow the existing path when no file identity exists.

## Tests

Run from `pi-extension/`:

- `corepack pnpm exec vitest run src/extension.test.ts src/pairing/storage.test.ts` → 147 passed
- `corepack pnpm typecheck` → passed
- `corepack pnpm test` → 575 passed, 3 skipped
- `corepack pnpm build` → passed
- `git diff --check` → passed
