### PR TITLE
fix(cockpit): re-apply window size after show on Linux

### DIFF
--- a/cockpit/lib/main.dart
+++ b/cockpit/lib/main.dart
@@ -104,6 +104,16 @@ Future<void> _setupWindow(Box<dynamic> winBox) async {
       await windowManager.setBounds(Rect.fromLTWH(x, y, w, h));
     }
     await windowManager.show();
+
+    // Linux/window_manager can show a 10x10 window despite WindowOptions.size.
+    // Re-apply visible bounds after show; harmless on macOS/Windows.
+    if (x != null && y != null) {
+      await windowManager.setBounds(Rect.fromLTWH(x, y, w, h));
+    } else {
+      await windowManager.setSize(Size(w, h));
+      await windowManager.center();
+    }
+
     await windowManager.focus();
   });
 }


### PR DESCRIPTION
Fix Cockpit opening as a tiny invisible window on Linux.

Problem:
On Linux, window_manager.waitUntilReadyToShow() can ignore WindowOptions.size, so Cockpit launches as a 10x10 window at +10+10. The app runs, but looks like it never opened.

Fix:
In cockpit/lib/main.dart, after windowManager.show(), re-apply window bounds:
- saved position: setBounds(x, y, w, h)
- first launch: setSize(1280x720) and center()

Should be harmless on macOS/Windows.

Test plan:
- Launch Cockpit on Linux and confirm window is about 1280x720, not 10x10