### PR TITLE
fix(app): preserve explicit room routing

### DIFF
--- a/app/lib/data/transport/connection_manager.dart
+++ b/app/lib/data/transport/connection_manager.dart
@@ -240,6 +240,10 @@ class ConnectionManager extends Service {
       return;
     }
     _activeRoomId = roomId;
+    final active = _activePeer;
+    if (active != null) {
+      _activePeer = active.copyWith(roomId: roomId);
+    }
     // Push down to the underlying WS transport so outbound envelopes
     // get the right `room` value.
     final cur = _status;
@@ -985,8 +989,8 @@ class ConnectionManager extends Service {
     final active = _activePeer;
     if (active == null) return;
     if (toStandardB64(active.remoteEpk) != peerKey) return;
-    if (active.roomId != null && active.roomId == _activeRoomId) {
-      return; // already bound — discovery is a no-op
+    if (active.roomId != null) {
+      return; // explicit room selection — discovery must not override it
     }
     _activeRoomId = discoveredRoom;
     final cur = _status;

--- a/app/test/transport/connection_manager_test.dart
+++ b/app/test/transport/connection_manager_test.dart
@@ -1043,6 +1043,11 @@ class _ControllableChannel implements IChannel, IControlLink {
   final _ctrl = StreamController<ServerMessage>.broadcast();
   final _controlCtrl = StreamController<ControlInbound>.broadcast();
   final List<Map<String, dynamic>> sentControl = [];
+  String? activeRoom;
+
+  void setActiveRoom(String roomId) {
+    activeRoom = roomId;
+  }
 
   @override
   Stream<ServerMessage> get serverMessages => _ctrl.stream;
@@ -1236,6 +1241,81 @@ void _registerRoomsTests() {
         final saved = storage.savedPeers;
         expect(saved, isNotEmpty);
         expect(saved.last.roomId, 'discovered-room-id');
+
+        cm.dispose();
+      },
+    );
+
+    test(
+      'explicit room switch is not overwritten by later room announce',
+      () async {
+        final storage = _FakeStorage([]);
+        final ch = _ControllableChannel();
+        final cm = ConnectionManager(
+          factory: (_, _) async => ch,
+          storage: storage,
+          emitDebounce: Duration.zero,
+        );
+        const peer = PeerRecord(
+          remoteEpk: 'epk_explicit',
+          sessionName: 'Pi',
+          relayUrl: 'wss://x',
+          pairedAt: '2026-01-01T00:00:00Z',
+          roomId: 'robflow',
+        );
+        await cm.connectTo(peer);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(cm.activeRoomId, 'robflow');
+
+        cm.switchRoom('remote');
+        expect(cm.activeRoomId, 'remote');
+        expect(ch.activeRoom, 'remote');
+
+        ch.pushControl(const RoomAnnounced(
+          peer: 'epk_explicit',
+          roomId: 'robflow',
+          name: 'robflow',
+          cwd: '/work/robflow',
+          startedAt: 1000,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(cm.activeRoomId, 'remote');
+        expect(ch.activeRoom, 'remote');
+        expect(storage.savedPeers, isEmpty);
+
+        cm.dispose();
+      },
+    );
+
+    test(
+      'explicit room switch is not overwritten by rooms snapshot order',
+      () async {
+        final ch = _ControllableChannel();
+        final cm = ConnectionManager(
+          factory: (_, _) async => ch,
+          storage: _FakeStorage([]),
+          emitDebounce: Duration.zero,
+        );
+        const peer = PeerRecord(
+          remoteEpk: 'epk_explicit_snapshot',
+          sessionName: 'Pi',
+          relayUrl: 'wss://x',
+          pairedAt: '2026-01-01T00:00:00Z',
+          roomId: 'robflow',
+        );
+        await cm.connectTo(peer);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        cm.switchRoom('remote');
+        ch.pushControl(const RoomsSnapshot(peer: 'epk_explicit_snapshot', rooms: [
+          RoomInfo(roomId: 'robflow', startedAt: 1000),
+          RoomInfo(roomId: 'remote', startedAt: 1001),
+        ]));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(cm.activeRoomId, 'remote');
+        expect(ch.activeRoom, 'remote');
 
         cm.dispose();
       },


### PR DESCRIPTION
## Problem
When the app is paired to one Pi peer that exposes multiple rooms/cwds, an explicit room switch is not stable. A later room announcement or rooms snapshot can move outbound routing back to the previously persisted room.

User-visible result: messages sent from Android can be delivered to the wrong Pi session/room after switching rooms.

## Fix
- keep `ConnectionManager`'s active peer room aligned when switching rooms
- restrict legacy room auto-adoption to peers that truly have no persisted room
- add regressions for room announcements/snapshots not overriding explicit room selection

## Where the bug was introduced
Introduced upstream in `0956a74ccc578367fafe08bdf1da64d96433aea8` (`feat: introduce room management and enhance peer registry`). That commit added the multi-room app routing code.

Exact source of the bug:
- `app/lib/data/transport/connection_manager.dart`, `switchRoom()` — updated `_activeRoomId` and the WS transport, but left `_activePeer.roomId` pointing at the previously persisted room.
- `app/lib/data/transport/connection_manager.dart`, `_maybeAdoptLegacyRoom()` — treated any mismatch between `_activePeer.roomId` and `_activeRoomId` as legacy discovery, so a later `RoomAnnounced`/`RoomsSnapshot` for the old room could overwrite the user's explicit room selection.

## Verification
- `cd app && flutter test test/transport/connection_manager_test.dart --plain-name 'explicit room switch'`
- `cd app && flutter test test/transport/connection_manager_test.dart`

Note: `flutter analyze` currently reports an unrelated upstream deprecation in `app/lib/ui/chat/widgets/input_bar.dart:802` (`axisAlignment` deprecated).