### PR TITLE
fix(extension): guard stale ctx in name sync to avoid pi uncaughtException crash

### DIFF
--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -608,7 +608,22 @@ function _displayName(cwd: string): string {
 let _syncingName = false;
 async function _syncNameFromPi(): Promise<void> {
   if (_disposed || _syncingName) return;
-  const piName = _pi?.getSessionName?.();
+  // Best-effort name sync. This is invoked fire-and-forget (`void
+  // _syncNameFromPi()`) from turn_start and session_start, so any rejection
+  // here escapes the runner's per-handler try/catch and crashes pi as an
+  // uncaughtException. After ctx.newSession()/fork()/switchSession()/reload()
+  // the captured _pi is stale and getSessionName() throws via assertActive —
+  // guard the read so a stale ctx degrades to a SKIPPED sync instead of a
+  // process exit. (The event ctx passed to these handlers does not carry
+  // getSessionName; only the pi ExtensionAPI does, and it is permanently
+  // stale once invalidated, so there is no fresh source to fall back to —
+  // skipping until the module is re-evaluated with a fresh _pi is correct.)
+  let piName: string | undefined;
+  try {
+    piName = _pi?.getSessionName?.();
+  } catch {
+    return; // stale ctx mid session-replacement — nothing to sync this turn
+  }
   if (!piName || !piName.trim()) return;
   const requested = sanitizeSegment(piName.trim());
   if (!requested) return;
@@ -621,6 +636,8 @@ async function _syncNameFromPi(): Promise<void> {
   _syncingName = true;
   try {
     await _renameAgent(requested);
+  } catch {
+    /* best-effort — never let a rename failure crash name sync */
   } finally {
     _syncingName = false;
   }
@@ -1766,7 +1783,14 @@ async function _cmdRoot(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void
   // Pi session name (`pi --name` / `/name`) is the source of truth — when set,
   // it wins over the persisted agent_name so the mesh identity follows the pi
   // session label. Falls back to config, then to basename(cwd).
-  const _piSessionName = _pi?.getSessionName?.();
+  let _piSessionName: string | undefined;
+  try {
+    _piSessionName = _pi?.getSessionName?.();
+  } catch {
+    // _pi is stale after session replacement/reload — fall back to the
+    // persisted agent_name / default rather than crashing the /remote-pi command.
+    _piSessionName = undefined;
+  }
   const requestedName =
     (_piSessionName && _piSessionName.trim() && sanitizeSegment(_piSessionName.trim()))
     || loadLocalConfig(cwd).agent_name


### PR DESCRIPTION
## Problem

Pi exits with an `uncaughtException` when remote-pi reads the session name off a stale captured `_pi` after `ctx.newSession()` / `ctx.fork()` / `ctx.switchSession()` / `ctx.reload()`:

```
pi exiting due to uncaughtException:
Error: This extension ctx is stale after session replacement or reload.
  at Object.assertActive (.../loader.js:132:19)
  at Object.getSessionName (.../loader.js:240:21)
  at _syncNameFromPi (.../remote-pi/dist/index.js:485:41)
  at .../remote-pi/dist/index.js:1235:14
  at ExtensionRunner.emit (.../runner.js:524:49)
```

Two conditions combine to crash the process:

### 1. Stale captured ctx
`_syncNameFromPi()` and `_cmdRoot()` call `_pi.getSessionName()` on the module-level captured `_pi`. The SDK invalidates that `ExtensionAPI` object (`runtime.invalidate()`, set **once, never cleared**) on session replacement, so `getSessionName()` throws via `assertActive`. The event `ctx` handed to `turn_start` / `session_start` does **not** carry `getSessionName` (only the `pi` ExtensionAPI does), and that object is permanently stale once invalidated — so there is no fresh source to fall back to.

### 2. Fire-and-forget escape
The call sites are `void _syncNameFromPi();` (async, not awaited). A sync throw inside the async function becomes a rejected promise that sails out past the runner's per-handler `try/catch` in `emit()` (which only catches `await handler(...)`, and the handler returns `undefined` immediately) and surfaces as an `unhandledRejection` → `uncaughtException` → **pi exits**.

This is reproducible on hosts that reuse the same extension module instance across `ctx.newSession()` (the captured `_pi` is never refreshed, `_disposed` is never cleared) — i.e. any daemon/long-running pi session that replaces its session.

## Fix

Guard the `_pi?.getSessionName?.()` read in `_syncNameFromPi()` and `_cmdRoot()` with `try/catch` so a stale ctx **degrades to a skipped name sync** (in `_cmdRoot`, falls back to the persisted `agent_name` / `defaultAgentName(cwd)`) instead of a process exit. Also add a `catch` around `await _renameAgent(requested)` so a rename failure can never escape the fire-and-forget call either. The next turn — once the module is re-evaluated with a fresh `_pi` — resumes syncing normally.

The name sync is best-effort/cosmetic (mirrors the pi session label into the mesh identity), so skipping it on a stale turn is correct behavior; it was never worth crashing pi for.

## Changes
- `pi-extension/src/index.ts`:
  - `_syncNameFromPi()`: wrap `_pi?.getSessionName?.()` in `try/catch` (return on stale); add `catch` around `await _renameAgent(requested)`.
  - `_cmdRoot()`: wrap `_pi?.getSessionName?.()` in `try/catch` (fall back to `undefined` → config → default).

## Verification
- `tsc --noEmit` → **No errors found**.
- The same fix has been applied and verified on the published `remote-pi@0.5.4` `dist/index.js` in a live environment (`node --check` passes; crash no longer reproduces after session replacement).

## Notes
- The broader module-level `_pi` pattern is still latent: other `_pi?.sendMessage(...)` / `_pi?.getThinkingLevel()` calls in **synchronous** event handlers are caught by `emit()`'s try/catch (so they only log, they don't crash), but any future **fire-and-forget async** use of `_pi` action methods would reproduce this class of bug. This PR fixes the immediate crash; a follow-up could refresh `_pi` on `session_start` if the SDK exposes a fresh handle, or move more reads behind `withSession`.
- No runtime behavior change in the non-stale path.