### PR TITLE
feat(pi-extension): show received image previews

### DIFF
--- a/pi-extension/package.json
+++ b/pi-extension/package.json
@@ -77,6 +77,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.79.10",
+    "@earendil-works/pi-tui": "^0.79.10",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
     "@noble/ed25519": "^3.1.0",

--- a/pi-extension/pnpm-lock.yaml
+++ b/pi-extension/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: ^0.79.10
         version: 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: ^0.79.10
+        version: 0.79.10
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -6,11 +6,14 @@
  */
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getCapabilities, setCapabilities } from "@earendil-works/pi-tui";
 import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-agent";
+
+const _convertToPngMock = vi.hoisted(() => vi.fn(async () => null));
 
 // ── Mock RelayClient ──────────────────────────────────────────────────────────
 
@@ -138,6 +141,11 @@ vi.mock("./pairing/qr.js", async (importOriginal) => {
       generateToken: vi.fn().mockReturnValue("test-token"),
     },
   };
+});
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+  return { ...orig, convertToPng: _convertToPngMock };
 });
 
 // Import AFTER mocks
@@ -845,6 +853,33 @@ function captureEventHandler(eventName: string): EventHandler {
   return captured;
 }
 
+function captureMessageRenderer(): {
+  getRenderer(): (message: { details?: unknown }, options: unknown, theme: unknown) => unknown;
+} {
+  let renderer: ((message: { details?: unknown }, options: unknown, theme: unknown) => unknown) | undefined;
+  const pi = {
+    on() { /* no-op */ },
+    registerCommand: () => undefined,
+    registerTool: () => undefined, registerShortcut: () => undefined,
+    registerFlag: () => undefined, getFlag: () => undefined,
+    registerMessageRenderer(type: string, callback: unknown) {
+      if (type === "remote-pi:received-image") {
+        renderer = callback as (message: { details?: unknown }, options: unknown, theme: unknown) => unknown;
+      }
+    },
+    sendMessage: () => undefined,
+    sendUserMessage: () => undefined,
+  } as unknown as ExtensionAPI;
+  (extension as ExtensionFactory)(pi);
+  if (!renderer) throw new Error("custom image renderer not registered");
+  return {
+    getRenderer(): (message: { details?: unknown }, options: unknown, theme: unknown) => unknown {
+      if (!renderer) throw new Error("custom image renderer not registered");
+      return renderer;
+    },
+  };
+}
+
 async function _pairForTest(appPeerId: string): Promise<void> {
   captureHandler("remote-pi");
   await _connectForTest(makeMockCtx());
@@ -1046,39 +1081,321 @@ describe("multi-channel broadcast (W2D)", () => {
     expect(recipients).toEqual(new Set(["ownerA__1234567890", "ownerB__abcdefghij"]));
   });
 
-  test("plan/30: user_message with an image → sendUserMessage gets ImageContent+TextContent; echo carries images", async () => {
+  test("plan/30: user_message with an image → save preview + send metadata-only custom message", async () => {
     await _pairForTest("ownerA__1234567890");
     // Override _pi with a spy to capture the multimodal content sent to the SDK.
     const sentToAgent: unknown[] = [];
+    const sentMessages: Array<[unknown, ...unknown[]]> = [];
+    const timeline: string[] = [];
+    const messageId = "msg with spaces/and##symbols";
     _setPiForTest({
-      sendUserMessage: (c: unknown) => { sentToAgent.push(c); },
-      sendMessage: () => undefined,
+      sendUserMessage: (c: unknown) => { timeline.push("agent"); sentToAgent.push(c); },
+      sendMessage: (...messageArgs) => { timeline.push("preview"); sentMessages.push(messageArgs); },
     });
     const sendsBefore = relayRef.current!.send.mock.calls.length;
 
     relayRef.current!.emit("message", JSON.stringify({
       peer: "ownerA__1234567890",
       ct: Buffer.from(JSON.stringify({
-        type: "user_message", id: "msg-img", text: "what is this?",
-        images: [{ data: "QUJD", mime: "image/jpeg" }],
+        type: "user_message",
+        id: messageId,
+        text: "what is this?",
+        images: [{ data: "QUJD", mime: "image/png" }],
       })).toString("base64"),
     }));
     await new Promise<void>((r) => setImmediate(r));
 
-    // (a) the agent received image-first, then the caption text.
+    // Preview is appended before SDK handoff so it cannot steer this turn.
+    expect(timeline).toEqual(["preview", "agent"]);
     expect(sentToAgent).toHaveLength(1);
     expect(sentToAgent[0]).toEqual([
-      { type: "image", data: "QUJD", mimeType: "image/jpeg" },
+      { type: "image", data: "QUJD", mimeType: "image/png" },
       { type: "text", text: "what is this?" },
     ]);
+
+    const previewCall = sentMessages.find((message) => {
+      const current = message[0] as { customType?: unknown };
+      return current.customType === "remote-pi:received-image";
+    });
+    const preview = previewCall?.[0] as { content?: string; display?: boolean; details?: { messageId?: string; mime?: string; path?: string; size?: number; index?: number; text?: string; error?: string; reason?: string } } | undefined;
+    expect(preview).toBeDefined();
+    expect(previewCall?.[1]).toBeUndefined();
+    expect(preview?.content).toBe("");
+    expect(preview?.display).toBe(true);
+    expect(preview?.details).toMatchObject({
+      messageId,
+      index: 0,
+      mime: "image/png",
+      size: 3,
+      text: "what is this?",
+    });
+    expect(preview?.details).not.toHaveProperty("data");
+    expect(preview?.details?.error).toBeUndefined();
+    expect(preview?.details?.reason).toBeUndefined();
+
+    const expectedBasename = "msg-with-spaces-and-symbols-0.png";
+    expect(preview?.details?.path).toContain(tmpdir());
+    expect(preview?.details?.path).toContain("pi-app-");
+    expect(readFileSync(preview!.details!.path!, "utf8")).toBe("ABC");
+    expect(basename(preview?.details?.path ?? "")).toBe(expectedBasename);
+    if (preview?.details?.path && process.platform !== "win32") {
+      const st = statSync(preview.details.path);
+      expect(st.mode & 0o777).toBe(0o600);
+      const stDir = statSync(dirname(preview.details.path));
+      expect(stDir.mode & 0o777).toBe(0o700);
+    }
+
     // The echo carries `images` so other owners render the bubble.
     const sent = relayRef.current!.send.mock.calls.slice(sendsBefore)
       .map((c) => c[0] as string).map(decodeSentCt);
     const echo = sent.find((d) => d.inner.type === "user_message");
     expect(echo?.inner).toMatchObject({
-      type: "user_message", id: "msg-img", text: "what is this?",
-      images: [{ data: "QUJD", mime: "image/jpeg" }],
+      type: "user_message", id: messageId, text: "what is this?",
+      images: [{ data: "QUJD", mime: "image/png" }],
     });
+  });
+
+  test("JPEG user_message generates optional private PNG preview when converter is available", async () => {
+    _convertToPngMock.mockResolvedValueOnce({ data: "iVBORw0KGgo=", mimeType: "image/png" });
+
+    await _pairForTest("ownerA__1234567890");
+    const sentMessages: Array<[unknown, ...unknown[]]> = [];
+    _setPiForTest({
+      sendUserMessage: () => undefined,
+      sendMessage: (...messageArgs) => { sentMessages.push(messageArgs); },
+    });
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "user_message",
+        id: "jpeg-msg",
+        text: "jpeg caption",
+        images: [{ data: "QUJD", mime: "image/jpeg" }],
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+
+    const previewCall = sentMessages.find((message) => {
+      const current = message[0] as { customType?: unknown };
+      return current.customType === "remote-pi:received-image";
+    });
+    const preview = previewCall?.[0] as { details?: { path?: string; previewPath?: string } } | undefined;
+    const previewPath = preview?.details?.previewPath;
+    expect(preview?.details?.path).toContain("jpeg-msg-0.jpg");
+    expect(previewPath).toContain("jpeg-msg-0.preview.png");
+    expect(readFileSync(previewPath!)).toEqual(Buffer.from("89504e470d0a1a0a", "hex"));
+    if (process.platform !== "win32") {
+      expect(statSync(previewPath!).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  test("converted preview output over 10 MiB falls back to saved original only", async () => {
+    _convertToPngMock.mockResolvedValueOnce({
+      data: Buffer.alloc(10 * 1024 * 1024 + 1).toString("base64"),
+      mimeType: "image/png",
+    });
+
+    await _pairForTest("ownerA__1234567890");
+    const sentMessages: Array<[unknown, ...unknown[]]> = [];
+    _setPiForTest({
+      sendUserMessage: () => undefined,
+      sendMessage: (...messageArgs) => { sentMessages.push(messageArgs); },
+    });
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "user_message",
+        id: "jpeg-big-preview",
+        text: "jpeg caption",
+        images: [{ data: "QUJD", mime: "image/jpeg" }],
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+
+    const previewCall = sentMessages.find((message) => {
+      const current = message[0] as { customType?: unknown };
+      return current.customType === "remote-pi:received-image";
+    });
+    const preview = previewCall?.[0] as { details?: { path?: string; previewPath?: string } } | undefined;
+    expect(preview?.details?.path).toContain("jpeg-big-preview-0.jpg");
+    expect(preview?.details?.previewPath).toBeUndefined();
+  });
+
+  test("active image steering defers local preview until agent_end", async () => {
+    await _pairForTest("ownerA__1234567890");
+    const onInput = captureEventHandler("input");
+    const onAgentEnd = captureEventHandler("agent_end");
+    onInput({ type: "input", text: "already running", source: "interactive" });
+
+    const sentToAgent: unknown[] = [];
+    const sentMessages: Array<[unknown, ...unknown[]]> = [];
+    _setPiForTest({
+      sendUserMessage: (content: unknown) => { sentToAgent.push(content); },
+      sendMessage: (...messageArgs) => { sentMessages.push(messageArgs); },
+    });
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "user_message",
+        id: "steer-image",
+        text: "extra photo",
+        streaming_behavior: "steer",
+        images: [{ data: "QUJD", mime: "image/png" }],
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(sentToAgent).toHaveLength(1);
+    expect(sentMessages).toHaveLength(0);
+
+    onAgentEnd({ type: "agent_end", messages: [] });
+    expect(sentMessages).toHaveLength(1);
+    expect((sentMessages[0][0] as { customType?: unknown }).customType).toBe("remote-pi:received-image");
+  });
+
+  test("slow idle JPEG conversion defers preview if another turn starts first", async () => {
+    let resolveConversion: ((value: { data: string; mimeType: string }) => void) | undefined;
+    _convertToPngMock.mockReturnValueOnce(new Promise((resolve) => {
+      resolveConversion = resolve;
+    }));
+
+    await _pairForTest("ownerA__1234567890");
+    const onInput = captureEventHandler("input");
+    const onAgentEnd = captureEventHandler("agent_end");
+    const sentMessages: Array<[unknown, ...unknown[]]> = [];
+    _setPiForTest({
+      sendUserMessage: () => undefined,
+      sendMessage: (...messageArgs) => { sentMessages.push(messageArgs); },
+    });
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "user_message",
+        id: "slow-jpeg",
+        text: "slow photo",
+        images: [{ data: "QUJD", mime: "image/jpeg" }],
+      })).toString("base64"),
+    }));
+    await vi.waitFor(() => expect(_convertToPngMock).toHaveBeenCalled());
+
+    onInput({ type: "input", text: "overtaking local turn", source: "interactive" });
+    resolveConversion?.({ data: "iVBORw0KGgo=", mimeType: "image/png" });
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(sentMessages).toHaveLength(0);
+
+    onAgentEnd({ type: "agent_end", messages: [] });
+    expect(sentMessages).toHaveLength(1);
+    expect((sentMessages[0][0] as { customType?: unknown }).customType).toBe("remote-pi:received-image");
+  });
+
+  test("received-image preview messages are filtered out of provider and compaction context", () => {
+    const previewMessage = { role: "custom", customType: "remote-pi:received-image", content: "", display: true, details: { path: "/tmp/photo.png" } };
+    const keepCustom = { role: "custom", customType: "remote-pi:mesh-message", content: "keep", display: true };
+    const keepUser = { role: "user", content: "hello" };
+
+    const onContext = captureEventHandler("context");
+    const result = onContext({
+      type: "context",
+      messages: [keepCustom, previewMessage, keepUser],
+    }) as { messages?: unknown[] };
+    expect(result.messages).toEqual([keepCustom, keepUser]);
+
+    const onBeforeCompact = captureEventHandler("session_before_compact");
+    const preparation = {
+      messagesToSummarize: [previewMessage, keepUser],
+      turnPrefixMessages: [keepCustom, previewMessage],
+    };
+    onBeforeCompact({
+      type: "session_before_compact",
+      preparation,
+      branchEntries: [],
+      reason: "manual",
+      willRetry: false,
+      signal: new AbortController().signal,
+    });
+    expect(preparation.messagesToSummarize).toEqual([keepUser]);
+    expect(preparation.turnPrefixMessages).toEqual([keepCustom]);
+  });
+
+  test("registers and uses remote-pi image renderer with Saved fallback", () => {
+    const { getRenderer } = captureMessageRenderer();
+    const theme = {
+      fg: (token: string, text: string) => `${token}:${text}`,
+      bg: (token: string, text: string) => `${token}:${text}`,
+    };
+    const dir = mkdtempSync(join(tmpdir(), "pi-ext-render-missing-"));
+    const message = {
+      customType: "remote-pi:received-image",
+      content: "",
+      display: true,
+      details: {
+        messageId: "msg-missing",
+        index: 2,
+        path: join(dir, "missing.png"),
+        mime: "image/png",
+        size: 123,
+        error: "missing file",
+        reason: "not present on disk",
+      },
+    };
+    const renderer = getRenderer();
+    const component = renderer(message, { expanded: false }, theme);
+    const rendered = (component as { render: (width: number) => string[] }).render(120).join("\n");
+    expect(rendered).toContain("📷 Photo from Android (msg-missing #2)");
+    expect(rendered).toContain("Saved: ");
+    expect(rendered).toContain(message.details.path);
+    expect(rendered).toContain("Error: missing file");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("renders JPEG inline when previewPath points to generated PNG", () => {
+    const { getRenderer } = captureMessageRenderer();
+    const theme = {
+      fg: (token: string, text: string) => `${token}:${text}`,
+      bg: (token: string, text: string) => `${token}:${text}`,
+    };
+    const dir = mkdtempSync(join(tmpdir(), "pi-ext-render-jpeg-preview-"));
+    const imagePath = join(dir, "photo.jpg");
+    const previewPath = join(dir, "photo.preview.png");
+
+    writeFileSync(imagePath, Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x46, 0x49, 0x46]));
+    writeFileSync(previewPath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+
+    const prevCaps = getCapabilities();
+    const message = {
+      customType: "remote-pi:received-image",
+      content: "",
+      display: true,
+      details: {
+        messageId: "msg-jpeg-preview",
+        index: 2,
+        path: imagePath,
+        previewPath,
+        mime: "image/jpeg",
+        size: 10,
+      },
+    };
+    setCapabilities({ ...prevCaps, images: "kitty" as const });
+
+    try {
+      const renderer = getRenderer();
+      const component = renderer(message, { expanded: false }, theme);
+      const renderedLines = (component as { render: (width: number) => string[] }).render(120);
+      const rendered = renderedLines.join("\n");
+      const imageLineIndex = renderedLines.findIndex((line) => line.includes("\x1b_G"));
+      expect(rendered).toContain("📷 Photo from Android (msg-jpeg-preview #2)");
+      expect(imageLineIndex).toBeGreaterThanOrEqual(0);
+      expect(renderedLines.slice(imageLineIndex + 1).some((line) => line === "")).toBe(true);
+      expect(rendered).toContain(imagePath);
+    } finally {
+      setCapabilities(prevCaps);
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("plan/30: user_message without images → no `images` key on the echo (text path unchanged)", async () => {

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -37,7 +37,7 @@ import type {
   ExtensionContext,
   ExtensionFactory,
 } from "@earendil-works/pi-coding-agent";
-import { SettingsManager } from "@earendil-works/pi-coding-agent";
+import { SettingsManager, convertToPng } from "@earendil-works/pi-coding-agent";
 import { type Ed25519Keypair } from "./pairing/crypto.js";
 import { buildQRUri, qrSession, renderQRAscii, clampPairTtlMs, TOKEN_TTL_MS } from "./pairing/qr.js";
 import {
@@ -99,7 +99,7 @@ import { runSetupWizard, type WizardUI } from "./session/setup_wizard.js";
 import { updateFooter, type FooterState } from "./ui/footer.js";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdirSync, copyFileSync, existsSync, unlinkSync, readFileSync, writeFileSync, realpathSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, copyFileSync, existsSync, unlinkSync, readFileSync, writeFileSync, realpathSync } from "node:fs";
 import { createInterface } from "node:readline";
 import { spawnSync } from "node:child_process";
 import { hostname, tmpdir } from "node:os";
@@ -111,6 +111,7 @@ import {
   isWebSocketScheme,
   toWebSocketUrl,
 } from "./config.js";
+import { Box, Container, Image, Text } from "@earendil-works/pi-tui";
 
 // ── State machine ─────────────────────────────────────────────────────────────
 //
@@ -160,6 +161,52 @@ let _relayUrl: string | null = null;  // URL used by current _relay connection
  */
 const _activePeers = new Map<string, PlainPeerChannel>();
 let _peerShort = "";  // shortid of the most recently attached peer (UX hint only)
+
+const REMOTE_PI_RECEIVED_IMAGE_TYPE = "remote-pi:received-image";
+const RECEIVED_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+type ReceivedImageDetails = {
+  messageId: string;
+  index: number;
+  mime: string;
+  size?: number;
+  path?: string;
+  previewPath?: string;
+  text?: string;
+  error?: string;
+  reason?: string;
+};
+
+const IMAGE_PREVIEW_MIME = "image/png";
+const IMAGE_CACHE_PREFIX = "pi-app-";
+type ReceivedImagePreviewDelivery = "immediate" | "defer";
+let _imageCacheDir: string | undefined;
+const _pendingReceivedImagePreviews: ReceivedImageDetails[] = [];
+
+function _isBase64Char(code: number): boolean {
+  return (code >= 48 && code <= 57) // 0-9
+    || (code >= 65 && code <= 90) // A-Z
+    || (code >= 97 && code <= 122) // a-z
+    || code === 43 // +
+    || code === 47; // /
+}
+
+function _isStrictBase64(data: string): boolean {
+  if (data.length === 0 || data.length % 4 !== 0) return false;
+  if (data.startsWith("=")) return false;
+
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  for (let i = 0; i < data.length; i += 1) {
+    const code = data.charCodeAt(i);
+    if (i >= data.length - padding) {
+      if (code !== 61) return false;
+      continue;
+    }
+    if (!_isBase64Char(code)) return false;
+  }
+
+  return true;
+}
 
 let _myRoomId: string | null = null;   // this Pi's room id (derived from cwd)
 // Plan/28 Wave D.1: `thinking` published alongside `model` so the app's
@@ -265,6 +312,375 @@ function _publishWorking(working: boolean): void {
   if (_relay && _myRoomId) {
     _relay.sendControl({ type: "room_meta_update", room_id: _myRoomId, meta: { working } });
   }
+}
+
+function _imageCacheRootDir(): string {
+  if (_imageCacheDir) {
+    try { mkdirSync(_imageCacheDir, { recursive: true, mode: 0o700 }); } catch {}
+    try { chmodSync(_imageCacheDir, 0o700); } catch {}
+    return _imageCacheDir;
+  }
+  const dir = mkdtempSync(join(tmpdir(), IMAGE_CACHE_PREFIX));
+  try { chmodSync(dir, 0o700); } catch {}
+  _imageCacheDir = dir;
+  return dir;
+}
+
+function _imageExtension(mime: string): string | undefined {
+  if (mime === "image/jpeg") return "jpg";
+  if (mime === "image/png") return "png";
+  if (mime === "image/webp") return "webp";
+  if (mime === "image/gif") return "gif";
+  return undefined;
+}
+
+function _safeFilenameToken(value: string): string {
+  return value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    || "message";
+}
+
+function _safePreviewPath(dir: string, messageId: string, index: number): string {
+  return join(dir, `${_safeFilenameToken(messageId)}-${index}.preview.png`);
+}
+
+function _cleanupPreviewFile(previewPath: string): void {
+  try {
+    if (existsSync(previewPath)) unlinkSync(previewPath);
+  } catch {
+    // best effort
+  }
+}
+
+async function _renderablePngPathFromImage(
+  imageData: string,
+  mime: string,
+  previewPath: string,
+): Promise<string | undefined> {
+  if (mime === IMAGE_PREVIEW_MIME) return undefined;
+
+  try {
+    const converted = await convertToPng(imageData, mime);
+    if (!converted || converted.mimeType !== IMAGE_PREVIEW_MIME || !converted.data) {
+      return undefined;
+    }
+
+    const previewBytes = Buffer.from(converted.data, "base64");
+    if (previewBytes.length === 0 || previewBytes.length > RECEIVED_IMAGE_MAX_BYTES) {
+      return undefined;
+    }
+
+    try {
+      writeFileSync(previewPath, previewBytes, { mode: 0o600 });
+      try { chmodSync(previewPath, 0o600); } catch {}
+      return previewPath;
+    } catch {
+      _cleanupPreviewFile(previewPath);
+    }
+  } catch {
+    _cleanupPreviewFile(previewPath);
+  }
+
+  return undefined;
+}
+
+function _decodeImagePayload(data: string, mime: string): { ok: true; decoded: Buffer; size: number } | { ok: false; reason: string } {
+  if (!_imageExtension(mime)) return { ok: false, reason: `unsupported mime: ${mime}` };
+  if (data.startsWith("data:")) return { ok: false, reason: "data URI payloads are not supported" };
+  if (!_isStrictBase64(data)) return { ok: false, reason: "invalid base64 payload" };
+
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  const estimate = (data.length / 4) * 3 - padding;
+  if (estimate > RECEIVED_IMAGE_MAX_BYTES) {
+    return { ok: false, reason: `image too large (${estimate} bytes)` };
+  }
+
+  const decoded = Buffer.from(data, "base64");
+  if (decoded.length === 0 || decoded.length > RECEIVED_IMAGE_MAX_BYTES) {
+    return { ok: false, reason: `invalid decoded image size (${decoded.length} bytes)` };
+  }
+
+  return { ok: true, decoded, size: decoded.length };
+}
+
+function _sendReceivedImagePreviewNow(details: ReceivedImageDetails): void {
+  if (!_pi) return;
+  try {
+    _pi.sendMessage<ReceivedImageDetails>({
+      customType: REMOTE_PI_RECEIVED_IMAGE_TYPE,
+      content: "",
+      display: true,
+      details,
+    });
+  } catch {
+    // TUI preview is best-effort; skip on failure.
+  }
+}
+
+function _shouldDeferReceivedImagePreview(): boolean {
+  return _currentTurnId !== null || _myRoomMeta?.working === true;
+}
+
+function _sendReceivedImagePreview(
+  details: ReceivedImageDetails,
+  delivery: ReceivedImagePreviewDelivery = "immediate",
+): void {
+  if (delivery === "defer" || _shouldDeferReceivedImagePreview()) {
+    _pendingReceivedImagePreviews.push(details);
+    return;
+  }
+  _sendReceivedImagePreviewNow(details);
+}
+
+function _flushPendingReceivedImagePreviews(): void {
+  if (_pendingReceivedImagePreviews.length === 0) return;
+  const pending = _pendingReceivedImagePreviews.splice(0);
+  for (const details of pending) _sendReceivedImagePreviewNow(details);
+}
+
+async function _collectReceivedImagePreviews(msg: ClientUserMessage): Promise<ReceivedImageDetails[]> {
+  if (!msg.images || msg.images.length === 0) return [];
+
+  const previews: ReceivedImageDetails[] = [];
+  const text = typeof msg.text === "string" ? msg.text : "";
+  const dir = _imageCacheRootDir();
+
+  for (let i = 0; i < msg.images.length; i += 1) {
+    const image = msg.images[i];
+    const mime = typeof image?.mime === "string" ? image.mime : "unknown";
+
+    if (!image || typeof image.data !== "string") {
+      console.error(`[remote-pi] malformed image in message ${msg.id} index=${i}`);
+      previews.push({
+        messageId: msg.id,
+        index: i,
+        mime,
+        ...(text ? { text } : {}),
+        error: "malformed image payload",
+        reason: "missing mime/data payload fields",
+      });
+      continue;
+    }
+
+    const decoded = _decodeImagePayload(image.data, image.mime);
+    if (!decoded.ok) {
+      console.error(`[remote-pi] skipped image id=${msg.id} index=${i}: ${decoded.reason}`);
+      previews.push({
+        messageId: msg.id,
+        index: i,
+        mime: image.mime,
+        ...(text ? { text } : {}),
+        error: "invalid image payload",
+        reason: decoded.reason,
+      });
+      continue;
+    }
+
+    const ext = _imageExtension(image.mime);
+    if (!ext) {
+      console.error(`[remote-pi] unsupported image mime in message ${msg.id} index=${i}: ${image.mime}`);
+      previews.push({
+        messageId: msg.id,
+        index: i,
+        mime: image.mime,
+        ...(text ? { text } : {}),
+        error: "invalid image payload",
+        reason: `unsupported mime: ${image.mime}`,
+      });
+      continue;
+    }
+
+    const filename = `${_safeFilenameToken(msg.id)}-${i}.${ext}`;
+    const path = join(dir, filename);
+
+    try {
+      writeFileSync(path, decoded.decoded, { mode: 0o600 });
+      try { chmodSync(path, 0o600); } catch {}
+
+      const previewPath =
+        image.mime === IMAGE_PREVIEW_MIME
+          ? undefined
+          : await _renderablePngPathFromImage(
+              image.data,
+              image.mime,
+              _safePreviewPath(dir, msg.id, i),
+            );
+
+      previews.push({
+        messageId: msg.id,
+        index: i,
+        mime: image.mime,
+        size: decoded.size,
+        path,
+        ...(previewPath ? { previewPath } : {}),
+        ...(text ? { text } : {}),
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(`[remote-pi] failed saving image id=${msg.id} index=${i}: ${detail}`);
+      previews.push({
+        messageId: msg.id,
+        index: i,
+        mime: image.mime,
+        ...(text ? { text } : {}),
+        path,
+        error: "failed to save image",
+        reason: detail,
+      });
+    }
+  }
+
+  return previews;
+}
+
+async function _emitReceivedImagePreviews(
+  msg: ClientUserMessage,
+  delivery: ReceivedImagePreviewDelivery = "immediate",
+): Promise<void> {
+  const previews = await _collectReceivedImagePreviews(msg);
+  for (const preview of previews) _sendReceivedImagePreview(preview, delivery);
+}
+
+function _registerReceivedImageRenderer(pi: ExtensionAPI): void {
+  pi.registerMessageRenderer<ReceivedImageDetails>(
+    REMOTE_PI_RECEIVED_IMAGE_TYPE,
+    (message, _options, theme) => {
+      const details = (message.details ?? {}) as Partial<ReceivedImageDetails>;
+      const path = typeof details.path === "string" ? details.path : "";
+      const previewPath = typeof details.previewPath === "string" ? details.previewPath : "";
+      const mime = typeof details.mime === "string" ? details.mime : "application/octet-stream";
+      const inlineImagePath = previewPath.length > 0
+        ? previewPath
+        : (mime === IMAGE_PREVIEW_MIME ? path : "");
+      const size = typeof details.size === "number" ? details.size : undefined;
+      const index = typeof details.index === "number" ? details.index : undefined;
+      const text = typeof details.text === "string" ? details.text.trim() : "";
+      const messageId = typeof details.messageId === "string" ? details.messageId : "unknown";
+      const error = typeof details.error === "string" ? details.error : undefined;
+      const reason = typeof details.reason === "string" ? details.reason : undefined;
+
+      const label = `📷 Photo from Android (${messageId}${index !== undefined ? ` #${index}` : ""})`;
+      const lines = [
+        theme.fg("customMessageLabel", label),
+        theme.fg("customMessageText", `Saved: ${path || "(not saved)"}`),
+      ];
+      if (size !== undefined) lines.push(theme.fg("customMessageText", `Size: ${size} bytes`));
+      if (mime) lines.push(theme.fg("customMessageText", `MIME: ${mime}`));
+      if (error) lines.push(theme.fg("customMessageText", `Error: ${error}`));
+      if (reason) lines.push(theme.fg("customMessageText", `Reason: ${reason}`));
+      if (text) lines.push(theme.fg("customMessageText", `Text: ${text}`));
+
+      const container = new Container();
+      const metadata = new Box(1, 1, (line) => theme.bg("customMessageBg", line));
+      metadata.addChild(new Text(lines.join("\n")));
+      container.addChild(metadata);
+
+      if (inlineImagePath && !error) {
+        try {
+          const imageData = readFileSync(inlineImagePath).toString("base64");
+          if (imageData.length > 0) {
+            const image = new Image(imageData, IMAGE_PREVIEW_MIME, {
+              fallbackColor: (str) => theme.fg("customMessageText", str),
+            });
+            // Keep Kitty image rows out of Box padding/background so pi-tui can
+            // preserve the empty reserved rows that make inline images visible.
+            container.addChild(image);
+          }
+        } catch {
+          // Keep the metadata-only fallback on any IO/terminal issue.
+        }
+      }
+
+      return container;
+    },
+  );
+}
+
+function _isReceivedImageContextMessage(message: unknown): boolean {
+  return typeof message === "object"
+    && message !== null
+    && (message as { role?: unknown }).role === "custom"
+    && (message as { customType?: unknown }).customType === REMOTE_PI_RECEIVED_IMAGE_TYPE;
+}
+
+function _filterReceivedImageMessagesFromContext<T>(messages: T[] | undefined): T[] {
+  return Array.isArray(messages)
+    ? messages.filter((message) => !_isReceivedImageContextMessage(message))
+    : [];
+}
+
+function _contentFromUserMessage(
+  msg: ClientUserMessage,
+): Parameters<ExtensionAPI["sendUserMessage"]>[0] {
+  return msg.images && msg.images.length > 0
+    ? [
+        ...msg.images.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mime })),
+        { type: "text" as const, text: msg.text },
+      ]
+    : msg.text;
+}
+
+function _echoUserMessage(msg: ClientUserMessage, forceSteer = false): void {
+  _broadcastToActive({
+    type: "user_message",
+    id: msg.id,
+    text: msg.text,
+    ...(msg.images && msg.images.length > 0 ? { images: msg.images } : {}),
+    ...(forceSteer || msg.streaming_behavior === "steer"
+      ? { streaming_behavior: "steer" as const }
+      : {}),
+  });
+}
+
+async function _deliverImageUserMessage(
+  sender: PlainPeerChannel,
+  msg: ClientUserMessage,
+  shouldSteer: boolean,
+): Promise<void> {
+  const previewDelivery: ReceivedImagePreviewDelivery =
+    shouldSteer || _currentTurnId !== null || _myRoomMeta?.working === true
+      ? "defer"
+      : "immediate";
+  const emitPreview = async () => {
+    try {
+      await _emitReceivedImagePreviews(msg, previewDelivery);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(`[remote-pi] failed emitting image preview id=${msg.id}: ${detail}`);
+    }
+  };
+  if (previewDelivery === "immediate") {
+    await emitPreview();
+  } else {
+    void emitPreview().finally(() => {
+      if (!_shouldDeferReceivedImagePreview()) _flushPendingReceivedImagePreviews();
+    });
+  }
+
+  const previousTurnId = _currentTurnId;
+  const seededTurnId = !shouldSteer || _currentTurnId === null;
+  if (seededTurnId) _currentTurnId = msg.id;
+
+  const wake = _wakeAgent(
+    _contentFromUserMessage(msg),
+    `app user_message id=${msg.id} (+${msg.images?.length ?? 0} image)`,
+    "steer",
+  );
+  if (!wake.ok) {
+    if (seededTurnId) _currentTurnId = previousTurnId;
+    sender.send({
+      type: "error",
+      code: "internal_error",
+      in_reply_to: msg.id,
+      message: `Agent rejected incoming message: ${wake.detail}`,
+    });
+    return;
+  }
+
+  _echoUserMessage(msg, shouldSteer);
 }
 
 // ── Cross-PC mesh wiring (plan/25 Wave B/C) ───────────────────────────────────
@@ -442,6 +858,8 @@ function _persistModelDefault(provider: string, modelId: string): void {
     writeFileSync(path, JSON.stringify(obj, null, 2));
   } catch { /* best-effort — model change already applied live */ }
 }
+
+type ClientUserMessage = Extract<ClientMessage, { type: "user_message" }>;
 
 // Per-turn messaging state
 let _currentTurnId: string | null = null;
@@ -686,6 +1104,7 @@ function _goIdle(byeReason?: import("./protocol/types.js").ByeReason): void {
   _activePeers.clear();
   _peerShort = "";
   _currentTurnId = null;
+  _pendingReceivedImagePreviews.length = 0;
 
   _relay?.close();
   _relay = null;
@@ -1285,6 +1704,15 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // session network natively. Getter captures `_meshNode` live so the
   // tool always sees the current state.
   registerAgentTools(pi, () => _meshNode?.peer() ?? null);
+  _registerReceivedImageRenderer(pi);
+
+  // Received-image preview entries are for local TUI display only. Pi's custom
+  // messages normally become user-role LLM context, so strip this type before
+  // every provider request; the actual Android image still reaches the model via
+  // the paired sendUserMessage call.
+  pi.on("context", (event) => ({
+    messages: _filterReceivedImageMessagesFromContext(event.messages),
+  }));
 
   // Tool calls execute without prompting the remote user. The Pi SDK has no
   // native `requiresApproval` per tool, and a hardcoded gate (Bash/Edit/Write)
@@ -1413,9 +1841,11 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   pi.on("agent_end", () => {
     // Buffer is fed by `message_end`; here we only finalize the outbound
     // turn signal to every connected owner. No buffer mutation.
-    if (!_anyPeerActive() || !_currentTurnId) return;
-    _broadcastToActive({ type: "agent_done", in_reply_to: _currentTurnId });
-    _currentTurnId = null;
+    if (_anyPeerActive() && _currentTurnId) {
+      _broadcastToActive({ type: "agent_done", in_reply_to: _currentTurnId });
+      _currentTurnId = null;
+    }
+    _flushPendingReceivedImagePreviews();
   });
 
   // plan/34: the broker no longer gates delivery on busy state, so we no
@@ -1455,7 +1885,15 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // Plan/32: compaction feedback. compact() doesn't run a turn, so bracket it
   // with working=true/false here. Returning void = no veto → default
   // compaction proceeds.
-  pi.on("session_before_compact", () => {
+  pi.on("session_before_compact", (event) => {
+    if (event.preparation) {
+      event.preparation.messagesToSummarize = _filterReceivedImageMessagesFromContext(
+        event.preparation.messagesToSummarize,
+      );
+      event.preparation.turnPrefixMessages = _filterReceivedImageMessagesFromContext(
+        event.preparation.turnPrefixMessages,
+      );
+    }
     _publishWorking(true);
   });
   pi.on("session_compact", (event) => {
@@ -3272,27 +3710,26 @@ export function _routeClientMessageFrom(
       // room is already working. Tell the SDK this is steering; otherwise it
       // rejects the message as a normal busy prompt. Seed a fallback id so
       // later chunks/done have a target instead of being dropped.
+      if (msg.images && msg.images.length > 0) {
+        void _deliverImageUserMessage(sender, msg, shouldSteer).catch((error) => {
+          const detail = error instanceof Error ? error.message : String(error);
+          console.error(`[remote-pi] failed delivering image message id=${msg.id}: ${detail}`);
+        });
+        break;
+      }
+
       const previousTurnId = _currentTurnId;
       const seededTurnId = !shouldSteer || _currentTurnId === null;
       if (seededTurnId) {
         _currentTurnId = msg.id;
       }
-      const content: Parameters<ExtensionAPI["sendUserMessage"]>[0] =
-        msg.images && msg.images.length > 0
-          ? [
-              ...msg.images.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mime })),
-              { type: "text" as const, text: msg.text },
-            ]
-          : msg.text;
       // Always include a streaming delivery mode for app-originated messages.
       // The SDK ignores `deliverAs` when idle, but requires it when a turn is
       // already running. This avoids a race where Remote Pi's mirror has not
       // seen turn_start/currentTurnId yet but the SDK is already busy.
       const wake = _wakeAgent(
-        content,
-        msg.images && msg.images.length > 0
-          ? `app user_message id=${msg.id} (+${msg.images.length} image)`
-          : `app user_message id=${msg.id}`,
+        msg.text,
+        `app user_message id=${msg.id}`,
         "steer",
       );
       if (!wake.ok) {
@@ -3305,14 +3742,7 @@ export function _routeClientMessageFrom(
         });
         break;
       }
-      const echo: ServerMessage = {
-        type: "user_message",
-        id: msg.id,
-        text: msg.text,
-        ...(msg.images && msg.images.length > 0 ? { images: msg.images } : {}),
-        ...(shouldSteer ? { streaming_behavior: "steer" as const } : {}),
-      };
-      _broadcastToActive(echo);
+      _echoUserMessage(msg, shouldSteer);
       break;
     }
     case "approve_tool":

--- a/pi-extension/src/session/global_config.ts
+++ b/pi-extension/src/session/global_config.ts
@@ -3,10 +3,9 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { ipcAddress, usesNamedPipe } from "./ipc.js";
 
-const HOME_PI_REMOTE = join(homedir(), ".pi", "remote");
+const HOME_PI_REMOTE = join((process.env["REMOTE_PI_HOME"] || homedir()), ".pi", "remote");
 const SESSIONS_DIR = join(HOME_PI_REMOTE, "sessions");
 const SKILLS_DIR = join(HOME_PI_REMOTE, "skills");
-
 /**
  * Fixed UDS session name. The local mesh is single per machine — every Pi
  * process on the host shares this broker. Previous versions exposed

--- a/plan/49-cli-image-preview.md
+++ b/plan/49-cli-image-preview.md
@@ -1,0 +1,179 @@
+# Plano 49 — Preview de imagem recebida no CLI
+
+**Objetivo**: quando o Android enviar uma foto em `user_message.images`, o Pi
+CLI/TUI também mostra a foto recebida. Hoje o modelo recebe a imagem, e o app
+renderiza o balão, mas a TUI do Pi só mostra a legenda/texto.
+
+## Contexto
+
+Fluxo atual (plano 30):
+
+`Android` → `user_message.images[]` → relay opaco → `pi-extension/src/index.ts`
+→ `_contentFromUserMessage()` converte para `ImageContent` do SDK →
+`_wakeAgent()` entrega ao modelo → `_echoUserMessage()` rebroadcast para owners.
+
+O ponto principal é o `case "user_message"` em `pi-extension/src/index.ts`, mas
+há dois caminhos de entrega que precisam do mesmo preview: mensagem direta e
+mensagem enfileirada durante compaction, drenada por `_drainCompactionQueue()`.
+Não tocar no relay: ele só encaminha `ct`. Não tocar no app: ele já envia e
+renderiza.
+
+## Decisão
+
+Usar **preview inline + caminho de fallback**:
+
+1. Ao receber imagem do Android, o `pi-extension` valida/decodifica o base64 e
+   salva os bytes em um cache temporário privado (`/tmp/pi-app-*` ou equivalente
+   de `os.tmpdir()`), com nome `<message-id>-<index>.<ext>`.
+2. O diretório temporário deve ser privado (`0700` best-effort) e cada arquivo
+   salvo deve ficar privado (`0600` best-effort), porque fotos são dados do
+   usuário e não devem inflar `~/.pi`.
+3. Para preview inline, JPEG/WebP/GIF podem gerar um arquivo temporário
+   `<message-id>-<index>.preview.png` via o helper público `convertToPng` do Pi.
+   A saída PNG convertida também respeita o limite de 10 MiB. O renderer só
+   entrega PNG ao componente `Image`; se a conversão falhar, fica só no fallback
+   textual com o caminho salvo.
+4. Emite um `pi.sendMessage({ customType: "remote-pi:received-image", content:
+   "", details, display: true })` **sem** `{ triggerTurn: true }`; no caminho
+   idle, o preview é anexado antes do `sendUserMessage` para não virar steer do
+   mesmo turn. Se a mensagem recebida já é steering de um turn ativo, o preview
+   é adiado até `agent_end`.
+5. `details` carrega só metadados pequenos: caminho, `previewPath` opcional,
+   mime, tamanho, índice, `messageId`, legenda/texto. Nunca guardar `data`,
+   base64 ou bytes da imagem em `content`/`details` para não inflar histórico.
+   Além disso, os hooks `context` e `session_before_compact` removem
+   `remote-pi:received-image` antes de provider requests e sumarização de
+   compaction para manter esses previews fora do contexto do modelo.
+6. Registra um renderer customizado para esse `customType`.
+7. O renderer tenta renderizar inline com `@earendil-works/pi-tui` `Image`
+   somente a partir de PNG (`path` quando a imagem original já é PNG, ou
+   `previewPath` gerado). O `Image` fica fora de `Box`/padding para preservar as
+   linhas reservadas do Kitty; terminais sem suporte ou conversão indisponível
+   caem no fallback textual + caminho do arquivo salvo.
+
+A imagem real continua vindo do `user_message` original para o modelo; a
+mensagem customizada existe só para exibição local na TUI.
+
+## Não-objetivos
+
+- Não mudar protocolo (`WireImage` fica igual).
+- Não mudar app Android/iOS.
+- Não mudar relay.
+- Não implementar galeria/zoom/gerenciador de anexos no desktop.
+- Não tentar renderizar via `process.stderr`/escape direto fora da TUI.
+
+## Estrutura esperada
+
+```text
+pi-extension/
+├── package.json                     # declarar @earendil-works/pi-tui direto
+└── src/
+    └── index.ts                     # hook no user_message + registro renderer
+```
+
+## Passos com critério de aceite
+
+### 1. Persistir imagem recebida
+
+- Adicionar helper pequeno para:
+  - aceitar só `image/jpeg`, `image/png`, `image/webp`, `image/gif`;
+  - mapear mime para extensão segura;
+  - rejeitar `data:` URI, whitespace e caracteres/padding fora de base64 padrão;
+  - estimar tamanho antes do decode e rejeitar payloads que possam passar de
+    10 MiB;
+  - decodificar e confirmar `buffer.length > 0 && buffer.length <= 10 MiB`;
+  - criar um diretório temporário privado via `mkdtempSync(join(tmpdir(), "pi-app-"))`
+    com `mode: 0o700`/`chmodSync(..., 0o700)` best-effort;
+  - escrever arquivo com nome derivado de `msg.id` + índice sanitizados,
+    extensão segura, `mode: 0o600` + `chmodSync(..., 0o600)` best-effort;
+  - para mime não-PNG, tentar gerar `*.preview.png` com `convertToPng`; se
+    falhar ou a saída PNG passar de 10 MiB, remover parcial e manter só o arquivo
+    original temporário.
+- Em erro de decode/mime, não derrubar o turn: registrar `console.error`, emitir
+  preview textual de falha, e continuar entregando a imagem ao modelo como hoje.
+
+**Aceite**: teste unitário cobre nome/extensão, mime recusado, `data:` URI,
+caracteres/padding inválidos, payload vazio, payload acima de 10 MiB e permissões
+POSIX quando a plataforma expõe mode bits.
+
+### 2. Surfacing no TUI
+
+- Criar um helper compartilhado, por exemplo `_showReceivedImagesInCli(msg)`.
+- Chamar esse helper em **dois lugares**:
+  1. caminho direto do `case "user_message"`: em idle, emitir antes de
+     `_wakeAgent()`; em steering ativo, enfileirar e só emitir no `agent_end`;
+  2. `_drainCompactionQueue()`, quando a compaction já terminou, antes do wake
+     bem-sucedido da mensagem que foi enfileirada durante compaction.
+- Esse helper emite `remote-pi:received-image` com `content: ""`, `display: true`
+  e metadados dos arquivos salvos em `details`; hooks de contexto/compaction
+  filtram esse `customType` antes de chamadas ao provider ou sumarização.
+- Não mudar o caminho sem imagem.
+
+**Aceite**: teste existente de `user_message` com imagem passa; novo teste vê
+`pi.sendMessage` chamado com `customType: "remote-pi:received-image"`,
+`display: true`, sem `triggerTurn`, e sem `data`/base64 em `content` ou `details`;
+teste sem imagem prova que nada novo é emitido; teste de imagem durante compaction
+prova que o preview aparece após a drenagem; teste de steering ativo prova que o
+preview local só é emitido após `agent_end`; teste de contexto prova que o
+`customType` não vai para provider requests nem sumarização de compaction.
+
+### 3. Renderer inline + fallback
+
+- Declarar `@earendil-works/pi-tui` como dependência direta do `pi-extension`
+  (já é dependência transitiva do Pi, mas import direto deve ser explícito).
+- Registrar `pi.registerMessageRenderer("remote-pi:received-image", renderer)`
+  no setup da extensão.
+- Renderer monta um componente simples:
+  - título curto: `📷 Photo from Android`;
+  - legenda se existir;
+  - linha `Saved: <path>` sempre visível;
+  - escolhe caminho renderizável: `previewPath` quando presente, senão `path`
+    apenas se `mime === "image/png"`;
+  - lê esse PNG e passa `readFileSync(...).toString("base64")` para
+    `new Image(base64Data, "image/png", theme, ...)`, fora de qualquer `Box`
+    que adicione padding/background às linhas da imagem.
+- Se arquivo sumiu, conversão não existir, ou terminal não suportar imagem,
+  renderizar fallback textual com mime/tamanho + caminho, sem throw e sem tentar
+  renderizar JPEG cru (evita linhas em branco no Kitty).
+
+**Aceite**: typecheck passa; teste automatizado captura o renderer registrado,
+invoca com arquivo ausente e/ou terminal sem imagem e confirma título +
+`Saved: <path>` sem throw; smoke manual em terminal com suporte mostra a foto;
+terminal sem suporte mostra fallback + path.
+
+### 4. Verificação
+
+Rodar no `pi-extension/`:
+
+```bash
+pnpm typecheck
+pnpm test
+```
+
+Smoke manual:
+
+1. Rebuild/instalar extensão local se necessário.
+2. `/remote-pi pair` e enviar foto do Android.
+3. Confirmar que:
+   - a TUI mostra preview ou fallback + caminho temporário `/tmp/pi-app-*`;
+   - o modelo continua recebendo a imagem;
+   - Android continua vendo o balão com imagem;
+   - mensagem sem imagem permanece igual;
+   - foto enviada durante compaction aparece quando a fila drena.
+
+## Definition of Done
+
+- [x] Foto Android aparece no Pi CLI/TUI com inline preview quando suportado.
+- [x] Fallback mostra caminho salvo quando inline não é suportado.
+- [x] Arquivo é salvo em cache temporário privado (`/tmp/pi-app-*`/`os.tmpdir()`) com extensão segura e permissões privadas best-effort.
+- [x] Sem mudança em relay/protocolo/app.
+- [x] Preview cobre caminho direto e caminho enfileirado durante compaction.
+- [x] `remote-pi:received-image` não guarda base64/bytes em `content` nem `details`, e é filtrado do contexto do provider.
+- [x] `pnpm typecheck` verde em `pi-extension/`.
+- [x] `pnpm test` verde em `pi-extension/`.
+- [x] Smoke manual Android → Pi feito.
+
+## Próximos planos
+
+Se o cache crescer demais, adicionar limpeza simples por idade/tamanho em um plano
+futuro. Não bloquear este plano com política de retenção agora.


### PR DESCRIPTION
## Problem
Android can send images to a Pi session, and the agent receives the image as multimodal input, but the Pi CLI/TUI does not show the terminal user what image arrived.

User-visible result: when an Android user sends an image, the Pi-side transcript can look like only text/caption arrived, even though the model received image content. That makes it hard to verify what was sent and to follow the conversation from the terminal.

## Fix
- show Android-sent images in the Pi CLI/TUI as `remote-pi:received-image` custom messages
- save originals/previews in a private OS temp cache instead of embedding image bytes in transcript text
- render PNG previews inline when the current TUI supports image rendering
- generate optional PNG previews for non-PNG inputs when conversion is available
- keep provider/compaction context clean by filtering preview-only messages out of model context
- defer preview display during active turns so image metadata does not steer the current agent turn

## Safety / behavior notes
- preview messages are metadata-only; raw base64 image data is not stored in the custom message payload
- cached files use sanitized names under a private temp directory
- large/unsupported conversions fall back to saved originals without inline preview
- existing Android-to-agent multimodal delivery and owner echo behavior are preserved

## Validation
- `cd pi-extension && corepack pnpm typecheck`
- `cd pi-extension && corepack pnpm build`
- `cd pi-extension && corepack pnpm test` (587 passed, 3 skipped)
