### PR TITLE
feat(cockpit): adiciona visualização em árvore ao Source Control

### DIFF
--- a/cockpit/lib/app/cockpit/ui/widgets/file_tree_panel.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_tree_panel.dart
@@ -142,6 +142,10 @@ class _FileTreePanelState extends State<FileTreePanel> {
   /// Aba ativa do painel: árvore de arquivos, busca ou source control.
   _RightPaneTab _tab = _RightPaneTab.files;
 
+  /// Source Control começa na lista compacta e pode alternar para a hierarquia
+  /// de pastas sem afetar a árvore principal de arquivos.
+  bool _sourceControlTree = false;
+
   /// Criação inline em andamento (uma de cada vez).
   _PendingCreate? _pending;
 
@@ -404,6 +408,7 @@ class _FileTreePanelState extends State<FileTreePanel> {
                   ),
                 if (widget.isGitRepo)
                   _HeaderIcon(
+                    key: const ValueKey('source-control-tab'),
                     icon: Icons.account_tree_outlined,
                     tooltip: 'Source Control',
                     selected: scMode,
@@ -411,8 +416,22 @@ class _FileTreePanelState extends State<FileTreePanel> {
                         setState(() => _tab = _RightPaneTab.sourceControl),
                   ),
                 const Spacer(),
+                if (scMode)
+                  _HeaderIcon(
+                    key: const ValueKey('source-control-view-toggle'),
+                    icon: _sourceControlTree
+                        ? Icons.view_list_outlined
+                        : Icons.account_tree_outlined,
+                    tooltip: _sourceControlTree
+                        ? 'View as List'
+                        : 'View as Tree',
+                    onTap: () => setState(
+                      () => _sourceControlTree = !_sourceControlTree,
+                    ),
+                  ),
                 // "New file/folder" só no modo Files (o source control é leitura).
-                if (widget.rootPath.isNotEmpty && tab == _RightPaneTab.files) ...[
+                if (widget.rootPath.isNotEmpty &&
+                    tab == _RightPaneTab.files) ...[
                   _HeaderIcon(
                     icon: Icons.note_add_outlined,
                     tooltip: 'New file',
@@ -450,6 +469,7 @@ class _FileTreePanelState extends State<FileTreePanel> {
                     gitStatusOf: widget.gitStatusOf,
                     selectedPath: effectiveSelected,
                     onOpenDiff: widget.onOpenDiff,
+                    viewAsTree: _sourceControlTree,
                     onTapDiff: (path) {
                       _select(path);
                       (widget.onTapDiff ?? widget.onOpenDiff)(path);
@@ -1194,6 +1214,7 @@ class _ChangedTree extends StatelessWidget {
     required this.selectedPath,
     required this.onOpenDiff,
     required this.onTapDiff,
+    required this.viewAsTree,
   });
 
   final String rootPath;
@@ -1202,6 +1223,7 @@ class _ChangedTree extends StatelessWidget {
   final String? selectedPath;
   final ValueChanged<String> onOpenDiff;
   final ValueChanged<String> onTapDiff;
+  final bool viewAsTree;
 
   @override
   Widget build(BuildContext context) {
@@ -1236,6 +1258,23 @@ class _ChangedTree extends StatelessWidget {
       return ap.toLowerCase().compareTo(bp.toLowerCase());
     });
 
+    if (viewAsTree) {
+      final root = _ChangedDirectory('');
+      for (final file in files) {
+        root.add(file);
+      }
+      return SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
+        child: _ChangedDirectoryView(
+          directory: root,
+          gitStatusOf: gitStatusOf,
+          selectedPath: selectedPath,
+          onOpenDiff: onOpenDiff,
+          onTapDiff: onTapDiff,
+        ),
+      );
+    }
+
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
       child: Column(
@@ -1255,14 +1294,147 @@ class _ChangedTree extends StatelessWidget {
   }
 }
 
+/// Nó em memória da visualização hierárquica de mudanças.
+class _ChangedDirectory {
+  _ChangedDirectory(this.name);
+
+  final String name;
+  final Map<String, _ChangedDirectory> directories =
+      <String, _ChangedDirectory>{};
+  final List<_ChangedFile> files = <_ChangedFile>[];
+
+  void add(_ChangedFile file) {
+    var current = this;
+    for (final part in file.dir.split('/').where((part) => part.isNotEmpty)) {
+      current = current.directories.putIfAbsent(
+        part,
+        () => _ChangedDirectory(part),
+      );
+    }
+    current.files.add(file);
+  }
+}
+
+/// Conteúdo de uma pasta da árvore de Source Control. A raiz não desenha linha;
+/// subpastas começam expandidas para a troca de visualização revelar os arquivos.
+class _ChangedDirectoryView extends StatefulWidget {
+  const _ChangedDirectoryView({
+    required this.directory,
+    required this.gitStatusOf,
+    required this.selectedPath,
+    required this.onOpenDiff,
+    required this.onTapDiff,
+    this.depth = 0,
+    this.isRoot = true,
+  });
+
+  final _ChangedDirectory directory;
+  final GitFileStatus? Function(String absolutePath) gitStatusOf;
+  final String? selectedPath;
+  final ValueChanged<String> onOpenDiff;
+  final ValueChanged<String> onTapDiff;
+  final int depth;
+  final bool isRoot;
+
+  @override
+  State<_ChangedDirectoryView> createState() => _ChangedDirectoryViewState();
+}
+
+class _ChangedDirectoryViewState extends State<_ChangedDirectoryView> {
+  bool _expanded = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final directories = widget.directory.directories.values.toList()
+      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    final files = widget.directory.files.toList()
+      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (!widget.isRoot)
+          HoverTap(
+            key: ValueKey(
+              'source-control-folder:${widget.depth}:${widget.directory.name}',
+            ),
+            hoverColor: context.colors.panel,
+            borderRadius: BorderRadius.circular(5),
+            onTap: () => setState(() => _expanded = !_expanded),
+            padding: EdgeInsets.only(left: 6 + widget.depth * 14, right: 6),
+            child: SizedBox(
+              height: 26,
+              child: Row(
+                children: [
+                  Icon(
+                    _expanded
+                        ? Icons.keyboard_arrow_down
+                        : Icons.keyboard_arrow_right,
+                    size: 15,
+                    color: context.colors.text3,
+                  ),
+                  const SizedBox(width: 2),
+                  Icon(
+                    _expanded
+                        ? Icons.folder_open_outlined
+                        : Icons.folder_outlined,
+                    size: 16,
+                    color: context.colors.text3,
+                  ),
+                  const SizedBox(width: 7),
+                  Flexible(
+                    child: Text(
+                      widget.directory.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.typo.body.copyWith(
+                        fontSize: 13,
+                        color: context.colors.text2,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        if (widget.isRoot || _expanded) ...[
+          for (final directory in directories)
+            _ChangedDirectoryView(
+              directory: directory,
+              gitStatusOf: widget.gitStatusOf,
+              selectedPath: widget.selectedPath,
+              onOpenDiff: widget.onOpenDiff,
+              onTapDiff: widget.onTapDiff,
+              depth: widget.isRoot ? 0 : widget.depth + 1,
+              isRoot: false,
+            ),
+          for (final file in files)
+            _ChangedRow(
+              key: ValueKey('source-control-file:${file.absPath}'),
+              file: file,
+              gitStatus: widget.gitStatusOf(file.absPath),
+              selected: file.absPath == widget.selectedPath,
+              depth: widget.isRoot ? 0 : widget.depth + 1,
+              showDirectory: false,
+              onTap: () => widget.onTapDiff(file.absPath),
+              onDoubleTap: () => widget.onOpenDiff(file.absPath),
+            ),
+        ],
+      ],
+    );
+  }
+}
+
 /// Uma linha da lista plana de source control (só leitura, sem menu).
 class _ChangedRow extends StatefulWidget {
   const _ChangedRow({
+    super.key,
     required this.file,
     required this.gitStatus,
     required this.selected,
     required this.onTap,
     required this.onDoubleTap,
+    this.depth = 0,
+    this.showDirectory = true,
   });
 
   final _ChangedFile file;
@@ -1270,6 +1442,8 @@ class _ChangedRow extends StatefulWidget {
   final bool selected;
   final VoidCallback? onTap;
   final VoidCallback? onDoubleTap;
+  final int depth;
+  final bool showDirectory;
 
   @override
   State<_ChangedRow> createState() => _ChangedRowState();
@@ -1306,7 +1480,7 @@ class _ChangedRowState extends State<_ChangedRow> {
       hoverColor: colors.panel,
       borderRadius: BorderRadius.circular(5),
       onTap: _handleTap,
-      padding: const EdgeInsets.only(left: 6, right: 6),
+      padding: EdgeInsets.only(left: 6 + widget.depth * 14, right: 6),
       child: SizedBox(
         height: 26,
         child: Row(
@@ -1321,7 +1495,7 @@ class _ChangedRowState extends State<_ChangedRow> {
                 style: typo.body.copyWith(fontSize: 13, color: nameColor),
               ),
             ),
-            if (file.dir.isNotEmpty) ...[
+            if (widget.showDirectory && file.dir.isNotEmpty) ...[
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
@@ -1360,6 +1534,7 @@ Color? _gitColor(AppColors colors, GitFileStatus? status) {
 
 class _HeaderIcon extends StatelessWidget {
   const _HeaderIcon({
+    super.key,
     required this.icon,
     required this.tooltip,
     required this.onTap,

--- a/cockpit/test/ui/file_tree_panel_test.dart
+++ b/cockpit/test/ui/file_tree_panel_test.dart
@@ -1,4 +1,5 @@
 import 'package:cockpit/app/cockpit/domain/entities/file_node.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_file_status.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/file_tree_panel.dart';
 import 'package:cockpit/app/core/domain/result.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
@@ -71,5 +72,63 @@ void main() {
         expect(tappedFile, '/workspace/file1.txt');
       },
     );
+
+    testWidgets('source control alternates between list and tree views', (
+      tester,
+    ) async {
+      const changedPath = '/workspace/lib/app/main.dart';
+
+      await tester.pumpWidget(
+        ShadcnApp(
+          theme: buildTheme(brightness: Brightness.dark),
+          home: Scaffold(
+            child: FileTreePanel(
+              rootPath: '/workspace',
+              revision: 1,
+              listChildren: (_) async => const [],
+              gitStatusOf: (path) =>
+                  path == changedPath ? GitFileStatus.modified : null,
+              onOpenFile: (_) {},
+              onOpenDiff: (_) {},
+              isGitRepo: true,
+              changedPaths: const [changedPath],
+              onOpenWith: (_) {},
+              onCreateInFolder: (_, _) {},
+              onCreate: (_, _, _) async => const Success(null),
+              onRename: (_, _) async => const Success(null),
+              onDelete: (_) async => const Success(null),
+              onMove: (_, _) async => const Success(null),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('source-control-tab')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('main.dart'), findsOneWidget);
+      expect(find.text('lib/app'), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const ValueKey('source-control-view-toggle')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('lib/app'), findsNothing);
+      expect(find.text('lib'), findsOneWidget);
+      expect(find.text('app'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('source-control-file:$changedPath')),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('source-control-view-toggle')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('lib/app'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## O que mudou

- adiciona um botão no painel Source Control para alternar entre lista e árvore
- mantém a lista compacta como visualização padrão
- agrupa os arquivos modificados em pastas expansíveis na visualização em árvore
- preserva a seleção de arquivos e a abertura do diff com clique e clique duplo
- adiciona um teste de widget cobrindo as duas direções da alternância

## Por que mudar

Conjuntos grandes de alterações ficam mais fáceis de navegar quando os arquivos podem ser visualizados dentro da hierarquia de diretórios, sem remover a lista compacta já existente para consultas rápidas.

## Preview

<!-- Adicione aqui uma captura de tela ou GIF demonstrando a alternância entre lista e árvore. -->

|View as List | View as Tree|
|------------|-------------|
|<img width="870" height="1360" alt="CleanShot 2026-07-17 at 19 13 32@2x" src="https://github.com/user-attachments/assets/6a2dd08c-1dd0-4379-a142-ff34f9013fbd" />|<img width="882" height="1328" alt="CleanShot 2026-07-17 at 19 14 16@2x" src="https://github.com/user-attachments/assets/0af34861-bb88-46ab-aeae-fe4970ed34cf" />|

## Validação

- `flutter test test/ui/file_tree_panel_test.dart`
- `flutter analyze`
