### PR TITLE
fix (android): preserve active room on WS reconnect after background

### DIFF
--- a/app/lib/data/sync/sync_service.dart
+++ b/app/lib/data/sync/sync_service.dart
@@ -71,6 +71,7 @@ class SyncService extends Service {
   // session index (durable, for Home) and exposed in-memory (for the chat
   // pill, no box-key matching needed).
   bool _working = false;
+  bool _sawRemoteWorking = false;
   // Id of the user message the in-flight reply is answering — the `cancel`
   // target while working. Null when idle.
   String? _workingReplyTo;
@@ -92,7 +93,10 @@ class SyncService extends Service {
     this.pendingSendTimeout = const Duration(seconds: 20),
   }) {
     _connSub = _conn.statusStream.listen(_onStatus);
-    _roomsSub = _conn.roomsStream.listen((_) => _writeRuntime());
+    _roomsSub = _conn.roomsStream.listen((_) {
+      _writeRuntime();
+      _syncTurnStateFromRoomMeta();
+    });
     _presenceSub = _conn.presenceStream.listen((_) => _writeRuntime());
     _onStatus(_conn.status); // replay current
   }
@@ -146,6 +150,7 @@ class SyncService extends Service {
     _chunkBuffer.clear();
     _chunkReplyTo = '';
     _workingReplyTo = null;
+    _sawRemoteWorking = false;
     _setQueuedText(null);
     // Session switch: the previous chat's in-flight sends are no longer ours
     // to confirm — drop their backstops so a stale timer can't fire later.
@@ -326,8 +331,11 @@ class SyncService extends Service {
     final epk = _activeEpk;
     if (epk == null) return;
     final room = _activeRoomId;
-    // Session wiped → any optimistic sends are moot; disarm their backstops.
+    // Session wiped → any optimistic sends/streaming/working state are moot.
     _cancelAllSendTimers();
+    _discardStreamingState();
+    _setQueuedText(null);
+    _setWorking(false);
     await _enqueue(() async {
       if (_activeEpk != epk || _activeRoomId != room) return;
       final box = await _boxes.msgsBox(epk, room);
@@ -871,6 +879,21 @@ class SyncService extends Service {
     if (!_queuedController.isClosed) _queuedController.add(text);
   }
 
+  void _syncTurnStateFromRoomMeta() {
+    final epk = _activeEpk;
+    if (epk == null) return;
+    final remoteWorking = _conn.isRoomWorking(epk, _activeRoomId);
+    if (remoteWorking) {
+      _sawRemoteWorking = true;
+      return;
+    }
+    if (_sawRemoteWorking && _working) {
+      _discardStreamingState();
+      _setWorking(false);
+    }
+    _sawRemoteWorking = false;
+  }
+
   void _setWorking(bool on, {String? preview, String? replyTo}) {
     _setActivity(
       on ? SessionActivity.working : SessionActivity.idle,
@@ -885,6 +908,7 @@ class SyncService extends Service {
       if (replyTo != null) _workingReplyTo = replyTo;
     } else {
       _workingReplyTo = null;
+      _sawRemoteWorking = false;
     }
     if (_working == on) return;
     _working = on;

--- a/app/lib/data/transport/connection_manager.dart
+++ b/app/lib/data/transport/connection_manager.dart
@@ -497,15 +497,17 @@ class ConnectionManager extends Service {
     // is viewing. Trust the live selection — never clobber it from a
     // lagging peer.roomId (fixes header=cwd-A, messages/sync=cwd-B).
     final samePeer = _activePeer?.remoteEpk == peer.remoteEpk;
-    if (samePeer) {
+    if (samePeer && _activePeer?.roomId != null) {
       _activePeer = peer.copyWith(roomId: _activeRoomId);
     } else {
+      // Keep a legacy peer unbound until room discovery can persist its
+      // canonical room. Assigning the implicit `main` here would make
+      // `_maybeAdoptLegacyRoom` treat it as already bound.
       _activePeer = peer;
       final boundRoom = peer.roomId ?? 'main';
       if (boundRoom != _activeRoomId) {
         _activeRoomId = boundRoom;
       }
-      _activePeer = peer.copyWith(roomId: _activeRoomId);
     }
     _emit(const StatusConnecting());
 

--- a/app/lib/data/transport/connection_manager.dart
+++ b/app/lib/data/transport/connection_manager.dart
@@ -483,7 +483,6 @@ class ConnectionManager extends Service {
     final token = CancelToken();
     _connectCancel = token;
     _connectInFlight = true;
-    _activePeer = peer;
     // Plan 17 fix — set the destination room from the persisted
     // PeerRecord BEFORE emitting StatusOnline so the very first send
     // after connect goes to the right (peer, room) on the relay. If
@@ -491,9 +490,22 @@ class ConnectionManager extends Service {
     // `_activeRoomId = 'main'` and rely on the discovery flow in
     // `_onControl` to learn the real room from a subsequent
     // `room_announced` push and then update _activeRoomId + persist.
-    final boundRoom = peer.roomId ?? 'main';
-    if (boundRoom != _activeRoomId) {
-      _activeRoomId = boundRoom;
+    //
+    // Same-peer reconnect (WS retry after backgrounding): the `peer`
+    // argument is often a stale capture from `_watchChannel` while
+    // `switchRoom` already moved `_activeRoomId` for the cwd the user
+    // is viewing. Trust the live selection — never clobber it from a
+    // lagging peer.roomId (fixes header=cwd-A, messages/sync=cwd-B).
+    final samePeer = _activePeer?.remoteEpk == peer.remoteEpk;
+    if (samePeer) {
+      _activePeer = peer.copyWith(roomId: _activeRoomId);
+    } else {
+      _activePeer = peer;
+      final boundRoom = peer.roomId ?? 'main';
+      if (boundRoom != _activeRoomId) {
+        _activeRoomId = boundRoom;
+      }
+      _activePeer = peer.copyWith(roomId: _activeRoomId);
     }
     _emit(const StatusConnecting());
 

--- a/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
+++ b/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
@@ -275,7 +275,14 @@ class ChatViewModel extends ViewModel<ChatState> {
   Future<void> approveTool(String toolCallId, ApproveDecision decision) =>
       _sync.approveTool(toolCallId, decision);
 
-  Future<void> clearActiveSession() => _sync.clearActiveSession();
+  Future<void> clearActiveSession() async {
+    _messages = const [];
+    _streaming = null;
+    _working = false;
+    _queuedText = null;
+    _recompute();
+    await _sync.clearActiveSession();
+  }
 
   Future<void> reconnect() async {
     final peer = _activePeer;

--- a/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
+++ b/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
@@ -205,7 +205,14 @@ class ChatViewModel extends ViewModel<ChatState> {
     final nowOnline = s is StatusOnline;
     _lastStatus = s;
     // Auto re-sync on a fresh online edge so the chat catches up.
-    if (nowOnline && !wasOnline) _sync.requestSync();
+    if (nowOnline && !wasOnline) {
+      // WS retry can snap ConnectionManager to a stale cwd — re-align
+      // before SessionSync so history + sends target THIS chat.
+      if (_conn.activeRoomId != _activeRoomId) {
+        _conn.switchRoom(_activeRoomId);
+      }
+      _sync.requestSync();
+    }
     _recompute();
   }
 

--- a/app/test/data/sync/sync_service_test.dart
+++ b/app/test/data/sync/sync_service_test.dart
@@ -17,16 +17,26 @@ import 'package:app/protocol/protocol.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
-class _FakeChannel implements IChannel {
+class _FakeChannel implements IChannel, IControlLink {
   final _ctrl = StreamController<ServerMessage>.broadcast();
+  final _control = StreamController<ControlInbound>.broadcast();
   final List<ClientMessage> sent = [];
   @override
   Stream<ServerMessage> get serverMessages => _ctrl.stream;
   @override
+  Stream<ControlInbound> get controlFrames => _control.stream;
+  @override
   Future<void> send(ClientMessage msg) async => sent.add(msg);
   @override
-  Future<void> close() => _ctrl.close();
+  void sendControl(Map<String, dynamic> json) {}
+  @override
+  Future<void> close() async {
+    await _ctrl.close();
+    await _control.close();
+  }
+
   void push(ServerMessage m) => _ctrl.add(m);
+  void pushControl(ControlInbound m) => _control.add(m);
 }
 
 class _FakeStorage extends PairingStorage {
@@ -59,6 +69,7 @@ void main() {
     final conn = ConnectionManager(
       factory: (_, _) async => ch,
       storage: _FakeStorage(),
+      emitDebounce: Duration.zero,
     );
     final boxes = LocalBoxes();
     final sync = SyncService(
@@ -608,19 +619,67 @@ void main() {
     s.sync.dispose();
   });
 
-  test('clearActiveSession wipes the rows + index', () async {
-    final s = await setup();
-    s.ch.push(UserInput(id: 'u1', text: 'hi'));
-    await _settle();
-    expect(messages(s.epk), hasLength(1));
+  test(
+    'clearActiveSession wipes rows, index, and in-memory turn state',
+    () async {
+      final s = await setup();
+      s.ch.push(UserInput(id: 'u1', text: 'hi'));
+      await _settle();
+      expect(messages(s.epk), hasLength(1));
+      expect(s.sync.isWorking, isTrue);
+      expect(s.sync.streaming, isNotNull);
 
-    await s.sync.clearActiveSession();
-    await _settle();
-    expect(messages(s.epk), isEmpty);
-    expect(index(s.epk), isNull);
-    s.conn.dispose();
-    s.sync.dispose();
-  });
+      await s.sync.clearActiveSession();
+      await _settle();
+      expect(messages(s.epk), isEmpty);
+      expect(index(s.epk), isNull);
+      expect(s.sync.isWorking, isFalse);
+      expect(s.sync.streaming, isNull);
+      s.conn.dispose();
+      s.sync.dispose();
+    },
+  );
+
+  test(
+    'relay working=false clears stale active-chat local working state',
+    () async {
+      final s = await setup();
+      s.ch.push(UserInput(id: 'u1', text: 'hi'));
+      await _settle();
+      expect(s.sync.isWorking, isTrue);
+
+      s.ch.pushControl(
+        RoomAnnounced(peer: s.epk, roomId: 'main', startedAt: 1),
+      );
+      s.ch.pushControl(
+        RoomMetaUpdated(
+          peer: s.epk,
+          roomId: 'main',
+          working: true,
+          hasModel: false,
+          hasThinking: false,
+        ),
+      );
+      await _settle();
+      expect(s.sync.isWorking, isTrue);
+
+      s.ch.pushControl(
+        RoomMetaUpdated(
+          peer: s.epk,
+          roomId: 'main',
+          working: false,
+          hasModel: false,
+          hasThinking: false,
+        ),
+      );
+      await _settle();
+      expect(s.conn.isRoomWorking(s.epk, 'main'), isFalse);
+      expect(s.sync.isWorking, isFalse);
+      expect(s.sync.streaming, isNull);
+      s.conn.dispose();
+      s.sync.dispose();
+    },
+  );
 
   // Plan/32 safety net — a sent message whose echo never comes back must not
   // spin forever; the optimistic bubble is removed SILENTLY after the timeout.

--- a/app/test/transport/connection_manager_test.dart
+++ b/app/test/transport/connection_manager_test.dart
@@ -1446,6 +1446,7 @@ void _registerRoomsTests() {
       expect(cm.activeRoomId, 'main');
       cm.switchRoom('room-xyz');
       expect(cm.activeRoomId, 'room-xyz');
+      expect(cm.activePeer?.roomId, 'room-xyz');
 
       // Same room is a no-op.
       cm.switchRoom('room-xyz');
@@ -1453,6 +1454,45 @@ void _registerRoomsTests() {
 
       cm.dispose();
     });
+
+    test(
+      'WS retry keeps switchRoom cwd — stale peer.roomId must not clobber',
+      () async {
+        const peerB = PeerRecord(
+          remoteEpk: 'epk_test',
+          sessionName: 'test session',
+          relayUrl: 'ws://localhost:8080',
+          pairedAt: '2026-01-01T00:00:00Z',
+          roomId: 'channel-B',
+        );
+        var idx = 0;
+        final ch1 = _ControllableChannel();
+        final ch2 = _ControllableChannel();
+        final cm = ConnectionManager(
+          factory: (_, _) async => idx++ == 0 ? ch1 : ch2,
+          storage: _FakeStorage([peerB]),
+          emitDebounce: Duration.zero,
+        );
+        await cm.connectTo(peerB);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(cm.activeRoomId, 'channel-B');
+
+        cm.switchRoom('channel-A');
+        expect(cm.activeRoomId, 'channel-A');
+        expect(cm.activePeer?.roomId, 'channel-A');
+
+        await ch1.closeStream();
+        // First retry backoff is 1s.
+        await Future<void>.delayed(const Duration(milliseconds: 1100));
+
+        expect(cm.activeRoomId, 'channel-A',
+            reason: 'retry must not snap back to stale peer.roomId');
+        expect(cm.activePeer?.roomId, 'channel-A');
+        expect(cm.status, isA<StatusOnline>());
+
+        cm.dispose();
+      },
+    );
   });
 }
 

--- a/app/test/transport/connection_manager_test.dart
+++ b/app/test/transport/connection_manager_test.dart
@@ -1223,6 +1223,8 @@ void _registerRoomsTests() {
         await Future<void>.delayed(const Duration(milliseconds: 10));
         expect(cm.activeRoomId, 'main',
             reason: 'no persisted roomId → falls back to main');
+        expect(cm.activePeer?.roomId, isNull,
+            reason: 'legacy peer must remain unbound until discovery');
 
         // Relay announces the real room for this peer.
         ch.pushControl(const RoomAnnounced(


### PR DESCRIPTION
## Problem
After putting android app to background, WS same-peer retry reused a stale `PeerRecord.roomId` and overwrote the live `switchRoom` cwd, then header showed one room while SessionSync/sends hit another.

## Summary
- Keep `_activeRoomId` on same-peer reconnect; don’t clobber from lagging `peer.roomId`.
- Re-align transport before SessionSync on the online edge.
- Regression test: retry must not snap back to stale `peer.roomId`.

tested: switch android app to background, resume on cwd A -- checked that header/messages/sync stay on A
