### PR TITLE
fix(pi-extension): coalesce concurrent startup

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -3139,6 +3139,27 @@ describe("same-folder same-name → #N suffix (no refusal)", () => {
     }
   });
 
+  test("concurrent startup in one extension instance does not self-suffix", async () => {
+    process.env["REMOTE_PI_DIRECT_CONFIG"] = JSON.stringify({
+      agent_name: "Backoffice",
+      auto_start_relay: false,
+    });
+    const cwd = "/home/user/projects/remote_pi-concurrent";
+    try {
+      const root = captureHandler("remote-pi");
+      await Promise.all([
+        root("", makeMockCtx(cwd)),
+        root("", makeMockCtx(cwd)),
+      ]);
+
+      expect(_getLockedNameForTest()).toBe("Backoffice");
+      expect(_hasMeshNodeForTest()).toBe(true);
+    } finally {
+      delete process.env["REMOTE_PI_DIRECT_CONFIG"];
+      _resetCwdLockForTest();
+    }
+  });
+
   test("a supervised daemon refuses a busy base lock instead of joining as <name>#2", async () => {
     process.env["REMOTE_PI_DAEMON"] = "1";
     process.env["REMOTE_PI_DIRECT_CONFIG"] = JSON.stringify({

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -489,6 +489,9 @@ function _getSyncLimit(): number {
 const RECONNECT_BACKOFFS_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
 let _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let _reconnectAttempt = 0;
+// Coalesces concurrent `/remote-pi` startup paths inside ONE extension instance.
+// Separate Pi processes still keep the existing #N behavior via the cwd lock.
+let _cmdRootInFlight: Promise<void> | null = null;
 
 /** Test-only: exposes pending reconnect timer state. */
 export function _hasPendingReconnect(): boolean {
@@ -1771,6 +1774,22 @@ async function _cmdPeers(ctx: Pick<ExtensionContext, "ui">): Promise<void> {
  * idempotent connect + status display.
  */
 async function _cmdRoot(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void> {
+  if (_cmdRootInFlight) {
+    await _cmdRootInFlight;
+    _cmdStatus(ctx);
+    return;
+  }
+
+  const run = _cmdRootInner(ctx);
+  _cmdRootInFlight = run;
+  try {
+    await run;
+  } finally {
+    if (_cmdRootInFlight === run) _cmdRootInFlight = null;
+  }
+}
+
+async function _cmdRootInner(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void> {
   // This instance was torn down (session replacement) before its deferred
   // auto-init ran — don't connect, or we'd resurrect a ghost the broker can't
   // reach. The replacement instance (fresh module) drives the live connect.


### PR DESCRIPTION
## Problem
A single pi-extension instance can start Remote Pi twice at the same time: once from `session_start` auto-init and once from a concurrent `/remote-pi` command path.

User-visible result: one logical Pi session can race itself into extra mesh names like `Backoffice#2` / `Backoffice#3`, which then shows up as duplicate Android relay rooms for the same session.

## Root cause
`_cmdRoot()` was intended to be idempotent, but it was only idempotent after startup finished. During startup it performs async work before the mesh node/cwd lock state is fully established, so concurrent callers could both enter the join/start path.

The race was made reachable by `922eb57c2be61b5d95f07792eaf35e788233a233` (`fix(pi-extension): auto-start remote-pi on session_start, not factory setTimeout`), which correctly moved auto-init onto `session_start` but added another normal path into `_cmdRoot()`.

Exact vulnerable area:
- `pi-extension/src/index.ts`, `_cmdRoot()` — no in-flight startup guard, so concurrent calls inside the same extension instance could race before `_meshNode` / `_cwdLock` settled.

## Fix
- add a per-instance `_cmdRootInFlight` promise to coalesce concurrent root startup calls
- make later callers await the first startup and then print status
- keep the existing cross-process behavior unchanged: separate same-folder same-name Pi processes can still join as `<name>#2`
- add regression coverage for same-instance concurrent startup

## Validation
- `cd pi-extension && corepack pnpm exec vitest run src/extension.test.ts -t "concurrent startup"` (1 passed)
- `cd pi-extension && corepack pnpm exec vitest run src/extension.test.ts -t "same-folder same-name"` (3 passed)
- `cd pi-extension && corepack pnpm typecheck`
- `cd pi-extension && corepack pnpm build`
- `cd pi-extension && corepack pnpm test` (581 passed, 3 skipped)
