### PR TITLE
fix(relay): auth with overlapping owner meshes

### DIFF
--- a/relay/src/handlers/pi_forward.rs
+++ b/relay/src/handlers/pi_forward.rs
@@ -74,6 +74,7 @@ impl MeshAuthCache {
             }
         };
 
+        let mut union = HashSet::new();
         for blob in blobs {
             let parsed: serde_json::Value = match serde_json::from_slice(&blob) {
                 Ok(v) => v,
@@ -91,18 +92,21 @@ impl MeshAuthCache {
                 })
                 .collect();
             if set.contains(pi_pk) {
-                let mut g = self.inner.lock().unwrap();
-                g.insert(
-                    pi_pk.to_string(),
-                    CachedMembers {
-                        members: set.clone(),
-                        cached_at: Instant::now(),
-                    },
-                );
-                return Some(set);
+                union.extend(set);
             }
         }
-        None
+        if union.is_empty() {
+            return None;
+        }
+        let mut g = self.inner.lock().unwrap();
+        g.insert(
+            pi_pk.to_string(),
+            CachedMembers {
+                members: union.clone(),
+                cached_at: Instant::now(),
+            },
+        );
+        Some(union)
     }
 
     /// `true` iff both Pis belong to the same Owner's mesh.


### PR DESCRIPTION
Fix relay auth for overlapping owner meshes.

Context:
Found while testing remote peers after repeated relay reconnects on both machines. Relay showed connected, but `list_peers` kept returning only local peers.

Problem:
Relay auth stopped at the first mesh blob containing the target Pi. If a Pi appeared in multiple owner meshes, valid shared members from later blobs were ignored.

Fix:
Merge all matching mesh memberships before caching. Auth now sees every member from every mesh that includes the Pi.

Test:
Relay auth path now caches the merged member set instead of first-match only.
