### PR TITLE
fix(pi-extension): queue mesh messages between runs

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -173,6 +173,7 @@ const {
   _getLockedNameForTest,
   _resetCwdLockForTest,
   _handleControl,
+  _deliverMeshMessageToAgentForTest,
   CTRL_PREFIX,
 } = await import("./index.js");
 const { acquireCwdLock } = await import("./session/cwd_lock.js");
@@ -833,6 +834,63 @@ describe("/remote-pi revoke", () => {
 // `_getActivePeerCountForTest` import so it isn't flagged as unused even
 // when only some tests in this file consume it.
 void _getActivePeerCountForTest;
+
+// ── agent-network mesh delivery ──────────────────────────────────────────────
+
+describe("agent-network mesh delivery", () => {
+  test("holds messages until agent_end listeners finish and starts one turn for the batch", async () => {
+    const harness = captureEventHarness();
+    const sendMessage = vi.fn();
+    _setPiForTest({ sendMessage, sendUserMessage: () => undefined });
+    harness.handler("agent_start")({ type: "agent_start" });
+
+    _deliverMeshMessageToAgentForTest({
+      id: "mesh-message-1",
+      from: "/work/repo@reviewer",
+      re: null,
+      body: { status: "first" },
+    });
+    _deliverMeshMessageToAgentForTest({
+      id: "mesh-message-2",
+      from: "/work/repo@worker",
+      re: "mesh-message-1",
+      body: { status: "second" },
+    });
+    await Promise.resolve();
+
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    harness.handler("agent_end")({ type: "agent_end" });
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    harness.handler("agent_start")({ type: "agent_start" });
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    harness.handler("agent_end")({ type: "agent_end" });
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls[0]).toEqual([
+      expect.objectContaining({
+        customType: "remote-pi:mesh-message",
+        display: true,
+        content: expect.stringContaining("mesh-message-1"),
+      }),
+      { triggerTurn: false },
+    ]);
+    expect(sendMessage.mock.calls[1]).toEqual([
+      expect.objectContaining({
+        customType: "remote-pi:mesh-message",
+        display: true,
+        content: expect.stringContaining("mesh-message-2"),
+      }),
+      { triggerTurn: true, deliverAs: "followUp" },
+    ]);
+
+    harness.handler("agent_end")({ type: "agent_end" });
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  });
+});
 
 // ── user_input mirroring (local terminal / RPC) ───────────────────────────────
 

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -805,6 +805,12 @@ let _lastConsumedSteerText: string | null = null;
 type AndroidQueuedItem = QueuedMessageItem & { editable: true };
 let _queuedItems: AndroidQueuedItem[] = [];
 
+type MeshEnvelope = { id: string; from: string; re: string | null; body: unknown };
+let _pendingMeshMessages: MeshEnvelope[] = [];
+let _agentRunActive = false;
+let _agentRunGeneration = 0;
+let _meshDrainScheduled = false;
+
 function _queuedStateMessage(): ServerMessage {
   const first = _queuedItems[0];
   return {
@@ -1904,6 +1910,11 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
     });
   });
 
+  pi.on("agent_start", () => {
+    _agentRunActive = true;
+    _agentRunGeneration += 1;
+  });
+
   pi.on("message_start", (event) => {
     const message = event?.message as BufferMsg | undefined;
     if (!_anyPeerActive() || message?.role !== "user") return;
@@ -1988,6 +1999,18 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
     _flushPendingReceivedImagePreviews();
     _lastConsumedSteerText = null;
     _maybeDrainQueuedItem();
+
+    // agent_end listeners finish before pi-agent-core clears its active run.
+    // Defer mesh delivery to the next event-loop turn so triggerTurn cannot
+    // collide with the prompt that emitted this event. A queued continuation
+    // may start first; its generation keeps the older timer from clearing the
+    // new run's busy flag.
+    const endedGeneration = _agentRunGeneration;
+    setTimeout(() => {
+      if (_agentRunGeneration !== endedGeneration) return;
+      _agentRunActive = false;
+      _scheduleMeshMessageDrain();
+    }, 0);
   });
 
   // plan/34: the broker no longer gates delivery on busy state, so we no
@@ -3585,12 +3608,59 @@ function _wakeAgent(
  * Wake: we inject a CUSTOM message (role:"custom"), not a user message. The
  * SDK's `convertToLlm` maps custom → a user-role LLM message, so the agent
  * still sees + replies to it, but `message_end` does NOT buffer role:"custom",
- * so it never replays as `user_input` on session_sync. `triggerTurn` runs the
- * turn; `id` lets the LLM echo it via `agent_send(..., re=<id>)`.
+ * so it never replays as `user_input` on session_sync. Mesh messages are held
+ * until the current `agent_end` listeners finish, then appended as one batch
+ * before a single turn starts. This avoids calling `prompt()` during the gap
+ * where Pi has stopped streaming but the current agent run is still active.
+ * `id` lets the LLM echo it via
+ * `agent_send(..., re=<id>)`.
  */
-function _deliverMeshMessageToAgent(
-  env: { id: string; from: string; re: string | null; body: unknown },
-): void {
+function _meshMessageForAgent(env: MeshEnvelope) {
+  const bodyText = typeof env.body === "string" ? env.body : JSON.stringify(env.body);
+  const header = `[agent-network] message from "${env.from}" (id=${env.id}${env.re ? `, re=${env.re}` : ""}):`;
+  const footer = env.re
+    ? "(This is a reply to a previous message of yours.)"
+    : `(If a reply is expected, call agent_send with to="${env.from}" and re="${env.id}".)`;
+  return {
+    customType: "remote-pi:mesh-message",
+    content: `${header}\n${bodyText}\n\n${footer}`,
+    display: true,
+  };
+}
+
+function _scheduleMeshMessageDrain(): void {
+  if (_meshDrainScheduled || _pendingMeshMessages.length === 0) return;
+  _meshDrainScheduled = true;
+  queueMicrotask(() => {
+    _meshDrainScheduled = false;
+    const pi = _pi;
+    if (_agentRunActive || !pi || _pendingMeshMessages.length === 0) return;
+
+    const batch = _pendingMeshMessages.splice(0);
+    let delivered = 0;
+    _agentRunActive = true;
+    try {
+      batch.forEach((env, index) => {
+        const isLast = index === batch.length - 1;
+        pi.sendMessage(
+          _meshMessageForAgent(env),
+          isLast
+            ? { triggerTurn: true, deliverAs: "followUp" }
+            : { triggerTurn: false },
+        );
+        delivered += 1;
+      });
+    } catch (err) {
+      _agentRunActive = false;
+      _pendingMeshMessages = [...batch.slice(delivered), ..._pendingMeshMessages];
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`[remote-pi] queued mesh delivery failed: ${detail}`);
+      _safeNotify(`[remote-pi] failed to process queued mesh messages: ${detail}`, "error");
+    }
+  });
+}
+
+function _deliverMeshMessageToAgent(env: MeshEnvelope): void {
   const bodyText = typeof env.body === "string" ? env.body : JSON.stringify(env.body);
   const toolCallId = `mesh_${env.id}`;
   _broadcastToActive({
@@ -3603,25 +3673,17 @@ function _deliverMeshMessageToAgent(
   });
   _broadcastToActive({ type: "tool_result", tool_call_id: toolCallId, result: { from: env.from, message: bodyText } });
 
-  const label = `agent-network message from "${env.from}"`;
   if (!_pi) {
-    console.error(`[remote-pi] ${label}: agent session not bound yet — message dropped`);
+    console.error(`[remote-pi] agent-network message from "${env.from}": agent session not bound yet — message dropped`);
     return;
   }
-  const header = `[agent-network] message from "${env.from}" (id=${env.id}${env.re ? `, re=${env.re}` : ""}):`;
-  const footer = env.re
-    ? "(This is a reply to a previous message of yours.)"
-    : `(If a reply is expected, call agent_send with to="${env.from}" and re="${env.id}".)`;
-  try {
-    _pi.sendMessage(
-      { customType: "remote-pi:mesh-message", content: `${header}\n${bodyText}\n\n${footer}`, display: true },
-      { triggerTurn: true },
-    );
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    console.error(`[remote-pi] ${label}: agent rejected incoming message: ${detail}`);
-    _safeNotify(`[remote-pi] failed to process incoming message: ${detail}`, "error");
-  }
+  _pendingMeshMessages.push(env);
+  _scheduleMeshMessageDrain();
+}
+
+/** Test-only entry point for verifying mesh-to-agent delivery semantics. */
+export function _deliverMeshMessageToAgentForTest(env: MeshEnvelope): void {
+  _deliverMeshMessageToAgent(env);
 }
 
 /**


### PR DESCRIPTION
## What broke

I found the exact `Agent is already processing a prompt` exception in 9 separate async Pi child runs. The message wasn't cosmetic. A mesh envelope reached `_deliverMeshMessageToAgent()`, which called `sendMessage(..., { triggerTurn: true })` while `pi-agent-core` still had an `activeRun`.

The timing window is narrow & repeatable. Pi stops reporting `isStreaming` before every `agent_end` listener has returned. `AgentSession.sendCustomMessage()` sees the non-streaming state, takes the immediate prompt path, & `pi-agent-core` rejects that second prompt at its active-run guard.

A normal mesh message shouldn't depend on winning that race.

## What this changes

Remote Pi now tracks the `agent_start` / `agent_end` lifecycle & keeps inbound mesh envelopes in a local FIFO while a run is active. After the current `agent_end` listeners finish, a zero-delay timer drains the batch:

- every message except the last is appended with `triggerTurn: false`;
- the last message starts one turn with `triggerTurn: true`;
- `deliverAs: "followUp"` remains a second guard if Pi has already entered another streaming turn;
- a generation counter prevents an older `agent_end` timer from marking a newer queued continuation idle.

Two mesh messages therefore create 2 custom context messages & 1 agent turn. They don't create 2 competing prompts.

## Maintainer-controlled implementation prompt

If you'd rather discard this patch & implement the fix in your own structure, this is the complete behavior contract I used:

> In `pi-extension/src/index.ts`, prevent inbound agent-network mesh envelopes from calling `ExtensionAPI.sendMessage(..., { triggerTurn: true })` while any Pi agent run is active or while its `agent_end` listeners are still unwinding. Preserve FIFO order, the existing `remote-pi:mesh-message` custom-message format, reply correlation fields, & app tool-timeline broadcasts. Coalesce every waiting batch into one new turn by appending all but the final custom message without triggering, then triggering exactly once on the final message. Account for immediate queued continuations: an older completion callback must not clear the busy state of a newer run. Add an automated regression test that sends at least 2 mesh envelopes during an active run, proves no `sendMessage` call occurs synchronously or during a newer continuation, then proves the messages drain in order after the final run ends with exactly 1 `triggerTurn: true` call.

That gives you the intended result without requiring any particular helper names from this PR.

## Automated evidence

The new regression test sends 2 mesh envelopes during an active run. It asserts 0 deliveries before completion, 0 deliveries when a continuation starts before the deferred drain, FIFO ordering after the continuation ends, & exactly 1 turn-triggering call.

Validation from `pi-extension/`:

```text
pnpm test       33 files passed; 597 tests passed; 3 skipped
pnpm typecheck  passed
pnpm build      passed
git diff --check passed
```

The patch changes 2 files under `pi-extension/`. It doesn't change the relay protocol, mobile app, broker addressing, pairing, or cross-PC routing.
