### PR TITLE
feat(chat): add Android queued follow-ups

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -274,32 +274,49 @@ aceito nesta fatia por usar imagem comprimida (~150–400 KB). Histórico/
 
 ## Mensagem enfileirada durante turn ativo
 
-Fila curta **Pi-side, em memória**: enquanto há turn ativo, o app pode guardar
-um próximo prompt textual. A Pi-extension envia quando o turn atual acaba. Não é
-fila offline do relay; restart perde o estado.
+Fila curta **Pi-side, em memória**, de propriedade do Android: enquanto há turn
+ativo, o app pode guardar próximos prompts textuais de follow-up. A
+Pi-extension drena um item quando o turn atual acaba. Não é fila offline do
+relay; restart perde o estado.
 
 ### Wire
 
 ```jsonc
 // app → Pi-extension
 { "type": "queued_message_set", "id": "msg-2", "text": "próximo prompt" }
-{ "type": "queued_message_clear", "id": "clear-1" }
+{ "type": "queued_message_clear", "id": "clear-1", "target_id": "msg-2" }
+{ "type": "queued_message_clear", "id": "clear-all" }
 
 // Pi-extension → app(s)
-{ "type": "queued_message_state", "id": "msg-2", "text": "próximo prompt" }
-{ "type": "queued_message_state" } // vazio
+{
+  "type": "queued_message_state",
+  "id": "msg-2",
+  "text": "próximo prompt",
+  "items": [
+    { "id": "msg-2", "text": "próximo prompt", "editable": true, "created_at": 1782250000000 }
+  ]
+}
+{ "type": "queued_message_state", "items": [] } // vazio
 ```
 
 ### Semântica
 
-- `queued_message_set`: define/substitui uma pendência textual. `id` vira o id
-  do `user_message` drenado. App pode juntar múltiplos prompts com `\n`.
-- `queued_message_clear`: cancela a pendência.
-- Drain: quando `!turnActive && !currentTurnId`, limpa o estado, broadcasta
-  `queued_message_state` vazio, e processa como `user_message` normal
-  (`echo user_message` + `sendUserMessage(text)`).
+- `queued_message_set`: cria/substitui uma pendência textual Android-owned. `id`
+  vira o id do `user_message` drenado.
+- `queued_message_clear.target_id`: cancela um item. Sem `target_id`, cancela
+  todos os itens Android-owned (compat com o antigo clear de slot único).
+- Enquanto o Pi está ocupado, cada mudança broadcasta o estado completo para
+  todos os owners conectados.
+- Se `queued_message_set` chega quando o Pi já está idle, a extensão drena
+  imediatamente como `user_message` normal e broadcasta estado vazio, para não
+  deixar item preso esperando um turn futuro.
+- Drain: quando `currentTurnId == null`, `working != true` e não há compaction
+  ativa, remove um item, broadcasta `queued_message_state`, faz handoff para o
+  SDK, e só então ecoa `user_message` normal para todos os owners.
 - `session_sync`: envia o `queued_message_state` atual antes do histórico.
 - Só texto. `images` seguem apenas no `user_message` imediato.
+- Filas internas do Pi/TUI não são expostas/editáveis neste MVP: a extension API
+  não fornece ids estáveis nem mutação segura dessa fila.
 - Relay inalterado/opaco.
 
 ---

--- a/app/lib/data/local/records/message_record.dart
+++ b/app/lib/data/local/records/message_record.dart
@@ -24,6 +24,9 @@ class MessageRecord {
   /// Optimistic: sent locally, not yet echoed by the Pi.
   final bool pending;
 
+  /// Local-only hint: this pending user row was sent while the Pi was busy.
+  final bool steering;
+
   /// Plan/32 — tokens reclaimed by a compaction (compaction rows only).
   final int? tokensBefore;
 
@@ -36,6 +39,7 @@ class MessageRecord {
     this.tool,
     required this.ts,
     this.pending = false,
+    this.steering = false,
     this.tokensBefore,
   });
 
@@ -45,6 +49,7 @@ class MessageRecord {
     MessageImage? image,
     ToolEventData? tool,
     bool? pending,
+    bool? steering,
   }) => MessageRecord(
     id: id,
     seq: seq ?? this.seq,
@@ -54,6 +59,7 @@ class MessageRecord {
     tool: tool ?? this.tool,
     ts: ts,
     pending: pending ?? this.pending,
+    steering: steering ?? this.steering,
     tokensBefore: tokensBefore,
   );
 
@@ -66,6 +72,7 @@ class MessageRecord {
     if (tool != null) 'tool': tool!.toJson(),
     'ts': ts.millisecondsSinceEpoch,
     'pending': pending,
+    if (steering) 'steering': true,
     if (tokensBefore != null) 'tokens_before': tokensBefore,
   };
 
@@ -91,6 +98,7 @@ class MessageRecord {
           : null,
       ts: DateTime.fromMillisecondsSinceEpoch((j['ts'] as num).toInt()),
       pending: (j['pending'] as bool?) ?? false,
+      steering: (j['steering'] as bool?) ?? false,
       tokensBefore: (j['tokens_before'] as num?)?.toInt(),
     );
   }
@@ -103,6 +111,7 @@ class MessageRecord {
           id: id,
           text: text,
           status: pending ? UserMsgStatus.pending : UserMsgStatus.confirmed,
+          steering: steering,
           image: image,
         );
       case MsgRole.assistant:

--- a/app/lib/data/sync/sync_service.dart
+++ b/app/lib/data/sync/sync_service.dart
@@ -58,9 +58,9 @@ class SyncService extends Service {
   final StreamController<SessionEvent> _eventController =
       StreamController<SessionEvent>.broadcast();
 
-  String? _queuedText;
-  final StreamController<String?> _queuedController =
-      StreamController<String?>.broadcast();
+  List<QueuedMsg> _queuedMessages = const [];
+  final StreamController<List<QueuedMsg>> _queuedController =
+      StreamController<List<QueuedMsg>>.broadcast();
 
   bool _pendingSyncRequest = false;
   Timer? _syncDebounce;
@@ -104,8 +104,10 @@ class SyncService extends Service {
   StreamingMessage? get streaming => _streaming;
   Stream<StreamingMessage?> get streamingStream => _streamingController.stream;
   Stream<SessionEvent> get events => _eventController.stream;
-  String? get queuedText => _queuedText;
-  Stream<String?> get queuedStream => _queuedController.stream;
+  List<QueuedMsg> get queuedMessages => _queuedMessages;
+  String? get queuedText =>
+      _queuedMessages.isEmpty ? null : _queuedMessages.first.text;
+  Stream<List<QueuedMsg>> get queuedStream => _queuedController.stream;
 
   /// True while the active session's agent is producing a reply (whole turn).
   bool get isWorking => _working;
@@ -146,7 +148,7 @@ class SyncService extends Service {
     _chunkBuffer.clear();
     _chunkReplyTo = '';
     _workingReplyTo = null;
-    _setQueuedText(null);
+    _setQueuedMessages(const []);
     // Session switch: the previous chat's in-flight sends are no longer ours
     // to confirm — drop their backstops so a stale timer can't fire later.
     _cancelAllSendTimers();
@@ -179,6 +181,7 @@ class SyncService extends Service {
           image: image,
           ts: now,
           pending: true,
+          steering: isSteer,
         ),
       );
       if (!isSteer) {
@@ -262,19 +265,41 @@ class SyncService extends Service {
   @visibleForTesting
   int get debugPendingSendTimerCount => _pendingSendTimers.length;
 
-  Future<void> setQueuedMessage(String text) async {
+  Future<void> queueMessage(String text) async {
     final ch = _conn.channel;
     if (ch == null) return;
-    _setQueuedText(text);
-    await ch.send(QueuedMessageSet(id: _newId(), text: text));
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    final id = _newId();
+    _setQueuedMessages([
+      ..._queuedMessages,
+      QueuedMsg(
+        id: id,
+        text: trimmed,
+        editable: true,
+        createdAt: DateTime.now(),
+      ),
+    ]);
+    await ch.send(QueuedMessageSet(id: id, text: trimmed));
   }
 
-  Future<void> clearQueuedMessage() async {
+  Future<void> setQueuedMessage(String text) => queueMessage(text);
+
+  Future<void> clearQueuedMessage([String? targetId]) async {
+    if (targetId == null) {
+      _setQueuedMessages(const []);
+    } else {
+      _setQueuedMessages([
+        for (final item in _queuedMessages)
+          if (item.id != targetId) item,
+      ]);
+    }
     final ch = _conn.channel;
-    _setQueuedText(null);
     if (ch == null) return;
-    await ch.send(QueuedMessageClear(id: _newId()));
+    await ch.send(QueuedMessageClear(id: _newId(), targetId: targetId));
   }
+
+  Future<void> clearQueuedMessages() => clearQueuedMessage();
 
   Future<void> cancel(String targetId) async {
     // User-driven cancel of this message → disarm its no-echo backstop too.
@@ -400,9 +425,10 @@ class SyncService extends Service {
         _flushTimer = Timer(const Duration(milliseconds: 16), _flushChunks);
         _setWorking(true, replyTo: inReplyTo);
 
-      case AgentDone():
+      case AgentDone(:final inReplyTo):
         // Finalize whatever text accumulated since the last tool boundary.
         final text = _finalizeSegment();
+        _clearSteeringLabel(inReplyTo);
         _setWorking(false, preview: text.isEmpty ? null : text);
 
       case AgentMessage(:final inReplyTo, :final text):
@@ -421,8 +447,19 @@ class SyncService extends Service {
               ),
         );
 
-      case QueuedMessageState(:final text):
-        _setQueuedText(text?.isNotEmpty == true ? text : null);
+      case QueuedMessageState(:final items):
+        _setQueuedMessages([
+          for (final item in items)
+            QueuedMsg(
+              id: item.id,
+              text: item.text,
+              editable: item.editable,
+              createdAt: item.createdAt,
+            ),
+        ]);
+
+      case SteerConsumed(:final id):
+        _clearSteeringLabel(id);
 
       case UserInput(
         :final id,
@@ -435,6 +472,12 @@ class SyncService extends Service {
         debugPrint('[msg-echo] id=$id');
         // Echo arrived → the send landed; disarm the no-echo backstop.
         _pendingSendTimers.remove(id)?.cancel();
+        if (_queuedMessages.any((item) => item.id == id)) {
+          _setQueuedMessages([
+            for (final item in _queuedMessages)
+              if (item.id != id) item,
+          ]);
+        }
         // ignore: discarded_futures
         _upsert(
           MsgRole.user,
@@ -521,12 +564,14 @@ class SyncService extends Service {
         // confirmed user/tool rows as the audit trail of what happened.
         // ignore: discarded_futures
         _removePendingById(targetId);
+        _clearSteeringLabels();
         _setWorking(false);
 
       case Bye(:final rawReason):
         if (!_eventController.isClosed) {
           _eventController.add(PeerWentOffline(rawReason));
         }
+        _clearSteeringLabels();
         _setWorking(false);
         final peer = _conn.activePeer;
         if (peer != null) {
@@ -546,6 +591,7 @@ class SyncService extends Service {
           break;
         }
         _discardStreamingState();
+        _clearSteeringLabels();
         _setWorking(false);
         // ignore: discarded_futures
         _upsert(
@@ -829,6 +875,45 @@ class SyncService extends Service {
     });
   }
 
+  void _clearSteeringLabel(String id) {
+    final epk = _activeEpk;
+    if (epk == null) return;
+    final room = _activeRoomId;
+    // ignore: discarded_futures
+    _enqueue(() async {
+      if (_activeEpk != epk || _activeRoomId != room) return;
+      final box = await _boxes.msgsBox(epk, room);
+      final seq = _idToSeq[_key(MsgRole.user, id)];
+      if (seq == null) return;
+      final raw = box.get(seq);
+      if (raw == null) return;
+      final existing = MessageRecord.fromJson(_coerce(raw));
+      if (existing.role != MsgRole.user || !existing.steering) return;
+      await box.put(seq, existing.copyWith(steering: false).toJson());
+    });
+  }
+
+  void _clearSteeringLabels() {
+    final epk = _activeEpk;
+    if (epk == null) return;
+    final room = _activeRoomId;
+    // ignore: discarded_futures
+    _enqueue(() async {
+      if (_activeEpk != epk || _activeRoomId != room) return;
+      final box = await _boxes.msgsBox(epk, room);
+      for (final key in box.keys.toList()) {
+        final raw = box.get(key);
+        if (raw == null) continue;
+        final existing = MessageRecord.fromJson(_coerce(raw));
+        if (existing.role != MsgRole.user || !existing.steering) continue;
+        await box.put(
+          (key as num).toInt(),
+          existing.copyWith(steering: false).toJson(),
+        );
+      }
+    });
+  }
+
   Future<void> _removePendingById(String id) {
     final epk = _activeEpk;
     if (epk == null) return Future<void>.value();
@@ -863,13 +948,15 @@ class SyncService extends Service {
     );
   }
 
+  void _setQueuedMessages(List<QueuedMsg> items) {
+    final next = List<QueuedMsg>.unmodifiable(items);
+    if (_queuedMessages == next) return;
+    _queuedMessages = next;
+    if (!_queuedController.isClosed) _queuedController.add(next);
+  }
+
   /// Single source of "the active session is working". Drives the in-memory
   /// flag/stream (chat pill) AND the durable session index (Home dot).
-  void _setQueuedText(String? text) {
-    if (_queuedText == text) return;
-    _queuedText = text;
-    if (!_queuedController.isClosed) _queuedController.add(text);
-  }
 
   void _setWorking(bool on, {String? preview, String? replyTo}) {
     _setActivity(

--- a/app/lib/domain/session_state.dart
+++ b/app/lib/domain/session_state.dart
@@ -43,9 +43,37 @@ class MessageImage {
   int get hashCode => Object.hash(data, mime);
 }
 
+/// Android-owned queued follow-up shown above the composer. Protocol-free
+/// domain value; SyncService maps wire items into this shape.
+class QueuedMsg {
+  final String id;
+  final String text;
+  final bool editable;
+  final DateTime createdAt;
+
+  const QueuedMsg({
+    required this.id,
+    required this.text,
+    required this.editable,
+    required this.createdAt,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is QueuedMsg &&
+      other.id == id &&
+      other.text == text &&
+      other.editable == editable &&
+      other.createdAt == createdAt;
+
+  @override
+  int get hashCode => Object.hash(id, text, editable, createdAt);
+}
+
 class UserMsg extends ChatMessage {
   final String text;
   final UserMsgStatus status;
+  final bool steering;
 
   /// Plan/30 — optional attached image (one max). `null` for text-only
   /// messages, which is every message before this feature.
@@ -55,11 +83,17 @@ class UserMsg extends ChatMessage {
     required super.id,
     required this.text,
     this.status = UserMsgStatus.confirmed,
+    this.steering = false,
     this.image,
   });
 
-  UserMsg copyWith({UserMsgStatus? status}) =>
-      UserMsg(id: id, text: text, status: status ?? this.status, image: image);
+  UserMsg copyWith({UserMsgStatus? status, bool? steering}) => UserMsg(
+    id: id,
+    text: text,
+    status: status ?? this.status,
+    steering: steering ?? this.steering,
+    image: image,
+  );
 
   @override
   bool operator ==(Object other) =>
@@ -67,10 +101,11 @@ class UserMsg extends ChatMessage {
       other.id == id &&
       other.text == text &&
       other.status == status &&
+      other.steering == steering &&
       other.image == image;
 
   @override
-  int get hashCode => Object.hash(id, text, status, image);
+  int get hashCode => Object.hash(id, text, status, steering, image);
 }
 
 class AssistantMsg extends ChatMessage {

--- a/app/lib/protocol/protocol.dart
+++ b/app/lib/protocol/protocol.dart
@@ -497,10 +497,15 @@ class QueuedMessageSet extends ClientMessage {
 
 class QueuedMessageClear extends ClientMessage {
   final String id;
-  QueuedMessageClear({required this.id});
+  final String? targetId;
+  QueuedMessageClear({required this.id, this.targetId});
 
   @override
-  Map<String, dynamic> toJson() => {'type': 'queued_message_clear', 'id': id};
+  Map<String, dynamic> toJson() => {
+    'type': 'queued_message_clear',
+    'id': id,
+    if (targetId != null) 'target_id': targetId,
+  };
 }
 
 class ApproveTool extends ClientMessage {
@@ -773,6 +778,7 @@ sealed class ServerMessage {
       // here is the "user-text-arrived" event regardless of origin.
       'user_input' || 'user_message' => UserInput.fromJson(json),
       'queued_message_state' => QueuedMessageState.fromJson(json),
+      'steer_consumed' => SteerConsumed.fromJson(json),
       'agent_message' => AgentMessage.fromJson(json),
       // Plan/32 — Pi-extension emits this when a context compaction finishes.
       'compaction' => Compaction.fromJson(json),
@@ -978,13 +984,72 @@ WireImage? _firstImage(dynamic raw) {
   return WireImage.fromJson(first.cast<String, dynamic>());
 }
 
-class QueuedMessageState extends ServerMessage {
-  final String? id;
-  final String? text;
-  QueuedMessageState({this.id, this.text});
+class QueuedMessageItem {
+  final String id;
+  final String text;
+  final bool editable;
+  final DateTime createdAt;
 
-  factory QueuedMessageState.fromJson(Map<String, dynamic> j) =>
-      QueuedMessageState(id: j['id'] as String?, text: j['text'] as String?);
+  const QueuedMessageItem({
+    required this.id,
+    required this.text,
+    required this.editable,
+    required this.createdAt,
+  });
+
+  factory QueuedMessageItem.fromJson(Map<String, dynamic> j) =>
+      QueuedMessageItem(
+        id: j['id'] as String,
+        text: (j['text'] as String?) ?? '',
+        editable: (j['editable'] as bool?) ?? true,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(
+          (j['created_at'] as num?)?.toInt() ?? 0,
+        ),
+      );
+}
+
+class QueuedMessageState extends ServerMessage {
+  final List<QueuedMessageItem> items;
+  QueuedMessageState({this.items = const []});
+
+  String? get id => items.isEmpty ? null : items.first.id;
+  String? get text => items.isEmpty ? null : items.first.text;
+
+  factory QueuedMessageState.fromJson(Map<String, dynamic> j) {
+    final rawItems = j['items'];
+    if (rawItems is List) {
+      return QueuedMessageState(
+        items: rawItems
+            .whereType<Map>()
+            .map((m) => QueuedMessageItem.fromJson(m.cast<String, dynamic>()))
+            .where((item) => item.text.isNotEmpty)
+            .toList(growable: false),
+      );
+    }
+    final id = j['id'] as String?;
+    final text = j['text'] as String?;
+    if (id == null || text == null || text.isEmpty) {
+      return QueuedMessageState();
+    }
+    return QueuedMessageState(
+      items: [
+        QueuedMessageItem(
+          id: id,
+          text: text,
+          editable: true,
+          createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+        ),
+      ],
+    );
+  }
+}
+
+class SteerConsumed extends ServerMessage {
+  final String id;
+  SteerConsumed({required this.id});
+
+  factory SteerConsumed.fromJson(Map<String, dynamic> j) =>
+      SteerConsumed(id: j['id'] as String);
 }
 
 class UserInput extends ServerMessage {

--- a/app/lib/ui/chat/chat_page.dart
+++ b/app/lib/ui/chat/chat_page.dart
@@ -417,8 +417,8 @@ class ChatPage extends StatelessWidget {
       onOpenQuickActions: actionsEnabled
           ? () => showQuickActionsSheet(context)
           : null,
-      queuedText: isReady ? state.queuedText : null,
-      onSetQueued: vm.setQueuedMessage,
+      queuedMessages: isReady ? state.queuedMessages : const [],
+      onSetQueued: vm.queueMessage,
       onClearQueued: vm.clearQueuedMessage,
       // Plan/29 — hold-to-talk voice input. The VM is route-scoped (bound in
       // app_router alongside ChatViewModel); InputBar listens to it directly,

--- a/app/lib/ui/chat/states/chat_state.dart
+++ b/app/lib/ui/chat/states/chat_state.dart
@@ -43,7 +43,10 @@ class ChatReady extends ChatState {
   /// per-room, like Home) actually triggers a rebuild even when nothing
   /// else changed. See [ChatViewModel.isWorking].
   final bool isWorking;
-  final String? queuedText;
+  final List<QueuedMsg> queuedMessages;
+
+  String? get queuedText =>
+      queuedMessages.isEmpty ? null : queuedMessages.first.text;
 
   const ChatReady({
     required this.messages,
@@ -53,7 +56,7 @@ class ChatReady extends ChatState {
     this.peerOfflineReason,
     this.peerPresence = const PresenceUnknown(),
     this.isWorking = false,
-    this.queuedText,
+    this.queuedMessages = const [],
   });
 
   ChatReady copyWith({
@@ -64,10 +67,10 @@ class ChatReady extends ChatState {
     String? peerOfflineReason,
     PresenceState? peerPresence,
     bool? isWorking,
-    String? queuedText,
+    List<QueuedMsg>? queuedMessages,
     bool clearStreaming = false,
     bool clearPeerOffline = false,
-    bool clearQueuedText = false,
+    bool clearQueuedMessages = false,
   }) =>
       ChatReady(
         messages: messages ?? this.messages,
@@ -79,7 +82,9 @@ class ChatReady extends ChatState {
             : (peerOfflineReason ?? this.peerOfflineReason),
         peerPresence: peerPresence ?? this.peerPresence,
         isWorking: isWorking ?? this.isWorking,
-        queuedText: clearQueuedText ? null : (queuedText ?? this.queuedText),
+        queuedMessages: clearQueuedMessages
+            ? const []
+            : (queuedMessages ?? this.queuedMessages),
       );
 
   @override
@@ -92,7 +97,7 @@ class ChatReady extends ChatState {
       other.peerOfflineReason == peerOfflineReason &&
       other.peerPresence.runtimeType == peerPresence.runtimeType &&
       other.isWorking == isWorking &&
-      other.queuedText == queuedText;
+      other.queuedMessages == queuedMessages;
 
   @override
   int get hashCode => Object.hash(
@@ -103,7 +108,7 @@ class ChatReady extends ChatState {
         peerOfflineReason,
         peerPresence.runtimeType,
         isWorking,
-        queuedText,
+        queuedMessages,
       );
 }
 

--- a/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
+++ b/app/lib/ui/chat/viewmodels/chat_viewmodel.dart
@@ -31,7 +31,7 @@ class ChatViewModel extends ViewModel<ChatState> {
   StreamSubscription<RuntimeRecord>? _runtimeSub;
   StreamSubscription<StreamingMessage?>? _streamingSub;
   StreamSubscription<bool>? _workingSub;
-  StreamSubscription<String?>? _queuedSub;
+  StreamSubscription<List<QueuedMsg>>? _queuedSub;
   StreamSubscription<SessionEvent>? _eventSub;
   StreamSubscription<Map<String, List<RoomInfo>>>? _roomsSub;
   StreamSubscription<ConnectionStatus>? _statusSub;
@@ -44,7 +44,7 @@ class ChatViewModel extends ViewModel<ChatState> {
   List<ChatMessage> _messages = const [];
   StreamingMessage? _streaming;
   bool _working = false;
-  String? _queuedText;
+  List<QueuedMsg> _queuedMessages = const [];
   RuntimeRecord _runtime = const RuntimeRecord();
   bool _pairingRevoked = false;
   String? _peerOfflineReason;
@@ -106,16 +106,27 @@ class ChatViewModel extends ViewModel<ChatState> {
   /// The id to `cancel` to stop the in-flight reply (the user message the
   /// agent is answering). Null when idle. Prefers the live streaming target,
   /// falls back to the SyncService's tracked turn id.
-  String? get cancelTargetId => _streaming?.inReplyTo ?? _sync.workingReplyTo;
+  String? get cancelTargetId =>
+      _streaming?.inReplyTo ??
+      _sync.workingReplyTo ??
+      (isWorking ? 'working' : null);
 
-  String? get queuedText => _queuedText;
+  List<QueuedMsg> get queuedMessages => _queuedMessages;
+  String? get queuedText =>
+      _queuedMessages.isEmpty ? null : _queuedMessages.first.text;
 
-  void setQueuedMessage(String text) {
-    unawaited(_sync.setQueuedMessage(text));
+  void queueMessage(String text) {
+    unawaited(_sync.queueMessage(text));
   }
 
-  void clearQueuedMessage() {
-    unawaited(_sync.clearQueuedMessage());
+  void setQueuedMessage(String text) => queueMessage(text);
+
+  void clearQueuedMessage([String? id]) {
+    unawaited(_sync.clearQueuedMessage(id));
+  }
+
+  void clearQueuedMessages() {
+    unawaited(_sync.clearQueuedMessages());
   }
 
   // ---------------------------------------------------------------------------
@@ -158,7 +169,7 @@ class ChatViewModel extends ViewModel<ChatState> {
     // the constructor avoids inheriting the previous chat's bubble/pill.
     _streaming = _sync.streaming;
     _working = _sync.isWorking;
-    _queuedText = _sync.queuedText;
+    _queuedMessages = _sync.queuedMessages;
     _msgsSub = _read.watchMessages(epk, roomId).listen(_onMessages);
     _runtimeSub = _read.watchRuntime(epk, roomId).listen(_onRuntime);
 
@@ -182,8 +193,8 @@ class ChatViewModel extends ViewModel<ChatState> {
     _recompute();
   }
 
-  void _onQueued(String? text) {
-    _queuedText = text;
+  void _onQueued(List<QueuedMsg> messages) {
+    _queuedMessages = messages;
     _recompute();
   }
 
@@ -248,7 +259,7 @@ class ChatViewModel extends ViewModel<ChatState> {
       peerOfflineReason: _peerOfflineReason,
       peerPresence: peerPresence,
       isWorking: isWorking,
-      queuedText: _queuedText,
+      queuedMessages: _queuedMessages,
     );
   }
 

--- a/app/lib/ui/chat/widgets/input_bar.dart
+++ b/app/lib/ui/chat/widgets/input_bar.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app/data/images/image_picker_service.dart';
+import 'package:app/domain/session_state.dart';
 import 'package:app/ui/chat/attachment/states/attachment_state.dart';
 import 'package:app/ui/chat/attachment/viewmodels/attachment_viewmodel.dart';
 import 'package:app/ui/chat/voice/states/voice_input_state.dart';
@@ -41,10 +42,10 @@ class InputBar extends StatefulWidget {
   final VoidCallback? onOpenQuickActions;
   final VoidCallback? onStartAudio;
 
-  /// Pi-side queued text. Null means no queued message.
-  final String? queuedText;
+  /// Pi-side queued follow-ups. Empty means no queued messages.
+  final List<QueuedMsg> queuedMessages;
   final void Function(String text)? onSetQueued;
-  final VoidCallback? onClearQueued;
+  final void Function(String id)? onClearQueued;
 
   /// Plan/29 — voice-input ViewModel. When null the mic falls back to the
   /// legacy [onStartAudio] tap (and existing tests pump InputBar without it).
@@ -68,7 +69,7 @@ class InputBar extends StatefulWidget {
     this.onCancel,
     this.onOpenQuickActions,
     this.onStartAudio,
-    this.queuedText,
+    this.queuedMessages = const [],
     this.onSetQueued,
     this.onClearQueued,
     this.voice,
@@ -95,10 +96,6 @@ class _InputBarState extends State<InputBar> {
   late final FocusNode _focusNode = FocusNode(onKeyEvent: _onComposerKey);
   bool _empty = true;
   bool _cancelArmed = false;
-  // Message committed (via Enter/send) while a turn was working. Held here —
-  // not auto-derived from the field — so draft text the user is still editing
-  // is never sent without an explicit Enter. Flushed when the turn ends.
-  String? _queued;
   // True while the hold-to-talk gesture is active. Lets `_beginVoice` tell
   // whether the user is still holding once `startRecording` resolves — if not
   // (the permission prompt ended the hold), the recording is discarded.
@@ -108,7 +105,6 @@ class _InputBarState extends State<InputBar> {
   @override
   void initState() {
     super.initState();
-    _queued = widget.queuedText;
     _controller.addListener(_onTextChange);
     _subscribeTranscripts();
   }
@@ -119,9 +115,6 @@ class _InputBarState extends State<InputBar> {
     if (!identical(old.voice, widget.voice)) {
       _transcriptSub?.cancel();
       _subscribeTranscripts();
-    }
-    if (old.queuedText != widget.queuedText) {
-      _queued = widget.queuedText;
     }
   }
 
@@ -163,19 +156,11 @@ class _InputBarState extends State<InputBar> {
     widget.onSend(text);
   }
 
-  void _clearQueued() {
-    if (_queued == null) return;
-    setState(() => _queued = null);
-    widget.onClearQueued?.call();
-  }
-
-  void _editQueued() {
-    final text = _queued;
-    if (text == null) return;
-    setState(() => _queued = null);
-    widget.onClearQueued?.call();
-    _controller.text = text;
-    _controller.selection = TextSelection.collapsed(offset: text.length);
+  void _editQueued(QueuedMsg item) {
+    if (!item.editable) return;
+    widget.onClearQueued?.call(item.id);
+    _controller.text = item.text;
+    _controller.selection = TextSelection.collapsed(offset: item.text.length);
     _focusNode.requestFocus();
   }
 
@@ -360,11 +345,14 @@ class _InputBarState extends State<InputBar> {
                   image: attachState.image,
                   onRemove: widget.attachment!.removeImage,
                 ),
-              if (_queued != null && _queued!.isNotEmpty)
+              for (final item in widget.queuedMessages)
                 _QueuedMessagePreview(
-                  text: _queued!,
-                  onTap: _editQueued,
-                  onClear: _clearQueued,
+                  text: item.text,
+                  editable: item.editable,
+                  onTap: item.editable ? () => _editQueued(item) : null,
+                  onClear: item.editable
+                      ? () => widget.onClearQueued?.call(item.id)
+                      : null,
                 ),
               Row(
                 children: [
@@ -503,13 +491,15 @@ class _InputBarState extends State<InputBar> {
 class _QueuedMessagePreview extends StatelessWidget {
   const _QueuedMessagePreview({
     required this.text,
-    required this.onTap,
-    required this.onClear,
+    required this.editable,
+    this.onTap,
+    this.onClear,
   });
 
   final String text;
-  final VoidCallback onTap;
-  final VoidCallback onClear;
+  final bool editable;
+  final VoidCallback? onTap;
+  final VoidCallback? onClear;
 
   @override
   Widget build(BuildContext context) {
@@ -548,7 +538,7 @@ class _QueuedMessagePreview extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        'Queued. Tap to edit.',
+                        editable ? 'Queued. Tap to edit.' : 'Queued follow-up.',
                         style: TextStyle(
                           color: colors.accent,
                           fontFamily: kMonoFamily,
@@ -571,20 +561,22 @@ class _QueuedMessagePreview extends StatelessWidget {
                     ],
                   ),
                 ),
-                const SizedBox(width: 6),
-                SizedBox(
-                  width: 28,
-                  height: 28,
-                  child: IconButton(
-                    key: const Key('input-bar-clear-queued'),
-                    tooltip: 'Clear queued message',
-                    padding: EdgeInsets.zero,
-                    iconSize: 16,
-                    splashRadius: 16,
-                    onPressed: onClear,
-                    icon: Icon(LucideIcons.x, color: colors.muted2),
+                if (onClear != null) ...[
+                  const SizedBox(width: 6),
+                  SizedBox(
+                    width: 28,
+                    height: 28,
+                    child: IconButton(
+                      key: const Key('input-bar-clear-queued'),
+                      tooltip: 'Clear queued message',
+                      padding: EdgeInsets.zero,
+                      iconSize: 16,
+                      splashRadius: 16,
+                      onPressed: onClear,
+                      icon: Icon(LucideIcons.x, color: colors.muted2),
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
           ),
@@ -722,7 +714,10 @@ class _TranscribingStrip extends StatelessWidget {
         SizedBox(
           width: 13,
           height: 13,
-          child: CircularProgressIndicator(strokeWidth: 2, color: colors.accent),
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: colors.accent,
+          ),
         ),
         const SizedBox(width: 10),
         Text(
@@ -796,10 +791,7 @@ class _QuickActionsButtonState extends State<_QuickActionsButton>
     return SizeTransition(
       sizeFactor: _sizeFactor,
       axis: Axis.horizontal,
-      // Pin: Flutter 3.41.7 (CI FLUTTER_VERSION) — SizeTransition has no
-      // `alignment`; `axisAlignment` is only deprecated (not removed) on newer
-      // channels. Don't "fix the deprecation" without bumping the Flutter pin.
-      axisAlignment: -1.0,
+      alignment: Alignment.centerLeft,
       child: FadeTransition(
         opacity: _fade,
         child: Row(
@@ -912,7 +904,11 @@ class _ComposerActionButton extends StatelessWidget {
       );
     }
 
-    return GestureDetector(onTap: _resolveTap(), child: _button(context));
+    return GestureDetector(
+      key: const Key('input-bar-action'),
+      onTap: _resolveTap(),
+      child: _button(context),
+    );
   }
 
   Widget _button(BuildContext context) {

--- a/app/lib/ui/chat/widgets/message_bubble.dart
+++ b/app/lib/ui/chat/widgets/message_bubble.dart
@@ -21,6 +21,7 @@ class UserBubble extends StatelessWidget {
     // a red exclamation badge so the user knows to retry.
     final isPending = message.status == UserMsgStatus.pending;
     final isFailed = message.status == UserMsgStatus.failed;
+    final isSteering = message.steering;
     // Plan/30 — when an image is attached the bubble becomes an ImageBubble
     // (thumbnail + caption); otherwise the existing text card.
     final image = message.image;
@@ -61,13 +62,13 @@ class UserBubble extends StatelessWidget {
                       ),
                     ),
             ),
-            if (isPending || isFailed)
+            if (isPending || isSteering || isFailed)
               Padding(
                 padding: const EdgeInsets.only(top: 4, right: 4),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (isPending) ...[
+                    if (isPending || isSteering) ...[
                       SizedBox(
                         width: 10,
                         height: 10,
@@ -78,7 +79,7 @@ class UserBubble extends StatelessWidget {
                       ),
                       const SizedBox(width: 6),
                       Text(
-                        'sending…',
+                        isSteering ? 'steering…' : 'sending…',
                         style: typo.sansBody.copyWith(
                           color: colors.muted,
                           fontSize: 11,

--- a/app/test/data/local/records_test.dart
+++ b/app/test/data/local/records_test.dart
@@ -21,6 +21,7 @@ void main() {
         image: const MessageImage(data: 'QUJD', mime: 'image/jpeg'),
         ts: DateTime.fromMillisecondsSinceEpoch(1700),
         pending: true,
+        steering: true,
       );
       final back = MessageRecord.fromJson(r.toJson());
       expect(back.id, 'u1');
@@ -29,9 +30,11 @@ void main() {
       expect(back.text, 'hello');
       expect(back.image?.data, 'QUJD');
       expect(back.pending, isTrue);
+      expect(back.steering, isTrue);
       // Projects to the domain UserMsg the UI renders.
       final msg = back.toChatMessage() as UserMsg;
       expect(msg.status, UserMsgStatus.pending);
+      expect(msg.steering, isTrue);
       expect(msg.image, isNotNull);
     });
 

--- a/app/test/data/sync/sync_service_test.dart
+++ b/app/test/data/sync/sync_service_test.dart
@@ -150,6 +150,10 @@ void main() {
         (m) => m.text == 'refine this',
       );
       expect(sent.streamingBehavior, UserMessageStreamingBehavior.steer);
+      final steerRow = messages(s.epk).singleWhere((r) => r.id == sent.id);
+      expect(steerRow.pending, isTrue);
+      expect(steerRow.steering, isTrue);
+      expect((steerRow.toChatMessage() as UserMsg).steering, isTrue);
       expect(s.sync.workingReplyTo, 'u1');
       expect(s.sync.streaming, isNotNull);
       expect(s.sync.streaming!.inReplyTo, 'u1');
@@ -190,10 +194,147 @@ void main() {
     expect(s.sync.isWorking, isTrue);
     final rows = messages(s.epk);
     expect(rows, hasLength(2));
-    expect(rows.where((r) => r.id == sent.id).single.pending, isFalse);
+    var steerRow = rows.where((r) => r.id == sent.id).single;
+    expect(steerRow.pending, isFalse);
+    expect(steerRow.steering, isTrue, reason: 'echo only means accepted');
+    expect((steerRow.toChatMessage() as UserMsg).steering, isTrue);
     expect(index(s.epk)?.status, SessionActivity.working);
     expect(index(s.epk)?.lastMessagePreview, 'refine this');
 
+    s.ch.push(SteerConsumed(id: sent.id));
+    await _settle();
+
+    steerRow = messages(s.epk).where((r) => r.id == sent.id).single;
+    expect(steerRow.pending, isFalse);
+    expect(
+      steerRow.steering,
+      isFalse,
+      reason: 'actual queue delivery clears label',
+    );
+    expect((steerRow.toChatMessage() as UserMsg).steering, isFalse);
+
+    s.conn.dispose();
+    s.sync.dispose();
+  });
+
+  test(
+    'steer_consumed clears one steering label, not every queued steer',
+    () async {
+      final s = await setup();
+      s.ch.push(UserInput(id: 'u1', text: 'primary'));
+      await _settle();
+
+      await s.sync.sendMessage(
+        'first steer',
+        streamingBehavior: UserMessageStreamingBehavior.steer,
+      );
+      await s.sync.sendMessage(
+        'second steer',
+        streamingBehavior: UserMessageStreamingBehavior.steer,
+      );
+      await _settle();
+      final first = s.ch.sent.whereType<UserMessage>().lastWhere(
+        (m) => m.text == 'first steer',
+      );
+      final second = s.ch.sent.whereType<UserMessage>().lastWhere(
+        (m) => m.text == 'second steer',
+      );
+      for (final sent in [first, second]) {
+        s.ch.push(
+          UserInput(
+            id: sent.id,
+            text: sent.text,
+            streamingBehavior: UserMessageStreamingBehavior.steer,
+          ),
+        );
+      }
+      await _settle();
+      expect(
+        messages(s.epk).where((r) => r.id == first.id).single.steering,
+        isTrue,
+      );
+      expect(
+        messages(s.epk).where((r) => r.id == second.id).single.steering,
+        isTrue,
+      );
+
+      s.ch.push(AgentChunk(inReplyTo: 'u1', delta: 'working'));
+      await _settle();
+      expect(
+        messages(s.epk).where((r) => r.id == first.id).single.steering,
+        isTrue,
+      );
+      expect(
+        messages(s.epk).where((r) => r.id == second.id).single.steering,
+        isTrue,
+      );
+
+      s.ch.push(SteerConsumed(id: first.id));
+      await _settle();
+
+      expect(
+        messages(s.epk).where((r) => r.id == first.id).single.steering,
+        isFalse,
+      );
+      expect(
+        messages(s.epk).where((r) => r.id == second.id).single.steering,
+        isTrue,
+      );
+      s.conn.dispose();
+      s.sync.dispose();
+    },
+  );
+
+  test('agent_done clears only its steering label as a fallback', () async {
+    final s = await setup();
+    s.ch.push(UserInput(id: 'u1', text: 'primary'));
+    await _settle();
+
+    await s.sync.sendMessage(
+      'first steer',
+      streamingBehavior: UserMessageStreamingBehavior.steer,
+    );
+    await s.sync.sendMessage(
+      'second steer',
+      streamingBehavior: UserMessageStreamingBehavior.steer,
+    );
+    await _settle();
+    final first = s.ch.sent.whereType<UserMessage>().lastWhere(
+      (m) => m.text == 'first steer',
+    );
+    final second = s.ch.sent.whereType<UserMessage>().lastWhere(
+      (m) => m.text == 'second steer',
+    );
+    for (final sent in [first, second]) {
+      s.ch.push(
+        UserInput(
+          id: sent.id,
+          text: sent.text,
+          streamingBehavior: UserMessageStreamingBehavior.steer,
+        ),
+      );
+    }
+    await _settle();
+    expect(
+      messages(s.epk).where((r) => r.id == first.id).single.steering,
+      isTrue,
+    );
+    expect(
+      messages(s.epk).where((r) => r.id == second.id).single.steering,
+      isTrue,
+    );
+
+    s.ch.push(AgentDone(inReplyTo: first.id));
+    await _settle();
+
+    expect(
+      messages(s.epk).where((r) => r.id == first.id).single.steering,
+      isFalse,
+    );
+    expect(
+      messages(s.epk).where((r) => r.id == second.id).single.steering,
+      isTrue,
+    );
     s.conn.dispose();
     s.sync.dispose();
   });

--- a/app/test/protocol_test.dart
+++ b/app/test/protocol_test.dart
@@ -71,6 +71,59 @@ void main() {
     });
   });
 
+  group('Queued messages', () {
+    test('parses steer consumed clear signal', () {
+      final msg = ServerMessage.fromJson({
+        'type': 'steer_consumed',
+        'id': 's1',
+      }) as SteerConsumed;
+
+      expect(msg.id, 's1');
+    });
+
+    test('parses plural items and legacy fallback', () {
+      final plural = ServerMessage.fromJson({
+        'type': 'queued_message_state',
+        'items': [
+          {
+            'id': 'q1',
+            'text': 'next',
+            'editable': true,
+            'created_at': 123,
+          },
+        ],
+      }) as QueuedMessageState;
+
+      expect(plural.items, hasLength(1));
+      expect(plural.items.single.id, 'q1');
+      expect(plural.items.single.text, 'next');
+      expect(plural.items.single.editable, isTrue);
+      expect(plural.text, 'next');
+
+      final legacy = ServerMessage.fromJson({
+        'type': 'queued_message_state',
+        'id': 'old',
+        'text': 'legacy',
+      }) as QueuedMessageState;
+
+      expect(legacy.items, hasLength(1));
+      expect(legacy.items.single.id, 'old');
+      expect(legacy.items.single.text, 'legacy');
+      expect(legacy.items.single.editable, isTrue);
+    });
+
+    test('encodes targeted clear', () {
+      expect(
+        QueuedMessageClear(id: 'req1', targetId: 'q1').toJson(),
+        {'type': 'queued_message_clear', 'id': 'req1', 'target_id': 'q1'},
+      );
+      expect(
+        QueuedMessageClear(id: 'req2').toJson(),
+        {'type': 'queued_message_clear', 'id': 'req2'},
+      );
+    });
+  });
+
   group('ToolRequest', () {
     test('parses tool_call_id, tool, args', () {
       final msg = ServerMessage.fromJson({

--- a/app/test/ui/chat/chat_viewmodel_test.dart
+++ b/app/test/ui/chat/chat_viewmodel_test.dart
@@ -259,6 +259,69 @@ void main() {
     },
   );
 
+  test('queued state and commands roundtrip through ChatViewModel', () async {
+    final ch = _FakeChannel();
+    final storage = _FakeStorage();
+    final conn = ConnectionManager(
+      factory: (_, _) async => ch,
+      storage: storage,
+    );
+    final boxes = LocalBoxes();
+    final sync = SyncService(conn, boxes);
+    final read = SessionReadRepository(boxes);
+    final prefs = Preferences(_FakeSecureStorage());
+    await prefs.setSelectedPeerEpk(_peer.remoteEpk);
+    await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
+
+    conn.adopt(ch, _peer);
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    final vm = ChatViewModel(read, sync, conn, prefs, storage);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    ch.push(
+      QueuedMessageState(
+        items: [
+          QueuedMessageItem(
+            id: 'q1',
+            text: 'queued from pi',
+            editable: true,
+            createdAt: DateTime.fromMillisecondsSinceEpoch(123),
+          ),
+        ],
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    final state = vm.state as ChatReady;
+    expect(state.queuedMessages, hasLength(1));
+    expect(state.queuedMessages.single.id, 'q1');
+    expect(state.queuedMessages.single.text, 'queued from pi');
+    expect(state.queuedText, 'queued from pi');
+
+    vm.queueMessage(' next queued ');
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    final set = ch.sent.whereType<QueuedMessageSet>().last;
+    expect(set.text, 'next queued');
+    expect((vm.state as ChatReady).queuedMessages.map((q) => q.text), contains('next queued'));
+
+    vm.clearQueuedMessage('q1');
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    final clear = ch.sent.whereType<QueuedMessageClear>().last;
+    expect(clear.targetId, 'q1');
+    expect(
+      (vm.state as ChatReady).queuedMessages.map((q) => q.id),
+      isNot(contains('q1')),
+    );
+
+    ch.push(QueuedMessageState());
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect((vm.state as ChatReady).queuedMessages, isEmpty);
+
+    vm.dispose();
+    sync.dispose();
+    conn.dispose();
+  });
+
   test(
     'an empty session reaches ChatReady with no messages → the chat shows the '
     'default "Nothing here" placeholder (plan/32)',
@@ -348,6 +411,23 @@ void main() {
       isTrue,
       reason: 'state carries isWorking so the flip rebuilds the UI',
     );
+    expect(
+      vm.cancelTargetId,
+      'working',
+      reason: 'compaction/room-meta working has no turn id but still cancels',
+    );
+
+    await vm.sendMessage('meta-only steer');
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    final sentSteer = ch.sent.whereType<UserMessage>().lastWhere(
+      (m) => m.text == 'meta-only steer',
+    );
+    expect(sentSteer.streamingBehavior, UserMessageStreamingBehavior.steer);
+
+    await vm.cancel(vm.cancelTargetId!);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    final sentCancel = ch.sent.whereType<Cancel>().last;
+    expect(sentCancel.targetId, 'working');
 
     // If the app sees agent_done but the relay's meta.working=false
     // broadcast is delayed/missed, the active chat must not stay stuck on

--- a/app/test/ui/chat/input_bar_test.dart
+++ b/app/test/ui/chat/input_bar_test.dart
@@ -1,6 +1,7 @@
 // Plan/28 Wave C — settings/quick-actions icon visibility in the
 // chat input bar.
 
+import 'package:app/domain/session_state.dart';
 import 'package:app/ui/chat/widgets/input_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show LogicalKeyboardKey;
@@ -140,6 +141,108 @@ void main() {
     expect(find.byIcon(LucideIcons.square600), findsOneWidget); // stop
     expect(find.byIcon(LucideIcons.send600), findsNothing);
     expect(find.byIcon(LucideIcons.mic600), findsNothing);
+  });
+
+  testWidgets('streaming + text uses existing send button for steer', (
+    tester,
+  ) async {
+    String? queued;
+    String? sent;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InputBar(
+            disabled: false,
+            streaming: true,
+            onSend: (text) => sent = text,
+            onCancel: () {},
+            onSetQueued: (text) => queued = text,
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'steer me');
+    await tester.pump();
+    expect(find.byKey(const Key('input-bar-queue')), findsNothing);
+    await tester.tap(find.byKey(const Key('input-bar-action')));
+    await tester.pump();
+
+    expect(sent, 'steer me');
+    expect(queued, isNull);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text,
+      '',
+    );
+  });
+
+  testWidgets('queued preview edits and clears by id', (tester) async {
+    String? cleared;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InputBar(
+            disabled: false,
+            streaming: true,
+            queuedMessages: [
+              QueuedMsg(
+                id: 'q1',
+                text: 'queued text',
+                editable: true,
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1),
+              ),
+            ],
+            onSend: (_) {},
+            onCancel: () {},
+            onClearQueued: (id) => cleared = id,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('queued text'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('input-bar-queued-preview')));
+    await tester.pump();
+
+    expect(cleared, 'q1');
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text,
+      'queued text',
+    );
+  });
+
+  testWidgets('read-only queued preview has no clear affordance', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InputBar(
+            disabled: false,
+            streaming: true,
+            queuedMessages: [
+              QueuedMsg(
+                id: 'q1',
+                text: 'queued text',
+                editable: false,
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1),
+              ),
+            ],
+            onSend: (_) {},
+            onCancel: () {},
+            onClearQueued: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('input-bar-clear-queued')), findsNothing);
+    await tester.tap(find.byKey(const Key('input-bar-queued-preview')));
+    await tester.pump();
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text,
+      '',
+    );
   });
 
   testWidgets('streaming + text turns send into steering', (tester) async {

--- a/app/test/ui/chat/message_bubble_test.dart
+++ b/app/test/ui/chat/message_bubble_test.dart
@@ -62,4 +62,56 @@ void main() {
     expect(find.byType(SelectableText), findsOneWidget);
     expect(find.text('my message'), findsOneWidget);
   });
+
+  testWidgets('pending steer bubble shows steering label', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: UserBubble(
+            UserMsg(
+              id: 'u1',
+              text: 'busy follow-up',
+              status: UserMsgStatus.pending,
+              steering: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('steering…'), findsOneWidget);
+    expect(find.text('sending…'), findsNothing);
+  });
+
+  testWidgets('confirmed steer bubble keeps steering label', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: UserBubble(
+            UserMsg(id: 'u1', text: 'accepted follow-up', steering: true),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('steering…'), findsOneWidget);
+  });
+
+  testWidgets('pending normal bubble keeps sending label', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: UserBubble(
+            UserMsg(
+              id: 'u1',
+              text: 'normal send',
+              status: UserMsgStatus.pending,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('sending…'), findsOneWidget);
+  });
 }

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -162,6 +162,7 @@ const {
   _setCurrentModelForTest,
   _setPiForTest,
   _getCurrentTurnIdForTest,
+  _getPendingSteerIdsForTest,
   _connectForTest,
   _hasActivePeerForTest,
   _getActivePeerCountForTest,
@@ -852,6 +853,47 @@ function captureEventHandler(eventName: string): EventHandler {
   return captured;
 }
 
+function captureEventHarness(): {
+  handler: (eventName: string) => EventHandler;
+  emitBus: (channel: string, data: unknown) => void;
+} {
+  const handlers = new Map<string, EventHandler>();
+  const busHandlers = new Map<string, Array<(data: unknown) => void>>();
+  const pi = {
+    on(e: string, h: EventHandler) { handlers.set(e, h); },
+    events: {
+      emit(channel: string, data: unknown) {
+        for (const h of busHandlers.get(channel) ?? []) h(data);
+      },
+      on(channel: string, h: (data: unknown) => void) {
+        const list = busHandlers.get(channel) ?? [];
+        list.push(h);
+        busHandlers.set(channel, list);
+        return () => {
+          const current = busHandlers.get(channel) ?? [];
+          busHandlers.set(channel, current.filter((item) => item !== h));
+        };
+      },
+    },
+    registerCommand: () => undefined,
+    registerTool: () => undefined, registerShortcut: () => undefined,
+    registerFlag: () => undefined, getFlag: () => undefined,
+    registerMessageRenderer: () => undefined,
+    sendMessage: () => undefined, sendUserMessage: () => undefined,
+  } as unknown as ExtensionAPI;
+  (extension as ExtensionFactory)(pi);
+  return {
+    handler(eventName: string) {
+      const h = handlers.get(eventName);
+      if (!h) throw new Error(`event "${eventName}" handler not registered`);
+      return h;
+    },
+    emitBus(channel: string, data: unknown) {
+      (pi.events as unknown as { emit: (channel: string, data: unknown) => void }).emit(channel, data);
+    },
+  };
+}
+
 function captureMessageRenderer(): {
   getRenderer(): (message: { details?: unknown }, options: unknown, theme: unknown) => unknown;
 } {
@@ -1078,6 +1120,175 @@ describe("multi-channel broadcast (W2D)", () => {
     // Both owners received the echo (sender included).
     const recipients = new Set(echoes.map((d) => d.peer));
     expect(recipients).toEqual(new Set(["ownerA__1234567890", "ownerB__abcdefghij"]));
+  });
+
+  test("queued_message_set while working broadcasts editable queue and targeted clear", async () => {
+    await _pairForTest("ownerA__1234567890");
+    await _pairAdditionalForTest("ownerB__abcdefghij", "Android");
+    const harness = captureEventHarness();
+    const onInput = harness.handler("input");
+    onInput({ type: "input", text: "primary", source: "interactive" });
+    await new Promise<void>((r) => setImmediate(r));
+
+    const sendUserMessage = vi.fn();
+    _setPiForTest({ sendUserMessage, sendMessage: () => undefined });
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "queued_message_set", id: "q1", text: " next ",
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(sendUserMessage).not.toHaveBeenCalled();
+    let sent = relayRef.current!.send.mock.calls.slice(sendsBefore)
+      .map((c) => c[0] as string).map(decodeSentCt);
+    const states = sent.filter((d) => d.inner.type === "queued_message_state");
+    expect(states).toHaveLength(2);
+    expect(new Set(states.map((d) => d.peer))).toEqual(new Set(["ownerA__1234567890", "ownerB__abcdefghij"]));
+    for (const state of states) {
+      expect(state.inner).toMatchObject({
+        type: "queued_message_state",
+        id: "q1",
+        text: "next",
+        items: [expect.objectContaining({ id: "q1", text: "next", editable: true })],
+      });
+    }
+
+    const syncBefore = relayRef.current!.send.mock.calls.length;
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({ type: "session_sync", id: "sync-q", limit: 50 })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+    sent = relayRef.current!.send.mock.calls.slice(syncBefore)
+      .map((c) => c[0] as string).map(decodeSentCt);
+    expect(sent[0]?.inner.type).toBe("queued_message_state");
+    expect(sent[1]?.inner.type).toBe("session_history");
+
+    const clearBefore = relayRef.current!.send.mock.calls.length;
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "queued_message_clear", id: "clear-q", target_id: "q1",
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+    sent = relayRef.current!.send.mock.calls.slice(clearBefore)
+      .map((c) => c[0] as string).map(decodeSentCt);
+    expect(sent.filter((d) => d.inner.type === "queued_message_state").every((d) => (
+      Array.isArray(d.inner.items) && d.inner.items.length === 0
+    ))).toBe(true);
+  });
+
+  test("queued_message_set while idle drains immediately as a normal user turn", async () => {
+    await _pairForTest("ownerA__1234567890");
+    await _pairAdditionalForTest("ownerB__abcdefghij", "Android");
+    const sendUserMessage = vi.fn();
+    _setPiForTest({ sendUserMessage, sendMessage: () => undefined });
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "queued_message_set", id: "q-idle", text: "after this",
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(sendUserMessage).toHaveBeenCalledWith("after this", { deliverAs: "steer" });
+    expect(_getCurrentTurnIdForTest()).toBe("q-idle");
+    const sent = relayRef.current!.send.mock.calls.slice(sendsBefore)
+      .map((c) => c[0] as string).map(decodeSentCt);
+    const lastState = sent.filter((d) => d.inner.type === "queued_message_state").at(-1);
+    expect(lastState?.inner.items).toEqual([]);
+    const echoes = sent.filter((d) => d.inner.type === "user_message");
+    expect(echoes).toHaveLength(2);
+    for (const echo of echoes) {
+      expect(echo.inner).toMatchObject({ type: "user_message", id: "q-idle", text: "after this" });
+      expect(echo.inner).not.toHaveProperty("streaming_behavior");
+    }
+  });
+
+  test("queued drain waits for both agent_end and turn_end regardless of ordering", async () => {
+    await _pairForTest("ownerA__1234567890");
+    const harness = captureEventHarness();
+    const sendUserMessage = vi.fn();
+    _setPiForTest({ sendUserMessage, sendMessage: () => undefined });
+
+    harness.handler("input")({ type: "input", text: "primary", source: "interactive" });
+    harness.handler("turn_start")({ type: "turn_start", turnIndex: 0, timestamp: 0 });
+    await new Promise<void>((r) => setImmediate(r));
+    const sendsBeforeA = relayRef.current!.send.mock.calls.length;
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({ type: "queued_message_set", id: "q-order-a", text: "after A" })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+    expect(sendUserMessage).not.toHaveBeenCalledWith("after A", undefined);
+
+    harness.handler("agent_end")({ type: "agent_end" });
+    expect(sendUserMessage).not.toHaveBeenCalledWith("after A", { deliverAs: "steer" });
+    harness.handler("turn_end")({ type: "turn_end", turnIndex: 0, timestamp: 0 });
+    expect(sendUserMessage).toHaveBeenCalledWith("after A", { deliverAs: "steer" });
+    const statesA = relayRef.current!.send.mock.calls.slice(sendsBeforeA)
+      .map((c) => c[0] as string).map(decodeSentCt)
+      .filter((d) => d.inner.type === "queued_message_state");
+    expect(statesA.at(-1)?.inner.items).toEqual([]);
+
+    sendUserMessage.mockClear();
+    harness.handler("input")({ type: "input", text: "primary 2", source: "interactive" });
+    harness.handler("turn_start")({ type: "turn_start", turnIndex: 1, timestamp: 1 });
+    await new Promise<void>((r) => setImmediate(r));
+    const sendsBeforeB = relayRef.current!.send.mock.calls.length;
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({ type: "queued_message_set", id: "q-order-b", text: "after B" })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+    harness.handler("turn_end")({ type: "turn_end", turnIndex: 1, timestamp: 1 });
+    expect(sendUserMessage).not.toHaveBeenCalledWith("after B", { deliverAs: "steer" });
+    harness.handler("agent_end")({ type: "agent_end" });
+    expect(sendUserMessage).toHaveBeenCalledWith("after B", { deliverAs: "steer" });
+    const statesB = relayRef.current!.send.mock.calls.slice(sendsBeforeB)
+      .map((c) => c[0] as string).map(decodeSentCt)
+      .filter((d) => d.inner.type === "queued_message_state");
+    expect(statesB.at(-1)?.inner.items).toEqual([]);
+  });
+
+  test("queued drain restores item on synchronous sendUserMessage rejection", async () => {
+    await _pairForTest("ownerA__1234567890");
+    _setPiForTest({
+      sendUserMessage: vi.fn(() => { throw new Error("queue rejected"); }),
+      sendMessage: () => undefined,
+    });
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "queued_message_set", id: "q-fail", text: "after fail",
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+
+    const sent = relayRef.current!.send.mock.calls.slice(sendsBefore)
+      .map((c) => c[0] as string).map(decodeSentCt);
+    expect(sent.some((d) => d.inner.type === "user_message" && d.inner.id === "q-fail")).toBe(false);
+    expect(sent.find((d) => d.inner.type === "error")?.inner).toMatchObject({
+      type: "error",
+      code: "internal_error",
+      in_reply_to: "q-fail",
+    });
+    const lastState = sent.filter((d) => d.inner.type === "queued_message_state").at(-1);
+    expect(lastState?.inner).toMatchObject({
+      type: "queued_message_state",
+      id: "q-fail",
+      text: "after fail",
+      items: [expect.objectContaining({ id: "q-fail", text: "after fail" })],
+    });
   });
 
   test("plan/30: user_message with an image → save preview + send metadata-only custom message", async () => {
@@ -1460,6 +1671,131 @@ describe("multi-channel broadcast (W2D)", () => {
       });
     },
   );
+
+  test("plan/43: persisted user message clears the oldest pending steer", async () => {
+    await _pairForTest("ownerA__1234567890");
+    const sendUserMessage = vi.fn();
+    _setPiForTest({
+      sendUserMessage,
+      sendMessage: () => undefined,
+    });
+    const onMessageEnd = captureEventHandler("message_end");
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "user_message",
+        id: "msg-steer-end-consumed",
+        text: "consume this persisted steer",
+        streaming_behavior: "steer",
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+    expect(_getPendingSteerIdsForTest("consume this persisted steer")).toEqual(["msg-steer-end-consumed"]);
+
+    onMessageEnd({
+      type: "message_end",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "consume this persisted steer" }],
+        timestamp: Date.now(),
+      },
+    });
+    await new Promise<void>((r) => setImmediate(r));
+    expect(_getPendingSteerIdsForTest("consume this persisted steer")).toEqual([]);
+
+    const sent = relayRef.current!.send.mock.calls.slice(sendsBefore)
+      .map((c) => c[0] as string).map(decodeSentCt);
+    expect(sent.some((d) => (
+      d.inner.type === "steer_consumed" && d.inner.id === "msg-steer-end-consumed"
+    ))).toBe(true);
+  });
+
+  test("plan/43: started user message clears the oldest pending steer", async () => {
+    await _pairForTest("ownerA__1234567890");
+    const sendUserMessage = vi.fn();
+    _setPiForTest({
+      sendUserMessage,
+      sendMessage: () => undefined,
+    });
+    const onMessageStart = captureEventHandler("message_start");
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "user_message",
+        id: "msg-steer-consumed",
+        text: "consume this exact steer",
+        streaming_behavior: "steer",
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+    expect(_getPendingSteerIdsForTest("consume this exact steer")).toEqual(["msg-steer-consumed"]);
+
+    onMessageStart({
+      type: "message_start",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "SDK-rendered text differed" }],
+        timestamp: Date.now(),
+      },
+    });
+    await new Promise<void>((r) => setImmediate(r));
+    expect(_getPendingSteerIdsForTest("consume this exact steer")).toEqual([]);
+    expect(_getActivePeerCountForTest()).toBe(1);
+
+    const sent = relayRef.current!.send.mock.calls.slice(sendsBefore)
+      .map((c) => c[0] as string).map(decodeSentCt);
+    expect(sent.some((d) => (
+      d.inner.type === "steer_consumed" && d.inner.id === "msg-steer-consumed"
+    ))).toBe(true);
+  });
+
+  test("plan/43: message_start plus message_end consumes one steer only", async () => {
+    await _pairForTest("ownerA__1234567890");
+    _setPiForTest({
+      sendUserMessage: vi.fn(),
+      sendMessage: () => undefined,
+    });
+    const onMessageStart = captureEventHandler("message_start");
+    const onMessageEnd = captureEventHandler("message_end");
+    const sendsBefore = relayRef.current!.send.mock.calls.length;
+
+    for (const [id, text] of [["steer-1", "1"], ["steer-2", "2"]]) {
+      relayRef.current!.emit("message", JSON.stringify({
+        peer: "ownerA__1234567890",
+        ct: Buffer.from(JSON.stringify({
+          type: "user_message",
+          id,
+          text,
+          streaming_behavior: "steer",
+        })).toString("base64"),
+      }));
+    }
+    await new Promise<void>((r) => setImmediate(r));
+
+    const event = {
+      type: "message_start",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "1" }],
+        timestamp: Date.now(),
+      },
+    };
+    onMessageStart(event);
+    onMessageEnd({ ...event, type: "message_end" });
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(_getPendingSteerIdsForTest("1")).toEqual([]);
+    expect(_getPendingSteerIdsForTest("2")).toEqual(["steer-2"]);
+    const consumed = relayRef.current!.send.mock.calls.slice(sendsBefore)
+      .map((c) => c[0] as string)
+      .map(decodeSentCt)
+      .filter((d) => d.inner.type === "steer_consumed");
+    expect(consumed.map((d) => (d.inner as { id: string }).id)).toEqual(["steer-1"]);
+  });
 
   test("plan/43: steering without a known turn id still reaches SDK as steer", async () => {
     await _pairForTest("ownerA__1234567890");

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -58,6 +58,7 @@ import type {
   SessionHistoryEvent,
   ThinkingLevel,
   WireImage,
+  QueuedMessageItem,
 } from "./protocol/types.js";
 import { RelayClient, RoomAlreadyOpenError } from "./transport/relay_client.js";
 import { PlainPeerChannel } from "./transport/peer_channel.js";
@@ -678,6 +679,7 @@ async function _deliverImageUserMessage(
     return;
   }
 
+  if (shouldSteer) _trackPendingSteer(msg.id, msg.text);
   _echoUserMessage(msg, shouldSteer);
 }
 
@@ -741,6 +743,114 @@ type BufferMsg = {
   tokensBefore?: number;
 };
 let _messageBuffer: BufferMsg[] = [];
+type PendingSteer = { id: string; text: string };
+let _pendingSteers: PendingSteer[] = [];
+let _lastConsumedSteerText: string | null = null;
+
+type AndroidQueuedItem = QueuedMessageItem & { editable: true };
+let _queuedItems: AndroidQueuedItem[] = [];
+
+function _queuedStateMessage(): ServerMessage {
+  const first = _queuedItems[0];
+  return {
+    type: "queued_message_state",
+    ...(first ? { id: first.id, text: first.text } : {}),
+    items: _queuedItems.map((item) => ({ ...item })),
+  };
+}
+
+function _sendQueuedState(sender: PlainPeerChannel): void {
+  sender.send(_queuedStateMessage());
+}
+
+function _broadcastQueuedState(): void {
+  _broadcastToActive(_queuedStateMessage());
+}
+
+function _resetQueuedItems({ broadcast = false }: { broadcast?: boolean } = {}): void {
+  _queuedItems = [];
+  if (broadcast) _broadcastQueuedState();
+}
+
+function _upsertQueuedItem(item: AndroidQueuedItem): void {
+  const index = _queuedItems.findIndex((existing) => existing.id === item.id);
+  if (index === -1) {
+    _queuedItems = [..._queuedItems, item];
+  } else {
+    _queuedItems = [
+      ..._queuedItems.slice(0, index),
+      item,
+      ..._queuedItems.slice(index + 1),
+    ];
+  }
+  _broadcastQueuedState();
+}
+
+function _clearQueuedItems(targetId?: string): void {
+  _queuedItems = targetId
+    ? _queuedItems.filter((item) => item.id !== targetId)
+    : [];
+  _broadcastQueuedState();
+}
+
+function _isBusyForQueueDrain(): boolean {
+  return _currentTurnId !== null || _myRoomMeta?.working === true;
+}
+
+function _normalizeSteerText(text: string): string {
+  return text.trim();
+}
+
+function _trackPendingSteer(id: string, text: string): void {
+  const key = _normalizeSteerText(text);
+  if (!key) return;
+  _pendingSteers.push({ id, text: key });
+}
+
+function _consumePendingSteerForStartedUser(text: string): string | null {
+  if (_pendingSteers.length === 0) return null;
+  const key = _normalizeSteerText(text);
+  const index = key ? _pendingSteers.findIndex((item) => item.text === key) : -1;
+  const [item] = _pendingSteers.splice(index >= 0 ? index : 0, 1);
+  return item?.id ?? null;
+}
+
+function _broadcastConsumedSteerForUserContent(content: unknown): void {
+  const text = _stringifyContent(content);
+  if (_lastConsumedSteerText === text) {
+    _lastConsumedSteerText = null;
+    return;
+  }
+  const id = _consumePendingSteerForStartedUser(text);
+  if (!id) return;
+  _lastConsumedSteerText = text;
+  _broadcastToActive({ type: "steer_consumed", id });
+}
+
+function _maybeDrainQueuedItem(): void {
+  if (_isBusyForQueueDrain()) return;
+  const item = _queuedItems.shift();
+  if (!item) return;
+  _broadcastQueuedState();
+
+  const previousTurnId = _currentTurnId;
+  _currentTurnId = item.id;
+  const msg: ClientUserMessage = { type: "user_message", id: item.id, text: item.text };
+  const wake = _wakeAgent(item.text, `queued app user_message id=${item.id}`, "steer");
+  if (!wake.ok) {
+    _currentTurnId = previousTurnId;
+    _queuedItems = [item, ..._queuedItems];
+    _broadcastQueuedState();
+    _broadcastToActive({
+      type: "error",
+      code: "internal_error",
+      in_reply_to: item.id,
+      message: `Agent rejected queued message: ${wake.detail}`,
+    });
+    return;
+  }
+  _echoUserMessage(msg, false);
+}
 
 /** Test-only override of the message buffer. */
 /**
@@ -815,6 +925,11 @@ export function _setCurrentModelForTest(name: string | undefined): void {
 /** Test-only: read the active turn id used for plain `cancel` routing. */
 export function _getCurrentTurnIdForTest(): string | null {
   return _currentTurnId;
+}
+
+export function _getPendingSteerIdsForTest(text: string): string[] {
+  const key = _normalizeSteerText(text);
+  return _pendingSteers.filter((item) => item.text === key).map((item) => item.id);
 }
 
 /** Test-only: override the bound AgentSession so a spy can capture the
@@ -1043,6 +1158,8 @@ function _goIdle(byeReason?: import("./protocol/types.js").ByeReason): void {
   _stopAutoListener?.();
   _stopAutoListener = null;
 
+  if (_queuedItems.length > 0) _resetQueuedItems({ broadcast: true });
+
   // Tear down every per-owner channel and clear the map.
   for (const ch of _activePeers.values()) {
     try { ch.detach(); } catch { /* best-effort */ }
@@ -1051,6 +1168,9 @@ function _goIdle(byeReason?: import("./protocol/types.js").ByeReason): void {
   _peerShort = "";
   _currentTurnId = null;
   _pendingReceivedImagePreviews.length = 0;
+  _pendingSteers = [];
+  _lastConsumedSteerText = null;
+  _resetQueuedItems();
 
   _relay?.close();
   _relay = null;
@@ -1098,9 +1218,13 @@ function _onRelayClose(): void {
   for (const ch of _activePeers.values()) {
     try { ch.detach(); } catch { /* best-effort */ }
   }
+  if (_queuedItems.length > 0) _resetQueuedItems({ broadcast: true });
   _activePeers.clear();
   _peerShort = "";
   _currentTurnId = null;
+  _pendingSteers = [];
+  _lastConsumedSteerText = null;
+  _resetQueuedItems();
 
   _relay = null;  // _relayUrl preserved for retry
 
@@ -1719,6 +1843,12 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
     });
   });
 
+  pi.on("message_start", (event) => {
+    const message = event?.message as BufferMsg | undefined;
+    if (!_anyPeerActive() || message?.role !== "user") return;
+    _broadcastConsumedSteerForUserContent(message.content);
+  });
+
   pi.on("message_update", (event) => {
     if (!_anyPeerActive() || !_currentTurnId) return;
     const ae = event.assistantMessageEvent;
@@ -1762,8 +1892,11 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // or RPC. Previous impl overwrote on `agent_end` and lost everything but the
   // last turn (see diagnostics 14, 15).
   pi.on("message_end", (event) => {
-    const m = event?.message as { role?: string; stopReason?: string; errorMessage?: string } | undefined;
+    const m = event?.message as { role?: string; content?: unknown; stopReason?: string; errorMessage?: string } | undefined;
     if (!m) return;
+    if (m.role === "user" && _anyPeerActive()) {
+      _broadcastConsumedSteerForUserContent(m.content);
+    }
     if (m.role === "user" || m.role === "assistant" || m.role === "toolResult") {
       _messageBuffer.push(m as unknown as BufferMsg);
     }
@@ -1792,6 +1925,8 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
       _currentTurnId = null;
     }
     _flushPendingReceivedImagePreviews();
+    _lastConsumedSteerText = null;
+    _maybeDrainQueuedItem();
   });
 
   // plan/34: the broker no longer gates delivery on busy state, so we no
@@ -1822,6 +1957,7 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
     if (_relay && _myRoomId) {
       _relay.sendControl({ type: "room_meta_update", room_id: _myRoomId, meta: { working: false } });
     }
+    _maybeDrainQueuedItem();
   });
 
   // Plan/32: compaction feedback. compact() doesn't run a turn, so bracket it
@@ -1851,6 +1987,7 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
     _broadcastToActive({ type: "compaction", summary, tokens_before: tokensBefore, ts });
     // (3) Working ends.
     _publishWorking(false);
+    _maybeDrainQueuedItem();
   });
 
   // Re-capture the freshest base ctx on every session replacement so compact
@@ -3625,6 +3762,19 @@ export function _routeClientMessageFrom(
   }
   if (!_pi) return;
   switch (msg.type) {
+    case "queued_message_set": {
+      const text = msg.text.trim();
+      if (!text) {
+        _clearQueuedItems(msg.id);
+        break;
+      }
+      _upsertQueuedItem({ id: msg.id, text, editable: true, created_at: Date.now() });
+      _maybeDrainQueuedItem();
+      break;
+    }
+    case "queued_message_clear":
+      _clearQueuedItems(msg.target_id);
+      break;
     case "user_message": {
       // Source-of-truth rebroadcast (plan/24 W2D fix). Echo the message
       // back to every attached owner (sender included) after the SDK accepts
@@ -3681,6 +3831,7 @@ export function _routeClientMessageFrom(
         });
         break;
       }
+      if (shouldSteer) _trackPendingSteer(msg.id, msg.text);
       _echoUserMessage(msg, shouldSteer);
       break;
     }
@@ -3826,6 +3977,7 @@ function _handleSessionSync(
   sender: PlainPeerChannel,
   msg: Extract<ClientMessage, { type: "session_sync" }>,
 ): void {
+  _sendQueuedState(sender);
   if (_sessionStartedAt === null) {
     sender.send({
       type: "session_history",
@@ -3875,6 +4027,9 @@ function _handleSessionSync(
  */
 function _resetSessionForNew(inReplyTo: string): void {
   _messageBuffer = [];
+  _pendingSteers = [];
+  _lastConsumedSteerText = null;
+  _resetQueuedItems({ broadcast: true });
   _sessionStartedAt = Date.now();
   _broadcastToActive({
     type: "session_history",

--- a/pi-extension/src/protocol/types.ts
+++ b/pi-extension/src/protocol/types.ts
@@ -6,6 +6,13 @@ export type PairErrorCode =
 
 export type StreamingBehavior = "steer";
 
+export type QueuedMessageItem = {
+  id: string;
+  text: string;
+  editable: boolean;
+  created_at: number;
+};
+
 export type ClientMessage =
   | { type: "pair_request"; id: string; token: string; device_name: string }
   // Plan/30: optional `images` carry inline base64 attachments (one today).
@@ -18,7 +25,7 @@ export type ClientMessage =
       streaming_behavior?: StreamingBehavior;
     }
   | { type: "queued_message_set"; id: string; text: string }
-  | { type: "queued_message_clear"; id: string }
+  | { type: "queued_message_clear"; id: string; target_id?: string }
   | { type: "approve_tool"; id: string; tool_call_id: string; decision: "allow" | "deny" }
   | { type: "cancel"; id: string; target_id: string }
   | { type: "ping"; id: string }
@@ -131,7 +138,8 @@ export type ServerMessage =
       images?: WireImage[];
       streaming_behavior?: StreamingBehavior;
     }
-  | { type: "queued_message_state"; id?: string; text?: string }
+  | { type: "queued_message_state"; id?: string; text?: string; items?: QueuedMessageItem[] }
+  | { type: "steer_consumed"; id: string }
   | { type: "agent_chunk"; in_reply_to: string; delta: string }
   | { type: "agent_done"; in_reply_to: string; usage?: Usage }
   | { type: "agent_message"; in_reply_to: string; text: string; usage?: Usage }

--- a/plan/47-android-queued-editing.md
+++ b/plan/47-android-queued-editing.md
@@ -1,0 +1,941 @@
+# 47 — Android-owned queued follow-up MVP
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `subagent-driven-development` or `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not edit app/pi-extension code from the monorepo root; dispatch or work inside the owning subproject.
+
+**Goal:** Android shows queued follow-up messages, lets the user edit/clear Android-owned queued follow-ups before delivery, and drains them safely after the current Pi turn.
+
+**Architecture:** Keep the app SSOT rule: `SyncService` is the only transport/DB writer, and UI reads queue/session state through `ChatViewModel`. Remote Pi owns a small explicit follow-up queue for Android; it is separate from Pi SDK internal steering/follow-up queues because the extension API does not expose stable queue item IDs or mutation APIs. Draining a queued Android item follows the same invariants as a normal accepted app user message: seed `_currentTurnId`, hand off to Pi, echo `user_message` to all owners, then let existing chunk/done forwarding finish the turn.
+
+**Tech Stack:** TypeScript `pi-extension`, Pi extension API, Flutter/Dart app, Hive row-granular SSOT, existing `vitest` + `flutter test`.
+
+## Global Constraints
+
+- No code changes outside `app/` and `pi-extension/` for implementation; this root `plan/` file is planning only.
+- No new dependencies.
+- Preserve current Plan 43 behavior: while working, the main send action still sends **steer now**.
+- Queue is additive: while working with text, Android shows a separate Queue button for “run after current turn”.
+- Queue MVP is text-only. Image attachments keep the existing send/steer path.
+- Android-owned queued items are editable/clearable by Android before delivery.
+- Pi/TUI-originated SDK queued messages are **out of MVP**. No text matching, no internal SDK queue hacks.
+- If Android sends a queued item while Pi is idle, Pi drains it immediately as a normal text user message and broadcasts an empty queue state.
+- Multi-owner consistency is mandatory: every queue state change and every drained user message is broadcast to all active owners.
+- Sent-message editing is deferred to a separate feasibility plan. Do not implement `message_edit`, `entry_id`, or `ActionName.message_edit` in this plan.
+- Run verification from `app/` or `pi-extension/`, not from the monorepo root.
+
+---
+
+## Review Corrections Applied
+
+The first draft mixed a safe queue MVP with unsafe sent-message editing. Review found these implementation blockers, now removed or fixed here:
+
+- Sent-message editing needs command-only `navigateTree` and stable history entry IDs; current router contexts cannot prove that safely. It is deferred.
+- `message_edit` would require closed `ActionName` changes in TS and Dart; no `message_edit` appears in this plan.
+- Replacing `_messageBuffer` history mapping risks regressing ask_user/tool/compaction/image replay; this plan does not touch history mapping.
+- Queue drain must echo accepted queued messages as normal `user_message`; Task 3 requires this.
+- Queue drain must handle `agent_end`/`turn_end` ordering; Task 3 uses one busy helper and tests both event orders.
+- `_wakeAgent` only catches synchronous handoff rejection. Tests and wording only promise restore on synchronous rejection, not provider/runtime failures after handoff.
+- Queue `mode` is not client-settable in this MVP. Android queue items are always follow-up.
+
+---
+
+## Current Evidence / Gaps
+
+Already present:
+
+- `PROTOCOL.md` documents a one-slot queue shape:
+  - app → Pi: `queued_message_set`, `queued_message_clear`
+  - Pi → app: `queued_message_state`
+  - `session_sync` should send queued state before history.
+- App protocol/data/UI has partial one-slot scaffolding:
+  - `app/lib/protocol/protocol.dart`: `QueuedMessageSet`, `QueuedMessageClear`, `QueuedMessageState`
+  - `app/lib/data/sync/sync_service.dart`: `setQueuedMessage`, `clearQueuedMessage`, `_queuedText`, `queuedStream`
+  - `app/lib/ui/chat/viewmodels/chat_viewmodel.dart`: subscribes to queued state
+  - `app/lib/ui/chat/chat_page.dart`: passes `queuedText`, `onSetQueued`, `onClearQueued`
+  - `app/lib/ui/chat/widgets/input_bar.dart`: renders one queued preview and can pull it back into the composer
+- Pi extension protocol types already include `queued_message_set` / `queued_message_clear`, but `pi-extension/src/index.ts` does not route them or send `queued_message_state` in `session_sync`.
+- `InputBar.onSetQueued` is not used, so Android has no visible Queue button.
+- Current compaction fix has a separate `_compactionQueue` for app `user_message` during compaction. Do not replace it; the editable follow-up queue is separate.
+
+---
+
+## Non-goals
+
+- Sent-message editing from Android.
+- In-place mutation of already-sent user history.
+- Editing Pi/TUI internal SDK queues.
+- Queueing images.
+- Replacing steer-now as the default main send action while working.
+- Persisting queued items to disk across Pi process restarts.
+- New relay behavior.
+
+---
+
+## UX
+
+1. Idle composer:
+   - Send submits a normal user message.
+   - Queue button is hidden.
+2. Working composer with text and no image:
+   - Main send button still sends steer-now.
+   - A compact Queue/clock icon appears beside Send/Stop.
+   - Stop remains reachable through the existing inline stop affordance.
+3. Queued rows above composer:
+   - Show `Queued follow-up · <preview>`.
+   - Editable Android-owned rows have tap-to-edit and clear (`x`).
+4. Tap-to-edit behavior:
+   - Tapping a queued row clears that queued item on Pi and places the text back into the composer.
+   - If the user abandons the edit, the queued item is gone. This is deliberate for the MVP; it avoids distributed draft locks across multiple Android owners.
+5. Multi-owner behavior:
+   - Queue/clear/edit updates every connected Android owner.
+   - Drained item appears as a normal user bubble on every connected owner.
+
+---
+
+## Wire Contract
+
+### Client → Pi
+
+Existing messages are extended minimally:
+
+```json
+{ "type": "queued_message_set", "id": "q_123", "text": "run tests after this" }
+{ "type": "queued_message_clear", "id": "req_1", "target_id": "q_123" }
+{ "type": "queued_message_clear", "id": "req_2" }
+```
+
+Rules:
+
+- `queued_message_set.id` is the queue item id.
+- Reusing the same item id replaces that item text.
+- `queued_message_set.text.trim() === ""` clears that item id.
+- `queued_message_clear.target_id` clears one item.
+- `queued_message_clear` without `target_id` clears all Android-owned queued items, preserving the old one-slot clear intent.
+
+### Pi → app(s)
+
+`queued_message_state` keeps legacy `id`/`text` and adds plural `items`:
+
+```json
+{
+  "type": "queued_message_state",
+  "id": "q_123",
+  "text": "run tests after this",
+  "items": [
+    {
+      "id": "q_123",
+      "text": "run tests after this",
+      "editable": true,
+      "created_at": 1782250000000
+    }
+  ]
+}
+```
+
+Empty state:
+
+```json
+{ "type": "queued_message_state", "items": [] }
+```
+
+Compatibility:
+
+- Older apps read `id`/`text` and show only the first queued item.
+- Newer apps reading an older Pi build fall back from missing `items` to legacy `id`/`text`.
+
+---
+
+## File Map
+
+### Docs / protocol
+
+- Modify: `PROTOCOL.md`
+  - Document plural `queued_message_state.items`, optional `target_id`, idle immediate drain, and Android-owned edit semantics.
+
+### Pi extension
+
+- Modify: `pi-extension/src/protocol/types.ts`
+  - Add `QueuedMessageItem`.
+  - Add `target_id?: string` to `queued_message_clear`.
+  - Add `items?: QueuedMessageItem[]` to `queued_message_state`.
+- Modify: `pi-extension/src/protocol/codec.ts` only if codec fixtures enumerate server/client message types.
+- Modify: `pi-extension/src/index.ts`
+  - Add module-local Android queued item store.
+  - Handle `queued_message_set` and `queued_message_clear`.
+  - Broadcast queue state on set/clear/drain/session reset/relay close.
+  - Send queue state before `session_history` in `session_sync`.
+  - Drain one queued item when safe, preserving normal app-user turn invariants.
+- Test: `pi-extension/src/extension.test.ts`
+  - Queue set/replace/clear/sync/drain/multi-owner/order tests.
+
+### App protocol/data/domain/UI
+
+- Modify: `app/lib/protocol/protocol.dart`
+  - Add `QueuedMessageItem` parser.
+  - Add `QueuedMessageState.items` with legacy fallback.
+  - Add `QueuedMessageClear.targetId` encoder.
+- Modify: `app/lib/domain/session_state.dart`
+  - Add protocol-free domain value `QueuedMsg`.
+- Modify: `app/lib/data/sync/sync_service.dart`
+  - Replace one `String?` queue state with `List<QueuedMsg>` state/stream.
+  - Keep `queuedText` compatibility getter only if it reduces diff.
+  - Add queue and clear-by-id commands.
+- Modify: `app/lib/ui/chat/states/chat_state.dart`
+  - Add `queuedMessages`.
+- Modify: `app/lib/ui/chat/viewmodels/chat_viewmodel.dart`
+  - Expose queue list and commands.
+- Modify: `app/lib/ui/chat/chat_page.dart`
+  - Pass queue list and callbacks to `InputBar`.
+- Modify: `app/lib/ui/chat/widgets/input_bar.dart`
+  - Add Queue icon and plural queue preview/edit rows.
+- Tests:
+  - `app/test/ui/chat/input_bar_test.dart`
+  - `app/test/ui/chat/chat_viewmodel_test.dart`
+  - protocol test file used by existing protocol tests.
+
+---
+
+## Task 1 — Protocol docs and queue schema
+
+**Files:**
+
+- Modify: `PROTOCOL.md`
+- Modify: `pi-extension/src/protocol/types.ts`
+- Modify: `app/lib/protocol/protocol.dart`
+- Test: existing app protocol tests and TS type/codec tests.
+
+**Interfaces produced:**
+
+TS:
+
+```ts
+export type QueuedMessageItem = {
+  id: string;
+  text: string;
+  editable: boolean;
+  created_at: number;
+};
+```
+
+Dart:
+
+```dart
+class QueuedMessageItem {
+  final String id;
+  final String text;
+  final bool editable;
+  final DateTime createdAt;
+}
+```
+
+- [x] **Step 1: Write failing Dart protocol tests**
+
+Add or extend the existing protocol test with:
+
+```dart
+test('queued_message_state parses plural items and legacy fallback', () {
+  final plural = ServerMessage.fromJson({
+    'type': 'queued_message_state',
+    'items': [
+      {
+        'id': 'q1',
+        'text': 'next',
+        'editable': true,
+        'created_at': 123,
+      },
+    ],
+  }) as QueuedMessageState;
+
+  expect(plural.items, hasLength(1));
+  expect(plural.items.single.id, 'q1');
+  expect(plural.items.single.text, 'next');
+  expect(plural.items.single.editable, isTrue);
+  expect(plural.text, 'next');
+
+  final legacy = ServerMessage.fromJson({
+    'type': 'queued_message_state',
+    'id': 'old',
+    'text': 'legacy',
+  }) as QueuedMessageState;
+
+  expect(legacy.items, hasLength(1));
+  expect(legacy.items.single.id, 'old');
+  expect(legacy.items.single.text, 'legacy');
+  expect(legacy.items.single.editable, isTrue);
+});
+
+test('queued_message_clear can target one queued item', () {
+  expect(
+    QueuedMessageClear(id: 'req1', targetId: 'q1').toJson(),
+    {'type': 'queued_message_clear', 'id': 'req1', 'target_id': 'q1'},
+  );
+  expect(
+    QueuedMessageClear(id: 'req2').toJson(),
+    {'type': 'queued_message_clear', 'id': 'req2'},
+  );
+});
+```
+
+Run from `app/`:
+
+```bash
+flutter test test/protocol_test.dart --plain-name queued_message_state
+```
+
+Expected before implementation: fails because `items`/`targetId` do not exist.
+
+- [x] **Step 2: Implement Dart protocol parsing/encoding**
+
+Implementation rules:
+
+- `QueuedMessageState.items` parses `items` when present.
+- If `items` is absent and `text` is non-empty, create one legacy item from `id/text`.
+- If both are absent/empty, `items == const []` and `text == null`.
+- `created_at` is milliseconds since epoch; missing value maps to `DateTime.fromMillisecondsSinceEpoch(0)`.
+- `QueuedMessageState.id` / `text` return the first item for compatibility.
+
+- [x] **Step 3: Add TS types**
+
+Update `pi-extension/src/protocol/types.ts` so these compile:
+
+```ts
+const clearOne: ClientMessage = { type: "queued_message_clear", id: "req1", target_id: "q1" };
+const clearAll: ClientMessage = { type: "queued_message_clear", id: "req2" };
+const state: ServerMessage = {
+  type: "queued_message_state",
+  id: "q1",
+  text: "next",
+  items: [{ id: "q1", text: "next", editable: true, created_at: 123 }],
+};
+```
+
+Do not add `message_edit` or queue `mode` types.
+
+- [x] **Step 4: Update `PROTOCOL.md`**
+
+Replace the old one-slot queue section with the wire contract above. Explicitly state:
+
+- Android queue is text-only follow-up.
+- Idle set drains immediately.
+- Pi/TUI internal queues are not exposed in this MVP.
+
+- [x] **Step 5: Verify Task 1**
+
+Run:
+
+```bash
+cd pi-extension && ../node_modules/.bin/tsc --noEmit
+cd app && flutter test test/protocol_test.dart
+```
+
+Expected: typecheck and protocol tests pass.
+
+---
+
+## Task 2 — Pi-extension queue state and sync
+
+**Files:**
+
+- Modify: `pi-extension/src/index.ts`
+- Test: `pi-extension/src/extension.test.ts`
+
+**Interfaces consumed:** Task 1 TS `QueuedMessageItem`.
+
+**Interfaces produced:**
+
+```ts
+type AndroidQueuedItem = {
+  id: string;
+  text: string;
+  editable: true;
+  created_at: number;
+};
+```
+
+Helpers:
+
+```ts
+function _sendQueuedState(sender: PlainPeerChannel): void;
+function _broadcastQueuedState(): void;
+function _upsertQueuedItem(item: AndroidQueuedItem): void;
+function _clearQueuedItems(targetId?: string): void;
+```
+
+- [x] **Step 1: Write failing queue state tests**
+
+Add tests in `pi-extension/src/extension.test.ts`:
+
+1. While working, `queued_message_set` broadcasts one queued item to every active owner.
+2. Reusing the same item id replaces text and keeps one item.
+3. `queued_message_clear { target_id }` removes only that item.
+4. `queued_message_clear` without `target_id` clears all Android queue items.
+5. `session_sync` sends `queued_message_state` before `session_history`.
+6. `session_new` / relay close broadcasts empty queue state.
+
+Use production routing (`_routeClientMessageFrom`) and captured event handlers already used by nearby tests. For “working”, trigger the captured `turn_start` or set the same room-meta path existing tests use; do not expect a queued item while idle.
+
+Expected failing assertion before implementation:
+
+```ts
+expect(ownerA.sent).toContainEqual(expect.objectContaining({
+  type: "queued_message_state",
+  items: [expect.objectContaining({ id: "q1", text: "next", editable: true })],
+}));
+```
+
+Run:
+
+```bash
+cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t queued_message
+```
+
+Expected before implementation: fails because router ignores queued messages.
+
+- [x] **Step 2: Add module-local queue store**
+
+In `pi-extension/src/index.ts` near current turn/compaction module state:
+
+```ts
+let _queuedItems: AndroidQueuedItem[] = [];
+```
+
+Keep this independent from existing `_compactionQueue`.
+
+- [x] **Step 3: Implement state send/broadcast helpers**
+
+`_sendQueuedState(sender)` sends:
+
+```ts
+const first = _queuedItems[0];
+sender.send({
+  type: "queued_message_state",
+  ...(first ? { id: first.id, text: first.text } : {}),
+  items: _queuedItems.map((item) => ({ ...item })),
+});
+```
+
+`_broadcastQueuedState()` calls `_sendQueuedState` for all active owners.
+
+- [x] **Step 4: Route set/clear messages**
+
+Add cases in `_routeClientMessageFrom`:
+
+```ts
+case "queued_message_set": {
+  const text = msg.text.trim();
+  if (!text) {
+    _clearQueuedItems(msg.id);
+    break;
+  }
+  _upsertQueuedItem({ id: msg.id, text, editable: true, created_at: Date.now() });
+  _maybeDrainQueuedItem();
+  break;
+}
+case "queued_message_clear":
+  _clearQueuedItems(msg.target_id);
+  break;
+```
+
+`_upsertQueuedItem` broadcasts state after mutation unless `_maybeDrainQueuedItem` drains immediately. Simpler acceptable implementation: broadcast queued state after upsert, then if idle drain and broadcast empty state. Tests should accept the final empty state in idle case.
+
+- [x] **Step 5: Send queue state during sync**
+
+At the start of `_handleSessionSync`, before `session_history`, call:
+
+```ts
+_sendQueuedState(sender);
+```
+
+- [x] **Step 6: Reset queue on session/relay teardown**
+
+Clear queue and broadcast empty state on:
+
+- successful `_resetSessionForNew`
+- relay close / `_goIdle` teardown paths that clear active peers
+- extension-level shutdown path if one exists beside relay close
+
+Do not clear queue on ordinary `turn_end`; that is handled by drain.
+
+- [x] **Step 7: Verify Task 2**
+
+Run:
+
+```bash
+cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t queued_message
+cd pi-extension && ../node_modules/.bin/tsc --noEmit
+```
+
+Expected: queue state/sync tests pass.
+
+---
+
+## Task 3 — Pi-extension drain lifecycle and echo invariants
+
+**Files:**
+
+- Modify: `pi-extension/src/index.ts`
+- Test: `pi-extension/src/extension.test.ts`
+
+**Interfaces consumed:** Task 2 `_queuedItems`, `_broadcastQueuedState`.
+
+**Interfaces produced:** Accepted queued items become normal app user turns after the active turn finishes.
+
+- [x] **Step 1: Write failing drain tests**
+
+Add tests for:
+
+1. While working, `queued_message_set` does not call `_pi.sendUserMessage` immediately.
+2. While idle, `queued_message_set` drains immediately and final queue state is empty.
+3. Draining seeds `_currentTurnId` with the queued item id.
+4. Draining calls `_wakeAgent(item.text, ..., "steer")` as an SDK-safe handoff; the app echo still omits `streaming_behavior` so it renders as a normal queued follow-up.
+5. After synchronous handoff succeeds, draining broadcasts `user_message { id, text }` with no `streaming_behavior` to all owners.
+6. A later `message_update` chunk uses `in_reply_to` equal to the queued item id.
+7. `agent_end` before `turn_end` drains exactly once after both “not current turn” and “not working” are true.
+8. `turn_end` before `agent_end` drains exactly once after both “not current turn” and “not working” are true.
+9. A synchronous `_wakeAgent` rejection restores the item and broadcasts it again.
+10. Async provider/runtime failure after accepted handoff is not restored; existing `error`/`agent_done` behavior handles the visible turn.
+
+Run:
+
+```bash
+cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t "queued drain"
+```
+
+Expected before implementation: fails because no drain exists.
+
+- [x] **Step 2: Add one busy helper**
+
+```ts
+function _isBusyForQueueDrain(): boolean {
+  return _compactionActive || _currentTurnId !== null || _myRoomMeta?.working === true;
+}
+```
+
+This helper is the only drain gate. Tests must cover both `agent_end`/`turn_end` orderings.
+
+- [x] **Step 3: Implement `_maybeDrainQueuedItem`**
+
+Pseudo-code:
+
+```ts
+function _maybeDrainQueuedItem(): void {
+  if (_isBusyForQueueDrain()) return;
+  const item = _queuedItems.shift();
+  if (!item) return;
+
+  _broadcastQueuedState();
+  const previousTurnId = _currentTurnId;
+  _currentTurnId = item.id;
+
+  const msg: ClientUserMessage = { type: "user_message", id: item.id, text: item.text };
+  const wake = _wakeAgent(item.text, `queued app user_message id=${item.id}`, "steer");
+  if (!wake.ok) {
+    _currentTurnId = previousTurnId;
+    _queuedItems.unshift(item);
+    _broadcastQueuedState();
+    _broadcastToActive({
+      type: "error",
+      code: "internal_error",
+      in_reply_to: item.id,
+      message: `Agent rejected queued message: ${wake.detail}`,
+    });
+    return;
+  }
+
+  _echoUserMessage(msg, false);
+}
+```
+
+Key invariant: echo happens only after synchronous SDK handoff is accepted.
+
+- [x] **Step 4: Call drain from both lifecycle events**
+
+At the end of `agent_end`, after broadcasting `agent_done` and setting `_currentTurnId = null`, call:
+
+```ts
+_maybeDrainQueuedItem();
+```
+
+At the end of `turn_end`, after publishing `working=false`, call:
+
+```ts
+_maybeDrainQueuedItem();
+```
+
+Both calls are required because event ordering can vary.
+
+- [x] **Step 5: Integrate compaction safely**
+
+In `_endCompaction`:
+
+- Keep existing `_compactionQueue` behavior unchanged.
+- If `_compactionQueue` has items, drain that existing steer queue first and let the next `agent_end`/`turn_end` drain Android follow-ups.
+- If `_compactionQueue` is empty, schedule `_maybeDrainQueuedItem()` after `_publishWorking(false)`.
+
+This preserves order: direct app messages sent during compaction (existing steer behavior) are not overtaken by follow-up queue items.
+
+- [x] **Step 6: Verify Task 3**
+
+Run:
+
+```bash
+cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t "queued"
+cd pi-extension && ../node_modules/.bin/tsc --noEmit
+```
+
+Expected: all queue/drain tests pass.
+
+---
+
+## Task 4 — App queue state in SyncService and ChatViewModel
+
+**Files:**
+
+- Modify: `app/lib/domain/session_state.dart`
+- Modify: `app/lib/data/sync/sync_service.dart`
+- Modify: `app/lib/ui/chat/states/chat_state.dart`
+- Modify: `app/lib/ui/chat/viewmodels/chat_viewmodel.dart`
+- Test: `app/test/ui/chat/chat_viewmodel_test.dart`
+- Test: existing SyncService tests if present.
+
+**Interfaces consumed:** Task 1 Dart protocol.
+
+**Interfaces produced:**
+
+```dart
+class QueuedMsg {
+  final String id;
+  final String text;
+  final bool editable;
+  final DateTime createdAt;
+}
+```
+
+`QueuedMsg` is a domain/UI value. It must not import protocol types.
+
+ViewModel commands:
+
+```dart
+void queueMessage(String text);
+void clearQueuedMessage(String id);
+void clearQueuedMessages();
+```
+
+- [x] **Step 1: Write failing ViewModel/SyncService tests**
+
+Add tests that assert:
+
+1. `QueuedMessageState(items:[...])` updates `ChatReady.queuedMessages`.
+2. Legacy `QueuedMessageState(id/text)` updates `ChatReady.queuedMessages` with one item.
+3. Empty `QueuedMessageState(items:[])` clears the queue.
+4. `queueMessage('x')` sends `QueuedMessageSet` with generated id and text `x`.
+5. `clearQueuedMessage('q1')` sends `QueuedMessageClear(targetId:'q1')`.
+6. Queue clears on session switch through existing `_resetTurnState` path.
+7. Receiving drained `user_message` echo removes the matching queued item if still present locally.
+
+- [x] **Step 2: Add domain `QueuedMsg`**
+
+In `app/lib/domain/session_state.dart`:
+
+```dart
+class QueuedMsg {
+  final String id;
+  final String text;
+  final bool editable;
+  final DateTime createdAt;
+
+  const QueuedMsg({
+    required this.id,
+    required this.text,
+    required this.editable,
+    required this.createdAt,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is QueuedMsg &&
+      other.id == id &&
+      other.text == text &&
+      other.editable == editable &&
+      other.createdAt == createdAt;
+
+  @override
+  int get hashCode => Object.hash(id, text, editable, createdAt);
+}
+```
+
+- [x] **Step 3: Replace SyncService one-slot queue state**
+
+Use list state:
+
+```dart
+List<QueuedMsg> _queuedMessages = const [];
+final StreamController<List<QueuedMsg>> _queuedController =
+    StreamController<List<QueuedMsg>>.broadcast();
+
+List<QueuedMsg> get queuedMessages => _queuedMessages;
+String? get queuedText => _queuedMessages.isEmpty ? null : _queuedMessages.first.text;
+Stream<List<QueuedMsg>> get queuedStream => _queuedController.stream;
+```
+
+Keep `queuedText` only as a compatibility getter for existing code during the migration.
+
+- [x] **Step 4: Map protocol queue state to domain queue state**
+
+In `case QueuedMessageState`, map each protocol item to `QueuedMsg`. Emit an immutable list copy.
+
+If legacy fallback produces one item with `createdAt` epoch zero, that is acceptable; UI does not display time.
+
+- [x] **Step 5: Add queue commands**
+
+`queueMessage`:
+
+```dart
+Future<void> queueMessage(String text) async {
+  final trimmed = text.trim();
+  if (trimmed.isEmpty) return;
+  final id = _newId();
+  _setQueuedMessages([
+    ..._queuedMessages,
+    QueuedMsg(id: id, text: trimmed, editable: true, createdAt: DateTime.now()),
+  ]);
+  final ch = _conn.channel;
+  if (ch == null) return;
+  await ch.send(QueuedMessageSet(id: id, text: trimmed));
+}
+```
+
+`clearQueuedMessage(id)` removes that id optimistically and sends targeted clear if online.
+
+`clearQueuedMessages()` clears all optimistically and sends untargeted clear if online.
+
+- [x] **Step 6: Update ChatState/ViewModel**
+
+Add `queuedMessages` to `ChatReady`, equality, `copyWith`, and `_compose`.
+
+In `ChatViewModel`, listen to the new list stream and expose:
+
+```dart
+List<QueuedMsg> get queuedMessages => _queuedMessages;
+void queueMessage(String text) => unawaited(_sync.queueMessage(text));
+void clearQueuedMessage(String id) => unawaited(_sync.clearQueuedMessage(id));
+void clearQueuedMessages() => unawaited(_sync.clearQueuedMessages());
+```
+
+- [x] **Step 7: Verify Task 4**
+
+Run:
+
+```bash
+cd app && flutter test test/ui/chat/chat_viewmodel_test.dart --plain-name queued
+cd app && flutter analyze
+```
+
+Expected: focused tests pass. The known unrelated `axisAlignment` deprecation may remain only if it already appears in the baseline; do not fix it in this plan.
+
+---
+
+## Task 5 — App queued-message UI
+
+**Files:**
+
+- Modify: `app/lib/ui/chat/chat_page.dart`
+- Modify: `app/lib/ui/chat/widgets/input_bar.dart`
+- Test: `app/test/ui/chat/input_bar_test.dart`
+
+**Interfaces consumed:** Task 4 `QueuedMsg` list and queue/clear callbacks.
+
+**Interfaces produced:** visible editable queued rows and Queue button.
+
+- [x] **Step 1: Write failing InputBar tests**
+
+Add widget tests for:
+
+1. While `streaming: true`, text entered, no image: Queue icon appears.
+2. Tapping Queue calls `onSetQueued(text)`, clears composer, and does not call `onSend`.
+3. Main Send while working still calls `onSend` so steer-now remains unchanged.
+4. A queued row renders preview text.
+5. Tapping editable queued row calls `onClearQueued(id)` and fills composer with queued text.
+6. Clear button calls `onClearQueued(id)`.
+7. Read-only queued row does not fill composer and has no clear button. This protects forward compatibility if Pi later emits read-only rows.
+8. Queue icon is hidden when an image attachment is present.
+9. Queue icon is hidden while idle.
+
+- [x] **Step 2: Update InputBar props**
+
+Replace one-slot props with list callbacks:
+
+```dart
+final List<QueuedMsg> queuedMessages;
+final void Function(String text)? onSetQueued;
+final void Function(String id)? onClearQueued;
+```
+
+Import `QueuedMsg` from `domain/session_state.dart`.
+
+- [x] **Step 3: Add queue action**
+
+When `widget.streaming && hasContent && !hasImage && canInteract`, show a compact Queue icon button.
+
+Handler:
+
+```dart
+void _queueCurrentText() {
+  final text = _controller.text.trim();
+  if (text.isEmpty) return;
+  _controller.clear();
+  widget.onSetQueued?.call(text);
+}
+```
+
+- [x] **Step 4: Render plural queued rows**
+
+Render above the text field:
+
+```dart
+for (final item in widget.queuedMessages)
+  _QueuedMessagePreview(
+    text: item.text,
+    editable: item.editable,
+    onTap: item.editable ? () => _editQueued(item) : null,
+    onClear: item.editable ? () => widget.onClearQueued?.call(item.id) : null,
+  )
+```
+
+`_editQueued(item)`:
+
+```dart
+void _editQueued(QueuedMsg item) {
+  if (!item.editable) return;
+  widget.onClearQueued?.call(item.id);
+  _controller.text = item.text;
+  _controller.selection = TextSelection.collapsed(offset: item.text.length);
+  _focusNode.requestFocus();
+}
+```
+
+Do not keep a separate `_queued` string in `InputBar`; the widget should render `widget.queuedMessages` directly.
+
+- [x] **Step 5: Wire ChatPage**
+
+Pass:
+
+```dart
+queuedMessages: isReady ? state.queuedMessages : const [],
+onSetQueued: vm.queueMessage,
+onClearQueued: vm.clearQueuedMessage,
+```
+
+Keep existing `onSend` unchanged so steer-now still flows through `vm.sendMessage`.
+
+- [x] **Step 6: Verify Task 5**
+
+Run:
+
+```bash
+cd app && flutter test test/ui/chat/input_bar_test.dart --plain-name queued
+cd app && flutter test test/ui/chat/chat_viewmodel_test.dart --plain-name queued
+cd app && flutter analyze
+```
+
+Expected: focused UI/ViewModel tests pass and analyzer has no new issues.
+
+---
+
+## Task 6 — Full verification and manual smoke
+
+**Files:** no code edits unless verification exposes a bug in changed code.
+
+- [x] **Step 1: Full Pi-extension verification**
+
+Run:
+
+```bash
+cd pi-extension && ../node_modules/.bin/tsc --noEmit
+cd pi-extension && ../node_modules/.bin/vitest run
+```
+
+Expected: typecheck passes; all tests pass.
+
+- [x] **Step 2: Full app verification**
+
+Run:
+
+```bash
+cd app && flutter test --reporter=compact
+cd app && flutter build apk --debug
+```
+
+Expected: tests pass; debug APK builds.
+
+- [x] **Step 3: Manual queue smoke**
+
+1. Start Pi with Remote Pi extension and open Android.
+2. Start a long-running prompt from Android or Pi.
+3. While Android shows working, type `run focused tests after this`.
+4. Tap Queue.
+5. Verify queued row appears on Android.
+6. If a second Android owner is connected, verify the same queued row appears there.
+7. Tap the queued row on one Android device, edit the text, tap Queue again.
+8. Verify all Android owners show the updated queued row.
+9. Let the current turn finish.
+10. Verify the queued row disappears.
+11. Verify the edited text appears as a normal user bubble on all owners.
+12. Verify the agent responds to the edited text.
+
+- [x] **Step 4: Manual idle protocol smoke**
+
+Use a debug/test sender or temporary app path to send `queued_message_set` while Pi is idle.
+
+Expected:
+
+- Android does not get stuck showing a queued row.
+- Pi broadcasts normal `user_message` for the queued text.
+- Agent responds normally.
+
+- [ ] **Step 5: Optional physical install if app changed**
+
+If preparing a release APK for the user's device:
+
+```bash
+cd app && flutter build apk --release
+adb install -r build/app/outputs/flutter-apk/app-release.apk
+adb shell monkey -p work.jacobmoura.remotepi 1
+```
+
+Expected: install says `Success`; app launches.
+
+---
+
+## Definition of Done
+
+- [x] `PROTOCOL.md` documents plural Android-owned queued follow-ups and idle immediate drain.
+- [x] Pi handles `queued_message_set` and `queued_message_clear`.
+- [x] Pi sends `queued_message_state` before `session_history` in `session_sync`.
+- [x] Pi broadcasts queue state changes to all active owners.
+- [x] Pi drains queued Android follow-ups only when `_currentTurnId === null`, `_myRoomMeta.working !== true`, and `_compactionActive === false`.
+- [x] Drained queued item is echoed as normal `user_message` to all owners after synchronous SDK handoff is accepted.
+- [x] Current steer-now behavior while working is unchanged.
+- [x] Android displays queued follow-up rows.
+- [x] Android can edit a queued row by pulling it back into the composer.
+- [x] Android can clear one queued row.
+- [x] Multi-owner queue state stays consistent.
+- [x] Pi/TUI internal SDK queue editing is not attempted.
+- [x] Sent-message editing is not implemented in this plan.
+- [x] `cd pi-extension && ../node_modules/.bin/tsc --noEmit` passes.
+- [x] `cd pi-extension && ../node_modules/.bin/vitest run` passes.
+- [x] `cd app && flutter test --reporter=compact` passes.
+- [x] `cd app && flutter build apk --debug` passes.
+
+---
+
+## Deferred: sent-message edit feasibility plan
+
+Sent-message editing remains desirable, but it needs a separate feasibility plan before code changes. That plan must answer these questions with tests or Pi SDK evidence:
+
+1. How does Remote Pi obtain a fresh, command-capable context with `navigateTree` for an app-originated request after `newSession`, `fork`, `switchSession`, and reload?
+2. How does the app identify editable user messages without replacing `_messageBuffer` history mapping or regressing ask_user/tool/compaction/image sync?
+3. After rewinding a branch and submitting edited text, when is the replacement `session_history` broadcast so it is not stale?
+4. What user-visible copy explains that edit creates/replaces a branch, not a cosmetic in-place mutation?
+5. How are multi-owner conflicts handled if one owner edits history while another is typing or has queued follow-ups?
+
+Until those are answered, sent-message edit should stay disabled in Android.

--- a/plan/47-android-queued-editing.md
+++ b/plan/47-android-queued-editing.md
@@ -1,941 +1,193 @@
-# 47 — Android-owned queued follow-up MVP
+# 47 — Android queued follow-ups and steer consumption (as built)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: use `subagent-driven-development` or `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not edit app/pi-extension code from the monorepo root; dispatch or work inside the owning subproject.
+**Status:** As-built documentation for `feed4e5c7b08ed4bf1b75db19bd10d19f8621bb4`; this is not an implementation plan.
 
-**Goal:** Android shows queued follow-up messages, lets the user edit/clear Android-owned queued follow-ups before delivery, and drains them safely after the current Pi turn.
+**Goal:** Record the shipped Android/Pi behavior accurately: Android has one Send action; while Pi is working, Send follows the Pi SDK `steer` path; the explicit Android-owned queued-message protocol/state exists and can be displayed/edited when received, but the composer does not provide a separate action to create queued messages.
 
-**Architecture:** Keep the app SSOT rule: `SyncService` is the only transport/DB writer, and UI reads queue/session state through `ChatViewModel`. Remote Pi owns a small explicit follow-up queue for Android; it is separate from Pi SDK internal steering/follow-up queues because the extension API does not expose stable queue item IDs or mutation APIs. Draining a queued Android item follows the same invariants as a normal accepted app user message: seed `_currentTurnId`, hand off to Pi, echo `user_message` to all owners, then let existing chunk/done forwarding finish the turn.
+**Sources:** the implementation at `feed4e5c7b08ed4bf1b75db19bd10d19f8621bb4` and the confirmed product decision that Android keeps one CLI-style Send/steer action with no separate Queue button.
 
-**Tech Stack:** TypeScript `pi-extension`, Pi extension API, Flutter/Dart app, Hive row-granular SSOT, existing `vitest` + `flutter test`.
+## Scope and non-goals
 
-## Global Constraints
+- This artifact describes existing behavior only; it proposes no application, extension, relay, or protocol change.
+- Android exposes a **single Send** action. There is no separate Queue button or queue-creation action in `InputBar`.
+- `onSetQueued` remains a passed-through optional callback, but `InputBar` does not invoke it. It is not a user-facing composer capability.
+- Queued-message wire commands and state are implemented independently of that missing composer action. Other callers of `SyncService.queueMessage` or the wire protocol can use them.
+- Queues are in-memory, Android-owned, text-only follow-ups. They are not Pi/TUI SDK internal queues and are not durable across Pi process/relay teardown.
+- Images use the existing `user_message` path, including steer delivery while working; the explicit `queued_message_set` protocol is text-only.
+- Sent-message editing and mutation of Pi/TUI queues are outside this artifact.
 
-- No code changes outside `app/` and `pi-extension/` for implementation; this root `plan/` file is planning only.
-- No new dependencies.
-- Preserve current Plan 43 behavior: while working, the main send action still sends **steer now**.
-- Queue is additive: while working with text, Android shows a separate Queue button for “run after current turn”.
-- Queue MVP is text-only. Image attachments keep the existing send/steer path.
-- Android-owned queued items are editable/clearable by Android before delivery.
-- Pi/TUI-originated SDK queued messages are **out of MVP**. No text matching, no internal SDK queue hacks.
-- If Android sends a queued item while Pi is idle, Pi drains it immediately as a normal text user message and broadcasts an empty queue state.
-- Multi-owner consistency is mandatory: every queue state change and every drained user message is broadcast to all active owners.
-- Sent-message editing is deferred to a separate feasibility plan. Do not implement `message_edit`, `entry_id`, or `ActionName.message_edit` in this plan.
-- Run verification from `app/` or `pi-extension/`, not from the monorepo root.
+## Architecture and state ownership
 
----
+`SyncService` owns app transport and local queued-message state. `ChatViewModel` observes it and `ChatPage` passes state/callbacks to `InputBar`. The extension owns its module-local `AndroidQueuedItem[]` and broadcasts the canonical `queued_message_state` to active owners.
 
-## Review Corrections Applied
+A queued item uses its own `id` as the drained `user_message` id. A successful drain first removes and broadcasts queue state, then performs the SDK handoff, then echoes a normal `user_message` to every active owner. If the SDK call throws synchronously, the extension restores the item and broadcasts an `internal_error`; later provider/runtime failures are handled by the existing turn/error flow.
 
-The first draft mixed a safe queue MVP with unsafe sent-message editing. Review found these implementation blockers, now removed or fixed here:
+## UX (actual Android behavior)
 
-- Sent-message editing needs command-only `navigateTree` and stable history entry IDs; current router contexts cannot prove that safely. It is deferred.
-- `message_edit` would require closed `ActionName` changes in TS and Dart; no `message_edit` appears in this plan.
-- Replacing `_messageBuffer` history mapping risks regressing ask_user/tool/compaction/image replay; this plan does not touch history mapping.
-- Queue drain must echo accepted queued messages as normal `user_message`; Task 3 requires this.
-- Queue drain must handle `agent_end`/`turn_end` ordering; Task 3 uses one busy helper and tests both event orders.
-- `_wakeAgent` only catches synchronous handoff rejection. Tests and wording only promise restore on synchronous rejection, not provider/runtime failures after handoff.
-- Queue `mode` is not client-settable in this MVP. Android queue items are always follow-up.
+1. **No text or image content:** the idle composer shows the microphone action; the working composer shows Stop. Queued previews, if state exists, render above the composer.
+2. **Text or image content:** the same Send button calls `onSend`. This includes an image with an empty caption. There is no alternate queue affordance.
+3. **While working:** the hint is `Steer current response…`; typed Send follows `ChatViewModel.sendMessage` and `SyncService.sendMessage`. The app's existing working-state logic supplies `streaming_behavior: "steer"` for a send during a working turn, and the extension also defensively infers steering when room metadata says working.
+4. **Queued state received from Pi:** every `QueuedMsg` renders as a preview above the composer. An editable preview can be tapped: the app sends `queued_message_clear` for that item and puts its text back in the composer. Its clear control also sends targeted clear. A read-only preview has neither edit nor clear control.
+5. **Stop:** while working with typed content, the existing inline Stop control remains reachable beside Send.
 
----
+The queued preview copy says `Queued. Tap to edit.` for editable items and `Queued follow-up.` for read-only items. This display/edit support must not be read as evidence of a separate Queue button.
 
-## Current Evidence / Gaps
+## Steering lifecycle
 
-Already present:
+### Send and SDK delivery
 
-- `PROTOCOL.md` documents a one-slot queue shape:
-  - app → Pi: `queued_message_set`, `queued_message_clear`
-  - Pi → app: `queued_message_state`
-  - `session_sync` should send queued state before history.
-- App protocol/data/UI has partial one-slot scaffolding:
-  - `app/lib/protocol/protocol.dart`: `QueuedMessageSet`, `QueuedMessageClear`, `QueuedMessageState`
-  - `app/lib/data/sync/sync_service.dart`: `setQueuedMessage`, `clearQueuedMessage`, `_queuedText`, `queuedStream`
-  - `app/lib/ui/chat/viewmodels/chat_viewmodel.dart`: subscribes to queued state
-  - `app/lib/ui/chat/chat_page.dart`: passes `queuedText`, `onSetQueued`, `onClearQueued`
-  - `app/lib/ui/chat/widgets/input_bar.dart`: renders one queued preview and can pull it back into the composer
-- Pi extension protocol types already include `queued_message_set` / `queued_message_clear`, but `pi-extension/src/index.ts` does not route them or send `queued_message_state` in `session_sync`.
-- `InputBar.onSetQueued` is not used, so Android has no visible Queue button.
-- Current compaction fix has a separate `_compactionQueue` for app `user_message` during compaction. Do not replace it; the editable follow-up queue is separate.
+- The wire model has `streaming_behavior?: "steer"` on `user_message` and its echo.
+- For any app `user_message`, the extension calls `_wakeAgent(..., "steer")`, which maps to Pi SDK `sendUserMessage(content, { deliverAs: "steer" })`. This matches the CLI-style steer delivery semantics and safely handles the race where the SDK is busy before the relay mirror is updated.
+- The extension treats explicit `streaming_behavior === "steer"` or room metadata `working === true` as a steering send. For non-empty trimmed text, it tracks the accepted message id/text in `_pendingSteers` before broadcasting the echoed message with `streaming_behavior: "steer"`.
+- An image-only steer with an empty caption is marked as steering by the app but is not added to `_pendingSteers`, because `_trackPendingSteer` ignores empty trimmed text. Therefore it does not receive a per-message `steer_consumed` acknowledgement through this text-matching path. This is a known as-built edge, not a claim that image steering is unsupported.
 
----
+### Per-message `steer_consumed`
 
-## Non-goals
-
-- Sent-message editing from Android.
-- In-place mutation of already-sent user history.
-- Editing Pi/TUI internal SDK queues.
-- Queueing images.
-- Replacing steer-now as the default main send action while working.
-- Persisting queued items to disk across Pi process restarts.
-- New relay behavior.
-
----
-
-## UX
-
-1. Idle composer:
-   - Send submits a normal user message.
-   - Queue button is hidden.
-2. Working composer with text and no image:
-   - Main send button still sends steer-now.
-   - A compact Queue/clock icon appears beside Send/Stop.
-   - Stop remains reachable through the existing inline stop affordance.
-3. Queued rows above composer:
-   - Show `Queued follow-up · <preview>`.
-   - Editable Android-owned rows have tap-to-edit and clear (`x`).
-4. Tap-to-edit behavior:
-   - Tapping a queued row clears that queued item on Pi and places the text back into the composer.
-   - If the user abandons the edit, the queued item is gone. This is deliberate for the MVP; it avoids distributed draft locks across multiple Android owners.
-5. Multi-owner behavior:
-   - Queue/clear/edit updates every connected Android owner.
-   - Drained item appears as a normal user bubble on every connected owner.
-
----
-
-## Wire Contract
-
-### Client → Pi
-
-Existing messages are extended minimally:
+When Pi reports a persisted/started user message, the extension consumes one tracked, non-empty-text pending steer (matching trimmed text when possible, otherwise the oldest pending entry) and broadcasts:
 
 ```json
-{ "type": "queued_message_set", "id": "q_123", "text": "run tests after this" }
-{ "type": "queued_message_clear", "id": "req_1", "target_id": "q_123" }
-{ "type": "queued_message_clear", "id": "req_2" }
+{ "type": "steer_consumed", "id": "<steer-message-id>" }
 ```
 
-Rules:
+Both `message_start` and `message_end` can observe the persisted user message. `_lastConsumedSteerText` prevents the duplicate observation from consuming a second pending steer. On `agent_end`, that duplicate guard is reset.
 
-- `queued_message_set.id` is the queue item id.
-- Reusing the same item id replaces that item text.
-- `queued_message_set.text.trim() === ""` clears that item id.
-- `queued_message_clear.target_id` clears one item.
-- `queued_message_clear` without `target_id` clears all Android-owned queued items, preserving the old one-slot clear intent.
+The app maps this event to `SteerConsumed` and calls `_clearSteeringLabel(id)`. Therefore `steer_consumed` clears the pending steering status for that exact message, not every pending steering label. The normal `agent_done` path also clears the label for the completed turn id.
 
-### Pi → app(s)
+## Explicit queued-message protocol/state
 
-`queued_message_state` keeps legacy `id`/`text` and adds plural `items`:
+### Client to Pi extension
 
-```json
+```jsonc
+{ "type": "queued_message_set", "id": "msg-2", "text": "next prompt" }
+{ "type": "queued_message_clear", "id": "clear-1", "target_id": "msg-2" }
+{ "type": "queued_message_clear", "id": "clear-all" }
+```
+
+- `queued_message_set` trims text. Non-empty text upserts an Android-owned item by id; reusing an id replaces its text and preserves list position.
+- An empty set clears the item whose id equals the request id.
+- `queued_message_clear.target_id` removes one item. Omitting `target_id` removes all Android-owned items.
+
+### Pi extension to app(s)
+
+```jsonc
 {
   "type": "queued_message_state",
-  "id": "q_123",
-  "text": "run tests after this",
+  "id": "msg-2", // legacy first-item compatibility field
+  "text": "next prompt", // legacy first-item compatibility field
   "items": [
     {
-      "id": "q_123",
-      "text": "run tests after this",
+      "id": "msg-2",
+      "text": "next prompt",
       "editable": true,
       "created_at": 1782250000000
     }
   ]
 }
-```
 
-Empty state:
-
-```json
 { "type": "queued_message_state", "items": [] }
 ```
 
-Compatibility:
+- The extension broadcasts the complete state after upsert, clear, drain, and eligible teardown/reset paths.
+- `session_sync` sends `queued_message_state` to the requesting owner before `session_history`.
+- The app parses plural `items`; if absent, it falls back to legacy `id`/`text` as one editable item with epoch creation time.
+- `SyncService` maps protocol items into immutable `QueuedMsg` values and publishes them to `ChatViewModel`. It removes a local queued item when the corresponding echoed `user_message` arrives.
 
-- Older apps read `id`/`text` and show only the first queued item.
-- Newer apps reading an older Pi build fall back from missing `items` to legacy `id`/`text`.
+### Drain behavior and actual busy guard
 
----
-
-## File Map
-
-### Docs / protocol
-
-- Modify: `PROTOCOL.md`
-  - Document plural `queued_message_state.items`, optional `target_id`, idle immediate drain, and Android-owned edit semantics.
-
-### Pi extension
-
-- Modify: `pi-extension/src/protocol/types.ts`
-  - Add `QueuedMessageItem`.
-  - Add `target_id?: string` to `queued_message_clear`.
-  - Add `items?: QueuedMessageItem[]` to `queued_message_state`.
-- Modify: `pi-extension/src/protocol/codec.ts` only if codec fixtures enumerate server/client message types.
-- Modify: `pi-extension/src/index.ts`
-  - Add module-local Android queued item store.
-  - Handle `queued_message_set` and `queued_message_clear`.
-  - Broadcast queue state on set/clear/drain/session reset/relay close.
-  - Send queue state before `session_history` in `session_sync`.
-  - Drain one queued item when safe, preserving normal app-user turn invariants.
-- Test: `pi-extension/src/extension.test.ts`
-  - Queue set/replace/clear/sync/drain/multi-owner/order tests.
-
-### App protocol/data/domain/UI
-
-- Modify: `app/lib/protocol/protocol.dart`
-  - Add `QueuedMessageItem` parser.
-  - Add `QueuedMessageState.items` with legacy fallback.
-  - Add `QueuedMessageClear.targetId` encoder.
-- Modify: `app/lib/domain/session_state.dart`
-  - Add protocol-free domain value `QueuedMsg`.
-- Modify: `app/lib/data/sync/sync_service.dart`
-  - Replace one `String?` queue state with `List<QueuedMsg>` state/stream.
-  - Keep `queuedText` compatibility getter only if it reduces diff.
-  - Add queue and clear-by-id commands.
-- Modify: `app/lib/ui/chat/states/chat_state.dart`
-  - Add `queuedMessages`.
-- Modify: `app/lib/ui/chat/viewmodels/chat_viewmodel.dart`
-  - Expose queue list and commands.
-- Modify: `app/lib/ui/chat/chat_page.dart`
-  - Pass queue list and callbacks to `InputBar`.
-- Modify: `app/lib/ui/chat/widgets/input_bar.dart`
-  - Add Queue icon and plural queue preview/edit rows.
-- Tests:
-  - `app/test/ui/chat/input_bar_test.dart`
-  - `app/test/ui/chat/chat_viewmodel_test.dart`
-  - protocol test file used by existing protocol tests.
-
----
-
-## Task 1 — Protocol docs and queue schema
-
-**Files:**
-
-- Modify: `PROTOCOL.md`
-- Modify: `pi-extension/src/protocol/types.ts`
-- Modify: `app/lib/protocol/protocol.dart`
-- Test: existing app protocol tests and TS type/codec tests.
-
-**Interfaces produced:**
-
-TS:
+The queue is drained by `_maybeDrainQueuedItem()` only when:
 
 ```ts
-export type QueuedMessageItem = {
-  id: string;
-  text: string;
-  editable: boolean;
-  created_at: number;
-};
+_currentTurnId === null && _myRoomMeta?.working !== true
 ```
 
-Dart:
+This is the actual `_isBusyForQueueDrain()` implementation. `_compactionActive` is not an implementation state and must not be presented as a drain condition.
 
-```dart
-class QueuedMessageItem {
-  final String id;
-  final String text;
-  final bool editable;
-  final DateTime createdAt;
-}
-```
+Drain is attempted from the upstream Pi lifecycle hooks:
 
-- [x] **Step 1: Write failing Dart protocol tests**
+- `agent_end`, after the extension broadcasts `agent_done`, clears `_currentTurnId`, flushes image previews, and resets the steer duplicate guard;
+- `turn_end`, after it publishes room `working: false`; and
+- `session_compact`, after it publishes room `working: false` and broadcasts the compaction event.
 
-Add or extend the existing protocol test with:
+`session_before_compact` publishes `working: true`. This upstream working-state bracketing is why compaction blocks draining without a separate compaction boolean. The two ordinary lifecycle hooks allow either `agent_end`/`turn_end` order: drain happens only after both parts of the busy condition are false.
 
-```dart
-test('queued_message_state parses plural items and legacy fallback', () {
-  final plural = ServerMessage.fromJson({
-    'type': 'queued_message_state',
-    'items': [
-      {
-        'id': 'q1',
-        'text': 'next',
-        'editable': true,
-        'created_at': 123,
-      },
-    ],
-  }) as QueuedMessageState;
+If `queued_message_set` arrives while idle, the extension drains it immediately. The SDK handoff still uses `deliverAs: "steer"`, but the echoed drained `user_message` intentionally omits `streaming_behavior`, so Android displays it as a normal follow-up rather than a pending steer.
 
-  expect(plural.items, hasLength(1));
-  expect(plural.items.single.id, 'q1');
-  expect(plural.items.single.text, 'next');
-  expect(plural.items.single.editable, isTrue);
-  expect(plural.text, 'next');
+`PROTOCOL.md` describes this as requiring no active compaction. In the as-built extension that condition is enforced through the room `working` bracket around compaction, not through a separate `_compactionActive` variable.
 
-  final legacy = ServerMessage.fromJson({
-    'type': 'queued_message_state',
-    'id': 'old',
-    'text': 'legacy',
-  }) as QueuedMessageState;
+## As-built file map
 
-  expect(legacy.items, hasLength(1));
-  expect(legacy.items.single.id, 'old');
-  expect(legacy.items.single.text, 'legacy');
-  expect(legacy.items.single.editable, isTrue);
-});
+| Area | Implemented files | Actual responsibility |
+| --- | --- | --- |
+| Protocol documentation | `PROTOCOL.md` | Documents queue commands/state, immediate idle drain, text-only scope, and SDK queue boundaries. |
+| Extension protocol | `pi-extension/src/protocol/types.ts` | Defines queue commands, `QueuedMessageItem`, queue state, `streaming_behavior`, and `steer_consumed`. |
+| Extension routing/lifecycle | `pi-extension/src/index.ts` | Owns queue state/drain, steer tracking/consumption, session-sync ordering, and lifecycle hooks. |
+| App protocol | `app/lib/protocol/protocol.dart` | Parses/encodes queue messages and parses `SteerConsumed`. |
+| App sync/domain | `app/lib/data/sync/sync_service.dart`, `app/lib/domain/session_state.dart` | Owns `QueuedMsg` state, queue commands, echoed-item removal, and per-id steering-label clearing. |
+| App state/UI | `app/lib/ui/chat/states/chat_state.dart`, `app/lib/ui/chat/viewmodels/chat_viewmodel.dart`, `app/lib/ui/chat/chat_page.dart`, `app/lib/ui/chat/widgets/input_bar.dart` | Exposes queue state, renders previews, and keeps the composer to one Send action. |
 
-test('queued_message_clear can target one queued item', () {
-  expect(
-    QueuedMessageClear(id: 'req1', targetId: 'q1').toJson(),
-    {'type': 'queued_message_clear', 'id': 'req1', 'target_id': 'q1'},
-  );
-  expect(
-    QueuedMessageClear(id: 'req2').toJson(),
-    {'type': 'queued_message_clear', 'id': 'req2'},
-  );
-});
-```
+## Task 1 — Protocol and state (implemented)
 
-Run from `app/`:
+The implementation supplies plural queue state with legacy first-item fields; targeted and all-item clear commands; protocol parsing fallback; and `steer_consumed` parsing. `QueuedMessageItem.created_at` is epoch milliseconds. No queue mode or sent-message-edit protocol was added.
+
+**Matching tests:** `app/test/protocol_test.dart` covers plural/legacy queued state, targeted clear encoding, and `steer_consumed` parsing.
+
+## Task 2 — Extension queue routing and synchronization (implemented)
+
+The extension routes `queued_message_set` and `queued_message_clear`, maintains `_queuedItems`, broadcasts canonical state to active owners, and emits state before history in `session_sync`. Reset/relay-close paths clear non-empty queue state.
+
+**Matching tests:** `pi-extension/src/extension.test.ts` covers working-set broadcast to two owners, targeted clear, sync ordering, and immediate idle drain.
+
+## Task 3 — Extension drain lifecycle and steering consumption (implemented)
+
+Queued drain waits for the actual turn id and room-working guards, handles both `agent_end`/`turn_end` orders, restores an item when the SDK call throws synchronously, and echoes a successfully drained item as a normal `user_message`. It uses Pi SDK steer delivery for the handoff.
+
+Pending steering with non-empty text is recorded for accepted steering sends and cleared one message at a time through `steer_consumed`, with duplicate `message_start`/`message_end` suppression. Reset and compaction behavior is supported directly by the cited source paths but does not have dedicated queue-specific tests in this commit.
+
+**Matching tests:** `pi-extension/src/extension.test.ts` covers idle delivery via `{ deliverAs: "steer" }`, both lifecycle orders, restore after a synchronous throw, exact-text consumption for one pending steer, fallback consumption for one unmatched pending steer, and duplicate-hook suppression. It does not prove later-item selection or oldest-of-many fallback.
+
+## Task 4 — App queue and steering state (implemented)
+
+`SyncService` stores immutable `List<QueuedMsg>`, exposes it through `queuedStream`, sends queue commands when its APIs are called, removes a queued item on its normal echo, and clears a single steering label on `SteerConsumed`. `ChatViewModel` and `ChatReady` relay the list to the UI. The image-only empty-caption edge described above is not tracked by `_pendingSteers`, so this per-id acknowledgement applies to tracked text steers.
+
+**Matching tests:** `app/test/data/sync/sync_service_test.dart` verifies that `steer_consumed` clears only the identified steering row; queue protocol parsing is covered in `app/test/protocol_test.dart`.
+
+## Task 5 — Android composer and queued previews (implemented)
+
+`InputBar` renders received queued previews and supports edit/clear for editable entries. It accepts `onSetQueued`, but contains no handler, icon, or control that calls it. Therefore Task 5 is complete only as preview/edit rendering and one-Send steering UX; it does **not** include a separate Queue button/action.
+
+While streaming with text, `_ComposerActionButton` stays in send-text mode and invokes `onSend`; the same button is the steer-now control. The inline Stop affordance remains visible.
+
+**Matching tests:** `app/test/ui/chat/input_bar_test.dart` verifies that streaming text uses the existing Send button for steer and does not call `onSetQueued`; tapping an editable preview clears it as part of edit; and read-only previews have no clear affordance. The test does not separately tap the dedicated editable-preview clear button. Empty-caption image Send behavior is covered by `app/test/ui/chat/attachment/input_bar_image_test.dart`.
+
+## Task 6 — Historical verification targets
+
+These are the relevant snapshot verification commands for the implementation; this documentation-only revision does not rerun or modify them:
 
 ```bash
-flutter test test/protocol_test.dart --plain-name queued_message_state
-```
-
-Expected before implementation: fails because `items`/`targetId` do not exist.
-
-- [x] **Step 2: Implement Dart protocol parsing/encoding**
-
-Implementation rules:
-
-- `QueuedMessageState.items` parses `items` when present.
-- If `items` is absent and `text` is non-empty, create one legacy item from `id/text`.
-- If both are absent/empty, `items == const []` and `text == null`.
-- `created_at` is milliseconds since epoch; missing value maps to `DateTime.fromMillisecondsSinceEpoch(0)`.
-- `QueuedMessageState.id` / `text` return the first item for compatibility.
-
-- [x] **Step 3: Add TS types**
-
-Update `pi-extension/src/protocol/types.ts` so these compile:
-
-```ts
-const clearOne: ClientMessage = { type: "queued_message_clear", id: "req1", target_id: "q1" };
-const clearAll: ClientMessage = { type: "queued_message_clear", id: "req2" };
-const state: ServerMessage = {
-  type: "queued_message_state",
-  id: "q1",
-  text: "next",
-  items: [{ id: "q1", text: "next", editable: true, created_at: 123 }],
-};
-```
-
-Do not add `message_edit` or queue `mode` types.
-
-- [x] **Step 4: Update `PROTOCOL.md`**
-
-Replace the old one-slot queue section with the wire contract above. Explicitly state:
-
-- Android queue is text-only follow-up.
-- Idle set drains immediately.
-- Pi/TUI internal queues are not exposed in this MVP.
-
-- [x] **Step 5: Verify Task 1**
-
-Run:
-
-```bash
-cd pi-extension && ../node_modules/.bin/tsc --noEmit
-cd app && flutter test test/protocol_test.dart
-```
-
-Expected: typecheck and protocol tests pass.
-
----
-
-## Task 2 — Pi-extension queue state and sync
-
-**Files:**
-
-- Modify: `pi-extension/src/index.ts`
-- Test: `pi-extension/src/extension.test.ts`
-
-**Interfaces consumed:** Task 1 TS `QueuedMessageItem`.
-
-**Interfaces produced:**
-
-```ts
-type AndroidQueuedItem = {
-  id: string;
-  text: string;
-  editable: true;
-  created_at: number;
-};
-```
-
-Helpers:
-
-```ts
-function _sendQueuedState(sender: PlainPeerChannel): void;
-function _broadcastQueuedState(): void;
-function _upsertQueuedItem(item: AndroidQueuedItem): void;
-function _clearQueuedItems(targetId?: string): void;
-```
-
-- [x] **Step 1: Write failing queue state tests**
-
-Add tests in `pi-extension/src/extension.test.ts`:
-
-1. While working, `queued_message_set` broadcasts one queued item to every active owner.
-2. Reusing the same item id replaces text and keeps one item.
-3. `queued_message_clear { target_id }` removes only that item.
-4. `queued_message_clear` without `target_id` clears all Android queue items.
-5. `session_sync` sends `queued_message_state` before `session_history`.
-6. `session_new` / relay close broadcasts empty queue state.
-
-Use production routing (`_routeClientMessageFrom`) and captured event handlers already used by nearby tests. For “working”, trigger the captured `turn_start` or set the same room-meta path existing tests use; do not expect a queued item while idle.
-
-Expected failing assertion before implementation:
-
-```ts
-expect(ownerA.sent).toContainEqual(expect.objectContaining({
-  type: "queued_message_state",
-  items: [expect.objectContaining({ id: "q1", text: "next", editable: true })],
-}));
-```
-
-Run:
-
-```bash
-cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t queued_message
-```
-
-Expected before implementation: fails because router ignores queued messages.
-
-- [x] **Step 2: Add module-local queue store**
-
-In `pi-extension/src/index.ts` near current turn/compaction module state:
-
-```ts
-let _queuedItems: AndroidQueuedItem[] = [];
-```
-
-Keep this independent from existing `_compactionQueue`.
-
-- [x] **Step 3: Implement state send/broadcast helpers**
-
-`_sendQueuedState(sender)` sends:
-
-```ts
-const first = _queuedItems[0];
-sender.send({
-  type: "queued_message_state",
-  ...(first ? { id: first.id, text: first.text } : {}),
-  items: _queuedItems.map((item) => ({ ...item })),
-});
-```
-
-`_broadcastQueuedState()` calls `_sendQueuedState` for all active owners.
-
-- [x] **Step 4: Route set/clear messages**
-
-Add cases in `_routeClientMessageFrom`:
-
-```ts
-case "queued_message_set": {
-  const text = msg.text.trim();
-  if (!text) {
-    _clearQueuedItems(msg.id);
-    break;
-  }
-  _upsertQueuedItem({ id: msg.id, text, editable: true, created_at: Date.now() });
-  _maybeDrainQueuedItem();
-  break;
-}
-case "queued_message_clear":
-  _clearQueuedItems(msg.target_id);
-  break;
-```
-
-`_upsertQueuedItem` broadcasts state after mutation unless `_maybeDrainQueuedItem` drains immediately. Simpler acceptable implementation: broadcast queued state after upsert, then if idle drain and broadcast empty state. Tests should accept the final empty state in idle case.
-
-- [x] **Step 5: Send queue state during sync**
-
-At the start of `_handleSessionSync`, before `session_history`, call:
-
-```ts
-_sendQueuedState(sender);
-```
-
-- [x] **Step 6: Reset queue on session/relay teardown**
-
-Clear queue and broadcast empty state on:
-
-- successful `_resetSessionForNew`
-- relay close / `_goIdle` teardown paths that clear active peers
-- extension-level shutdown path if one exists beside relay close
-
-Do not clear queue on ordinary `turn_end`; that is handled by drain.
-
-- [x] **Step 7: Verify Task 2**
-
-Run:
-
-```bash
-cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t queued_message
-cd pi-extension && ../node_modules/.bin/tsc --noEmit
-```
-
-Expected: queue state/sync tests pass.
-
----
-
-## Task 3 — Pi-extension drain lifecycle and echo invariants
-
-**Files:**
-
-- Modify: `pi-extension/src/index.ts`
-- Test: `pi-extension/src/extension.test.ts`
-
-**Interfaces consumed:** Task 2 `_queuedItems`, `_broadcastQueuedState`.
-
-**Interfaces produced:** Accepted queued items become normal app user turns after the active turn finishes.
-
-- [x] **Step 1: Write failing drain tests**
-
-Add tests for:
-
-1. While working, `queued_message_set` does not call `_pi.sendUserMessage` immediately.
-2. While idle, `queued_message_set` drains immediately and final queue state is empty.
-3. Draining seeds `_currentTurnId` with the queued item id.
-4. Draining calls `_wakeAgent(item.text, ..., "steer")` as an SDK-safe handoff; the app echo still omits `streaming_behavior` so it renders as a normal queued follow-up.
-5. After synchronous handoff succeeds, draining broadcasts `user_message { id, text }` with no `streaming_behavior` to all owners.
-6. A later `message_update` chunk uses `in_reply_to` equal to the queued item id.
-7. `agent_end` before `turn_end` drains exactly once after both “not current turn” and “not working” are true.
-8. `turn_end` before `agent_end` drains exactly once after both “not current turn” and “not working” are true.
-9. A synchronous `_wakeAgent` rejection restores the item and broadcasts it again.
-10. Async provider/runtime failure after accepted handoff is not restored; existing `error`/`agent_done` behavior handles the visible turn.
-
-Run:
-
-```bash
-cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t "queued drain"
-```
-
-Expected before implementation: fails because no drain exists.
-
-- [x] **Step 2: Add one busy helper**
-
-```ts
-function _isBusyForQueueDrain(): boolean {
-  return _compactionActive || _currentTurnId !== null || _myRoomMeta?.working === true;
-}
-```
-
-This helper is the only drain gate. Tests must cover both `agent_end`/`turn_end` orderings.
-
-- [x] **Step 3: Implement `_maybeDrainQueuedItem`**
-
-Pseudo-code:
-
-```ts
-function _maybeDrainQueuedItem(): void {
-  if (_isBusyForQueueDrain()) return;
-  const item = _queuedItems.shift();
-  if (!item) return;
-
-  _broadcastQueuedState();
-  const previousTurnId = _currentTurnId;
-  _currentTurnId = item.id;
-
-  const msg: ClientUserMessage = { type: "user_message", id: item.id, text: item.text };
-  const wake = _wakeAgent(item.text, `queued app user_message id=${item.id}`, "steer");
-  if (!wake.ok) {
-    _currentTurnId = previousTurnId;
-    _queuedItems.unshift(item);
-    _broadcastQueuedState();
-    _broadcastToActive({
-      type: "error",
-      code: "internal_error",
-      in_reply_to: item.id,
-      message: `Agent rejected queued message: ${wake.detail}`,
-    });
-    return;
-  }
-
-  _echoUserMessage(msg, false);
-}
-```
-
-Key invariant: echo happens only after synchronous SDK handoff is accepted.
-
-- [x] **Step 4: Call drain from both lifecycle events**
-
-At the end of `agent_end`, after broadcasting `agent_done` and setting `_currentTurnId = null`, call:
-
-```ts
-_maybeDrainQueuedItem();
-```
-
-At the end of `turn_end`, after publishing `working=false`, call:
-
-```ts
-_maybeDrainQueuedItem();
-```
-
-Both calls are required because event ordering can vary.
-
-- [x] **Step 5: Integrate compaction safely**
-
-In `_endCompaction`:
-
-- Keep existing `_compactionQueue` behavior unchanged.
-- If `_compactionQueue` has items, drain that existing steer queue first and let the next `agent_end`/`turn_end` drain Android follow-ups.
-- If `_compactionQueue` is empty, schedule `_maybeDrainQueuedItem()` after `_publishWorking(false)`.
-
-This preserves order: direct app messages sent during compaction (existing steer behavior) are not overtaken by follow-up queue items.
-
-- [x] **Step 6: Verify Task 3**
-
-Run:
-
-```bash
-cd pi-extension && ../node_modules/.bin/vitest run src/extension.test.ts -t "queued"
-cd pi-extension && ../node_modules/.bin/tsc --noEmit
-```
-
-Expected: all queue/drain tests pass.
-
----
-
-## Task 4 — App queue state in SyncService and ChatViewModel
-
-**Files:**
-
-- Modify: `app/lib/domain/session_state.dart`
-- Modify: `app/lib/data/sync/sync_service.dart`
-- Modify: `app/lib/ui/chat/states/chat_state.dart`
-- Modify: `app/lib/ui/chat/viewmodels/chat_viewmodel.dart`
-- Test: `app/test/ui/chat/chat_viewmodel_test.dart`
-- Test: existing SyncService tests if present.
-
-**Interfaces consumed:** Task 1 Dart protocol.
-
-**Interfaces produced:**
-
-```dart
-class QueuedMsg {
-  final String id;
-  final String text;
-  final bool editable;
-  final DateTime createdAt;
-}
-```
-
-`QueuedMsg` is a domain/UI value. It must not import protocol types.
-
-ViewModel commands:
-
-```dart
-void queueMessage(String text);
-void clearQueuedMessage(String id);
-void clearQueuedMessages();
-```
-
-- [x] **Step 1: Write failing ViewModel/SyncService tests**
-
-Add tests that assert:
-
-1. `QueuedMessageState(items:[...])` updates `ChatReady.queuedMessages`.
-2. Legacy `QueuedMessageState(id/text)` updates `ChatReady.queuedMessages` with one item.
-3. Empty `QueuedMessageState(items:[])` clears the queue.
-4. `queueMessage('x')` sends `QueuedMessageSet` with generated id and text `x`.
-5. `clearQueuedMessage('q1')` sends `QueuedMessageClear(targetId:'q1')`.
-6. Queue clears on session switch through existing `_resetTurnState` path.
-7. Receiving drained `user_message` echo removes the matching queued item if still present locally.
-
-- [x] **Step 2: Add domain `QueuedMsg`**
-
-In `app/lib/domain/session_state.dart`:
-
-```dart
-class QueuedMsg {
-  final String id;
-  final String text;
-  final bool editable;
-  final DateTime createdAt;
-
-  const QueuedMsg({
-    required this.id,
-    required this.text,
-    required this.editable,
-    required this.createdAt,
-  });
-
-  @override
-  bool operator ==(Object other) =>
-      other is QueuedMsg &&
-      other.id == id &&
-      other.text == text &&
-      other.editable == editable &&
-      other.createdAt == createdAt;
-
-  @override
-  int get hashCode => Object.hash(id, text, editable, createdAt);
-}
-```
-
-- [x] **Step 3: Replace SyncService one-slot queue state**
-
-Use list state:
-
-```dart
-List<QueuedMsg> _queuedMessages = const [];
-final StreamController<List<QueuedMsg>> _queuedController =
-    StreamController<List<QueuedMsg>>.broadcast();
-
-List<QueuedMsg> get queuedMessages => _queuedMessages;
-String? get queuedText => _queuedMessages.isEmpty ? null : _queuedMessages.first.text;
-Stream<List<QueuedMsg>> get queuedStream => _queuedController.stream;
-```
-
-Keep `queuedText` only as a compatibility getter for existing code during the migration.
-
-- [x] **Step 4: Map protocol queue state to domain queue state**
-
-In `case QueuedMessageState`, map each protocol item to `QueuedMsg`. Emit an immutable list copy.
-
-If legacy fallback produces one item with `createdAt` epoch zero, that is acceptable; UI does not display time.
-
-- [x] **Step 5: Add queue commands**
-
-`queueMessage`:
-
-```dart
-Future<void> queueMessage(String text) async {
-  final trimmed = text.trim();
-  if (trimmed.isEmpty) return;
-  final id = _newId();
-  _setQueuedMessages([
-    ..._queuedMessages,
-    QueuedMsg(id: id, text: trimmed, editable: true, createdAt: DateTime.now()),
-  ]);
-  final ch = _conn.channel;
-  if (ch == null) return;
-  await ch.send(QueuedMessageSet(id: id, text: trimmed));
-}
-```
-
-`clearQueuedMessage(id)` removes that id optimistically and sends targeted clear if online.
-
-`clearQueuedMessages()` clears all optimistically and sends untargeted clear if online.
-
-- [x] **Step 6: Update ChatState/ViewModel**
-
-Add `queuedMessages` to `ChatReady`, equality, `copyWith`, and `_compose`.
-
-In `ChatViewModel`, listen to the new list stream and expose:
-
-```dart
-List<QueuedMsg> get queuedMessages => _queuedMessages;
-void queueMessage(String text) => unawaited(_sync.queueMessage(text));
-void clearQueuedMessage(String id) => unawaited(_sync.clearQueuedMessage(id));
-void clearQueuedMessages() => unawaited(_sync.clearQueuedMessages());
-```
-
-- [x] **Step 7: Verify Task 4**
-
-Run:
-
-```bash
-cd app && flutter test test/ui/chat/chat_viewmodel_test.dart --plain-name queued
-cd app && flutter analyze
-```
-
-Expected: focused tests pass. The known unrelated `axisAlignment` deprecation may remain only if it already appears in the baseline; do not fix it in this plan.
-
----
-
-## Task 5 — App queued-message UI
-
-**Files:**
-
-- Modify: `app/lib/ui/chat/chat_page.dart`
-- Modify: `app/lib/ui/chat/widgets/input_bar.dart`
-- Test: `app/test/ui/chat/input_bar_test.dart`
-
-**Interfaces consumed:** Task 4 `QueuedMsg` list and queue/clear callbacks.
-
-**Interfaces produced:** visible editable queued rows and Queue button.
-
-- [x] **Step 1: Write failing InputBar tests**
-
-Add widget tests for:
-
-1. While `streaming: true`, text entered, no image: Queue icon appears.
-2. Tapping Queue calls `onSetQueued(text)`, clears composer, and does not call `onSend`.
-3. Main Send while working still calls `onSend` so steer-now remains unchanged.
-4. A queued row renders preview text.
-5. Tapping editable queued row calls `onClearQueued(id)` and fills composer with queued text.
-6. Clear button calls `onClearQueued(id)`.
-7. Read-only queued row does not fill composer and has no clear button. This protects forward compatibility if Pi later emits read-only rows.
-8. Queue icon is hidden when an image attachment is present.
-9. Queue icon is hidden while idle.
-
-- [x] **Step 2: Update InputBar props**
-
-Replace one-slot props with list callbacks:
-
-```dart
-final List<QueuedMsg> queuedMessages;
-final void Function(String text)? onSetQueued;
-final void Function(String id)? onClearQueued;
-```
-
-Import `QueuedMsg` from `domain/session_state.dart`.
-
-- [x] **Step 3: Add queue action**
-
-When `widget.streaming && hasContent && !hasImage && canInteract`, show a compact Queue icon button.
-
-Handler:
-
-```dart
-void _queueCurrentText() {
-  final text = _controller.text.trim();
-  if (text.isEmpty) return;
-  _controller.clear();
-  widget.onSetQueued?.call(text);
-}
-```
-
-- [x] **Step 4: Render plural queued rows**
-
-Render above the text field:
-
-```dart
-for (final item in widget.queuedMessages)
-  _QueuedMessagePreview(
-    text: item.text,
-    editable: item.editable,
-    onTap: item.editable ? () => _editQueued(item) : null,
-    onClear: item.editable ? () => widget.onClearQueued?.call(item.id) : null,
-  )
-```
-
-`_editQueued(item)`:
-
-```dart
-void _editQueued(QueuedMsg item) {
-  if (!item.editable) return;
-  widget.onClearQueued?.call(item.id);
-  _controller.text = item.text;
-  _controller.selection = TextSelection.collapsed(offset: item.text.length);
-  _focusNode.requestFocus();
-}
-```
-
-Do not keep a separate `_queued` string in `InputBar`; the widget should render `widget.queuedMessages` directly.
-
-- [x] **Step 5: Wire ChatPage**
-
-Pass:
-
-```dart
-queuedMessages: isReady ? state.queuedMessages : const [],
-onSetQueued: vm.queueMessage,
-onClearQueued: vm.clearQueuedMessage,
-```
-
-Keep existing `onSend` unchanged so steer-now still flows through `vm.sendMessage`.
-
-- [x] **Step 6: Verify Task 5**
-
-Run:
-
-```bash
-cd app && flutter test test/ui/chat/input_bar_test.dart --plain-name queued
-cd app && flutter test test/ui/chat/chat_viewmodel_test.dart --plain-name queued
-cd app && flutter analyze
-```
-
-Expected: focused UI/ViewModel tests pass and analyzer has no new issues.
-
----
-
-## Task 6 — Full verification and manual smoke
-
-**Files:** no code edits unless verification exposes a bug in changed code.
-
-- [x] **Step 1: Full Pi-extension verification**
-
-Run:
-
-```bash
-cd pi-extension && ../node_modules/.bin/tsc --noEmit
-cd pi-extension && ../node_modules/.bin/vitest run
-```
-
-Expected: typecheck passes; all tests pass.
-
-- [x] **Step 2: Full app verification**
-
-Run:
-
-```bash
+cd pi-extension && pnpm typecheck
+cd pi-extension && pnpm test
+cd pi-extension && pnpm build
 cd app && flutter test --reporter=compact
 cd app && flutter build apk --debug
 ```
 
-Expected: tests pass; debug APK builds.
-
-- [x] **Step 3: Manual queue smoke**
-
-1. Start Pi with Remote Pi extension and open Android.
-2. Start a long-running prompt from Android or Pi.
-3. While Android shows working, type `run focused tests after this`.
-4. Tap Queue.
-5. Verify queued row appears on Android.
-6. If a second Android owner is connected, verify the same queued row appears there.
-7. Tap the queued row on one Android device, edit the text, tap Queue again.
-8. Verify all Android owners show the updated queued row.
-9. Let the current turn finish.
-10. Verify the queued row disappears.
-11. Verify the edited text appears as a normal user bubble on all owners.
-12. Verify the agent responds to the edited text.
-
-- [x] **Step 4: Manual idle protocol smoke**
-
-Use a debug/test sender or temporary app path to send `queued_message_set` while Pi is idle.
-
-Expected:
-
-- Android does not get stuck showing a queued row.
-- Pi broadcasts normal `user_message` for the queued text.
-- Agent responds normally.
-
-- [ ] **Step 5: Optional physical install if app changed**
-
-If preparing a release APK for the user's device:
+Focused checks corresponding to this behavior:
 
 ```bash
-cd app && flutter build apk --release
-adb install -r build/app/outputs/flutter-apk/app-release.apk
-adb shell monkey -p work.jacobmoura.remotepi 1
+cd pi-extension && pnpm exec vitest run src/extension.test.ts -t 'queued|steer'
+cd app && flutter test test/protocol_test.dart
+cd app && flutter test test/data/sync/sync_service_test.dart
+cd app && flutter test test/ui/chat/input_bar_test.dart
+cd app && flutter test test/ui/chat/attachment/input_bar_image_test.dart
 ```
-
-Expected: install says `Success`; app launches.
-
----
 
 ## Definition of Done
 
-- [x] `PROTOCOL.md` documents plural Android-owned queued follow-ups and idle immediate drain.
-- [x] Pi handles `queued_message_set` and `queued_message_clear`.
-- [x] Pi sends `queued_message_state` before `session_history` in `session_sync`.
-- [x] Pi broadcasts queue state changes to all active owners.
-- [x] Pi drains queued Android follow-ups only when `_currentTurnId === null`, `_myRoomMeta.working !== true`, and `_compactionActive === false`.
-- [x] Drained queued item is echoed as normal `user_message` to all owners after synchronous SDK handoff is accepted.
-- [x] Current steer-now behavior while working is unchanged.
-- [x] Android displays queued follow-up rows.
-- [x] Android can edit a queued row by pulling it back into the composer.
-- [x] Android can clear one queued row.
-- [x] Multi-owner queue state stays consistent.
-- [x] Pi/TUI internal SDK queue editing is not attempted.
-- [x] Sent-message editing is not implemented in this plan.
-- [x] `cd pi-extension && ../node_modules/.bin/tsc --noEmit` passes.
-- [x] `cd pi-extension && ../node_modules/.bin/vitest run` passes.
-- [x] `cd app && flutter test --reporter=compact` passes.
-- [x] `cd app && flutter build apk --debug` passes.
-
----
-
-## Deferred: sent-message edit feasibility plan
-
-Sent-message editing remains desirable, but it needs a separate feasibility plan before code changes. That plan must answer these questions with tests or Pi SDK evidence:
-
-1. How does Remote Pi obtain a fresh, command-capable context with `navigateTree` for an app-originated request after `newSession`, `fork`, `switchSession`, and reload?
-2. How does the app identify editable user messages without replacing `_messageBuffer` history mapping or regressing ask_user/tool/compaction/image sync?
-3. After rewinding a branch and submitting edited text, when is the replacement `session_history` broadcast so it is not stale?
-4. What user-visible copy explains that edit creates/replaces a branch, not a cosmetic in-place mutation?
-5. How are multi-owner conflicts handled if one owner edits history while another is typing or has queued follow-ups?
-
-Until those are answered, sent-message edit should stay disabled in Android.
+- Android has a single Send control; during a working turn it sends through the steer path. There is no separate Queue button/action.
+- The extension uses Pi SDK `sendUserMessage(..., { deliverAs: "steer" })` for app sends, including queued-item handoff.
+- `steer_consumed` is emitted per consumed tracked, non-empty-text steer and clears only that message's pending steering label in the app; the image-only empty-caption edge is recorded above.
+- The explicit Android-owned queued-message set/clear/state protocol, multi-owner broadcast, legacy fields, and session-sync ordering are documented above.
+- Queued previews may be displayed/edited/cleared from received state, but the main composer does not create queued messages.
+- Queue drain uses `_currentTurnId` and room `working` state, with upstream `agent_end`, `turn_end`, and compaction hooks; it does not depend on `_compactionActive`.
+- Idle queued sets drain immediately and echo a normal `user_message` without `streaming_behavior`.
+- No Pi/TUI internal queue editing, sent-message editing, persistence, relay change, or separate queue-creation UI/action is claimed.


### PR DESCRIPTION
## Summary

- use the existing Send action with Pi steer semantics while a turn is active
- track app-originated steering messages until Pi reports they were consumed
- synchronize queued-message state and lifecycle across connected Android owners
- keep queued follow-ups editable/clearable through the shared protocol state

No separate Queue button is added; sending while Pi is working follows the existing CLI-style steer path.

## Validation

- `cd pi-extension && ../node_modules/.bin/tsc --noEmit`
- `cd pi-extension && ../node_modules/.bin/vitest run` — 33 files passed, 593 tests passed, 3 skipped
- `cd pi-extension && ../node_modules/.bin/tsc`
- `cd app && flutter analyze --no-pub` — no issues
- affected Flutter tests — 98 passed
- `git diff --check upstream/main..HEAD`