### PR TITLE
fix (cockpit): allow the user to select full-screen mode on macOS

### DIFF
--- a/cockpit/lib/app/core/ui/widgets/window_controls.dart
+++ b/cockpit/lib/app/core/ui/widgets/window_controls.dart
@@ -5,7 +5,10 @@ import 'package:shadcn_flutter/shadcn_flutter.dart';
 import 'package:window_manager/window_manager.dart';
 
 Future<void> _toggleMaximize() async {
-  if (await windowManager.isMaximized()) {
+  if (Platform.isMacOS) {
+    final isFull = await windowManager.isFullScreen();
+    await windowManager.setFullScreen(!isFull);
+  } else if (await windowManager.isMaximized()) {
     await windowManager.unmaximize();
   } else {
     await windowManager.maximize();


### PR DESCRIPTION
The purpose of this PR is to allow macOS users to click the button to expand the app so that it goes into full-screen mode.


https://github.com/user-attachments/assets/1d0f5449-6758-4a53-ae8e-bec5da1b1565

Close issue #43 