### PR TITLE
Prevent supervised daemon mesh duplicates

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -3038,6 +3038,34 @@ describe("same-folder same-name → #N suffix (no refusal)", () => {
       _resetCwdLockForTest();
     }
   });
+
+  test("a supervised daemon refuses a busy base lock instead of joining as <name>#2", async () => {
+    process.env["REMOTE_PI_DAEMON"] = "1";
+    process.env["REMOTE_PI_DIRECT_CONFIG"] = JSON.stringify({
+      agent_name: "Backoffice",
+      auto_start_relay: false,
+    });
+    const cwd = "/home/user/projects/remote_pi";
+    const first = await acquireCwdLock(cwd, "Backoffice");
+    expect(first.ok).toBe(true);
+    try {
+      const root = captureHandler("remote-pi");
+      const ctx = makeMockCtx(cwd);
+      await root("", ctx);
+
+      expect(_getLockedNameForTest()).toBeNull();
+      expect(_hasMeshNodeForTest()).toBe(false);
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("Daemon not started"),
+        "warning",
+      );
+    } finally {
+      if (first.ok) first.release();
+      delete process.env["REMOTE_PI_DAEMON"];
+      delete process.env["REMOTE_PI_DIRECT_CONFIG"];
+      _resetCwdLockForTest();
+    }
+  });
 });
 
 // ── relay reconnect with backoff ──────────────────────────────────────────────
@@ -3725,4 +3753,3 @@ describe("model meta", () => {
     }
   });
 });
-

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -1684,23 +1684,23 @@ async function _cmdRoot(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void
   // `_cmdJoin` does so the lock and the mesh registration agree on identity.
   const requestedName = loadLocalConfig(cwd).agent_name || defaultAgentName(cwd);
 
-  // Per-(cwd,name) lock, but COLLISION DOESN'T REFUSE — it auto-suffixes. If
-  // `(cwd, "Backoffice")` is already held by a live agent, try
-  // `(cwd, "Backoffice#2")`, `#3`, … until one binds. So a second agent with the
-  // same name in the same folder comes up as `Backoffice#2` (matching the
-  // broker's `_uniqueName` suffix scheme) instead of being turned away. The
-  // suffix N matches the broker's (`#2`-based) so lock + mesh name line up. The
-  // lock is a UDS socket (kernel auto-releases on exit/crash) bound for THIS
-  // process's lifetime; repeat `/remote-pi` calls are idempotent.
+  // Per-(cwd,name) lock. Interactive agents may coexist by auto-suffixing
+  // (`name#2`, `name#3`, …), but supervised daemons must be singletons for their
+  // registered cwd/name. If a daemon silently came up as `#2`, the supervisor
+  // would report "running" while the mesh had duplicate peers for one repo.
   if (_cwdLock === null) {
-    for (let n = 1; n <= 1000; n++) {
+    const isDaemon = process.env["REMOTE_PI_DAEMON"] === "1";
+    const maxAttempts = isDaemon ? 1 : 1000;
+    for (let n = 1; n <= maxAttempts; n++) {
       const candidate = n === 1 ? requestedName : `${requestedName}#${n}`;
       const result = await acquireCwdLock(cwd, candidate);
       if (result.ok) { _cwdLock = result; _lockedName = candidate; break; }
     }
     if (_cwdLock === null) {
       ctx.ui.notify(
-        `[remote-pi] Could not start: too many agents named "${requestedName}" already running in this folder.`,
+        process.env["REMOTE_PI_DAEMON"] === "1"
+          ? `[remote-pi] Daemon not started: another live agent already owns "${requestedName}" in this folder. Stop the old Pi process, then restart the daemon.`
+          : `[remote-pi] Could not start: too many agents named "${requestedName}" already running in this folder.`,
         "warning",
       );
       return;
@@ -2953,7 +2953,13 @@ async function _cmdJoin(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void
   // realpath so symlinked cwds map to one identity (matches roomIdForCwd).
   let canonCwd = cwd;
   try { canonCwd = realpathSync(cwd); } catch { /* cwd missing — use raw path */ }
-  const peer = new MeshNode({ sockPath: sock, name: agentName, cwd: canonCwd, auditPath: audit });
+  const peer = new MeshNode({
+    sockPath: sock,
+    name: agentName,
+    cwd: canonCwd,
+    auditPath: audit,
+    takeoverExisting: process.env["REMOTE_PI_DAEMON"] === "1",
+  });
 
   peer.onMessage((env) => {
     const body = env.body as { type?: string } | null;

--- a/pi-extension/src/session/broker.ts
+++ b/pi-extension/src/session/broker.ts
@@ -148,6 +148,10 @@ interface RegisterMsg {
   /** Optional working directory — enables (cwd,name) take-over (see
    *  `_handleRegister`). Absent → legacy `#N`-on-collision behavior. */
   cwd?: string;
+  /** Replace an existing same-(cwd,name) peer instead of suffixing `#N`.
+   *  Used by stable identities such as supervised daemons and session
+   *  replacement, where a second registration is the same logical agent. */
+  takeover?: boolean;
 }
 
 interface RegisterAck {
@@ -302,12 +306,12 @@ export class Broker {
 
     // (cwd, name) identity (plan/38). The cwd is the first-class axis: the
     // address embeds it, so two same-named agents in DIFFERENT folders get
-    // distinct addresses and never collide — `#N` fires only on the same cwd +
-    // same name. A legacy peer (no cwd) → cwd "" → `address == name`, preserving
-    // the old global-name behavior so a mixed mesh keeps routing.
+    // distinct addresses and never collide. Legacy peers (no cwd) keep the old
+    // global-name behavior. New peers can opt into exact-address takeover for
+    // same-folder reincarnations such as daemon restarts.
     conn.cwd = typeof req.cwd === "string" ? req.cwd : "";
 
-    const { name, address } = this._uniqueIdentity(conn.cwd, req.name);
+    const { name, address } = this._identityForRegister(conn.cwd, req.name, req.takeover === true);
     conn.name = name;
     conn.address = address;
     this.peers.set(address, conn);
@@ -391,9 +395,13 @@ export class Broker {
    * (matching the cwd-lock's suffix scheme) until the address is free; for a
    * legacy peer (cwd "") the address is the name, preserving global-name `#N`.
    */
-  private _uniqueIdentity(cwd: string, requested: string): { name: string; address: string } {
+  private _identityForRegister(cwd: string, requested: string, takeover: boolean): { name: string; address: string } {
     const sanitized = sanitizeMeshName(requested);
     let address = composeAddress({ cwd, name: sanitized });
+    if (takeover && cwd && this.peers.has(address)) {
+      this._dropPeerAt(address);
+      return { name: sanitized, address };
+    }
     if (!this.peers.has(address)) return { name: sanitized, address };
     // Collision: strip any client-provided `#N`, then re-suffix from #2.
     const base = sanitized.replace(/#\d+$/, "");
@@ -405,8 +413,19 @@ export class Broker {
     throw new Error(`name space exhausted for ${base} in ${cwd || "(no cwd)"}`);
   }
 
+  private _dropPeerAt(address: string): void {
+    const existing = this.peers.get(address);
+    if (!existing) return;
+    this.peers.delete(address);
+    // The old socket's close event may arrive after the replacement has been
+    // inserted. Clear its address so it cannot delete the replacement.
+    existing.address = "";
+    try { existing.socket.destroy(); } catch { /* ignored */ }
+  }
+
   private _onClose(conn: PeerConn): void {
     if (!conn.address) return;
+    if (this.peers.get(conn.address) !== conn) return;
     this.peers.delete(conn.address);
     this._broadcastSystem({ type: "peer_left", name: conn.address, address: conn.address }, conn.address);
   }

--- a/pi-extension/src/session/e2e.test.ts
+++ b/pi-extension/src/session/e2e.test.ts
@@ -666,6 +666,32 @@ describe("plan/38 — (cwd, name) mesh addressing (e2e)", () => {
     await a.leave(); await b.leave();
   });
 
+  test("takeoverExisting replaces the same cwd/name instead of creating #2", async () => {
+    const sock = tmpSock();
+    const first = await makePeerCwd(sock, "backend", "/a/backend");
+    const replacement = new SessionPeer({
+      sockPath: sock,
+      name: "backend",
+      cwd: "/a/backend",
+      takeoverExisting: true,
+      defaultTimeoutMs: 3000,
+    });
+    await replacement.start();
+
+    expect(replacement.name()).toBe("backend");
+    expect(replacement.address()).toBe("/a/backend@backend");
+
+    const reply = await replacement.request("broker", { type: "list_peers" });
+    const peers = (reply.body as { peers?: string[] }).peers ?? [];
+    expect(peers.filter((p) => p.startsWith("/a/backend@backend"))).toEqual([
+      "/a/backend@backend",
+    ]);
+
+    await expect(first.send("broadcast", { stale: true })).rejects.toThrow("session peer not connected");
+    await first.leave();
+    await replacement.leave();
+  });
+
   test("list_peers_reply carries peers_detailed ({cwd,name,address})", async () => {
     const sock = tmpSock();
     const a = await makePeerCwd(sock, "backend", "/a/backend");

--- a/pi-extension/src/session/mesh_node.ts
+++ b/pi-extension/src/session/mesh_node.ts
@@ -56,6 +56,9 @@ export interface MeshNodeOptions {
    *  keyed by (cwd, name) and a same-folder same-name reincarnation takes over
    *  instead of colliding into `#N`. Optional (legacy peers omit it). */
   cwd?: string;
+  /** Replace an existing same-(cwd,name) mesh registration. Intended for
+   *  stable process identities such as supervised daemons. */
+  takeoverExisting?: boolean;
   /** Optional audit log path passed through to SessionPeer. */
   auditPath?: string;
   /** Self-managed relay bridge — brought up if this node leads. */
@@ -103,6 +106,7 @@ export class MeshNode {
     this.log = opts.log ?? ((): void => {});
     const peerOpts: SessionPeerOptions = { sockPath: opts.sockPath, name: opts.name };
     if (opts.cwd !== undefined) peerOpts.cwd = opts.cwd;
+    if (opts.takeoverExisting !== undefined) peerOpts.takeoverExisting = opts.takeoverExisting;
     if (opts.auditPath !== undefined) peerOpts.auditPath = opts.auditPath;
     this.peer_ = new SessionPeer(peerOpts);
     if (opts.bridge) {

--- a/pi-extension/src/session/peer.ts
+++ b/pi-extension/src/session/peer.ts
@@ -27,6 +27,10 @@ export interface SessionPeerOptions {
    * Optional for backward-compat with peers that predate this field.
    */
   cwd?: string;
+  /** Replace an existing same-(cwd,name) registration instead of accepting a
+   *  broker-assigned `#N`. Use only for stable logical identities; ordinary
+   *  multi-agent sessions should leave this false. */
+  takeoverExisting?: boolean;
   auditPath?: string;
   /** Per-request default timeout (ms). Override per call if needed. */
   defaultTimeoutMs?: number;
@@ -300,6 +304,7 @@ export class SessionPeer {
         // payload for callers that don't supply it (broker treats absent cwd
         // as "no take-over", i.e. the old #N behavior).
         ...(this.opts.cwd !== undefined ? { cwd: this.opts.cwd } : {}),
+        ...(this.opts.takeoverExisting === true ? { takeover: true } : {}),
       }) + "\n";
       try {
         sock.write(req);


### PR DESCRIPTION
## Summary
- add an explicit same-(cwd,name) takeover mode to the local mesh broker registration path
- thread takeoverExisting through SessionPeer and MeshNode for stable supervised identities
- keep interactive same-name agents able to suffix as #2, but make REMOTE_PI_DAEMON refuse a busy base lock instead of silently joining as a duplicate peer

## Root cause
A supervised daemon could start while an older Pi process still held the same repo/name identity. The cwd lock seeker would silently reserve name#2, and the broker would then expose duplicate peers for the same repo while the supervisor still reported the daemon as healthy.

## Validation
- npm test -- src/session/e2e.test.ts
- npm test -- src/extension.test.ts
- npm run typecheck
- npm run build
- npm test

Note: pnpm is currently unusable in this checkout with the checked-in pnpm-workspace.yaml on my local pnpm (packages field missing or empty), so I used npm to install deps and run the equivalent package scripts.