### PR TITLE
fix(extension): guard saveLocalConfig against read-only fs (EROFS/EPERM)

### DIFF
--- a/pi-extension/src/session/local_config.ts
+++ b/pi-extension/src/session/local_config.ts
@@ -132,14 +132,27 @@ export function loadLocalConfig(cwd: string): LocalConfig {
 
 export function saveLocalConfig(cwd: string, patch: Partial<LocalConfig>): void {
   const p = pathFor(cwd);
-  mkdirSync(dirname(p), { recursive: true });
   const current = loadLocalConfig(cwd);
   const next: LocalConfig = { ...current, ...patch };
   // Always persist auto_start_relay explicitly (default true) so future reads
   // never need to guess. Backward-compat: legacy files without the field
   // are treated as true on read; we lock that intent in on first save.
   if (typeof next.auto_start_relay !== "boolean") next.auto_start_relay = true;
-  writeFileSync(p, JSON.stringify(next, null, 2));
+  // Best-effort persistence: a read-only config.json is a legitimate deployment
+  // (NixOS/Home Manager symlink into the immutable Nix store, read-only root,
+  // EPERM). The name/config sync is cosmetic — it must NEVER crash the pi
+  // process with an uncaughtException. `saveLocalConfig` is reached via
+  // fire-and-forget async paths (`void _syncNameFromPi()` from `turn_start` /
+  // `session_start`), so a sync throw from `mkdirSync`/`writeFileSync` sails
+  // past the runner's per-handler try/catch and takes down pi. Guard both fs
+  // calls together so a partial attempt can't throw past the caller.
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, JSON.stringify(next, null, 2));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[remote-pi] could not persist local config ${p}: ${message}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Pi exits with an `uncaughtException` when `remote-pi` tries to persist the synced agent name to a **read-only** `config.json`:

```
pi exiting due to uncaughtException: Error: EROFS: read-only file system, open '/home/will/.pi/remote-pi/config.json'
    at writeFileSync (node:fs:2422:20)
    at saveLocalConfig (.../remote-pi/dist/session/local_config.js:126:5)
    at _syncNameFromPi (.../remote-pi/dist/index.js:493:9)
    at .../remote-pi/dist/index.js:1235:14
    at ExtensionRunner.emit (.../runner.js:524:49)
```

Two conditions combine to crash the process:

### 1. Read-only config is a legitimate deployment
On NixOS / Home Manager, `~/.pi/remote-pi/config.json` is **declaratively managed** — Home Manager installs it as a symlink into the **immutable Nix store** (`/nix/store/…-home-manager-files/.pi/remote-pi/config.json`). Any `writeFileSync` on that path throws `EROFS`. The same applies to read-only roots, locked-down CI runners, and `EPERM` on restricted home dirs.

### 2. Fire-and-forget escape
`_syncNameFromPi()` is invoked as `void _syncNameFromPi()` from `turn_start` / `session_start` (async, not awaited). The `saveLocalConfig()` call inside it is **synchronous** — a throw from `writeFileSync` becomes a rejected promise that sails past the runner's per-handler `try/catch` in `emit()` (which only catches `await handler(...)`, and the handler returns `undefined` immediately) and surfaces as an `unhandledRejection` → `uncaughtException` → **pi exits**.

This is reproducible on **every turn** once the pi session name differs from the persisted `agent_name` and the config is read-only — i.e. the entire NixOS/Home Manager user base.

## Fix

Make `saveLocalConfig` **best-effort**: wrap `mkdirSync` + `writeFileSync` in `try/catch` and `console.warn` on failure instead of throwing. A read-only config is a valid deployment, and the name/config sync is cosmetic (mirrors the pi session label into the mesh identity) — it must never crash pi.

Guarding at `saveLocalConfig` (the root) protects **all** callers (`_syncNameFromPi`, `_renameAgent`, and any future writer) regardless of whether the call site is fire-and-forget or awaited.

## Changes
- `pi-extension/src/session/local_config.ts`:
  - `saveLocalConfig()`: move `mkdirSync` + `writeFileSync` into `try/catch`; on failure, `console.warn` and return (no throw).

## Verification
- `tsc --noEmit` → clean (the change only adds a `try/catch` around two existing sync calls; no type changes).
- The same fix applied to the published `remote-pi@0.5.4` `dist/session/local_config.js` in a live NixOS/Home Manager environment resolves the crash — pi no longer exits on `turn_start` when the config is a Nix-store symlink.

## Notes
- Complements #40 (which guards the stale-ctx `getSessionName()` throw in `_syncNameFromPi` / `_cmdRoot`). This PR addresses the **other** unguarded throw on the same fire-and-forget path — the `writeFileSync` inside `saveLocalConfig`. Together they make `_syncNameFromPi` fully crash-safe.
- No runtime behavior change in the writable-config path (the `try/catch` only fires on a write failure).