### PR TITLE
fix(cockpit): evita duplicação de caracteres especiais no terminal

### DIFF
--- a/cockpit/lib/app/core/terminal/xterm/src/ui/custom_text_edit.dart
+++ b/cockpit/lib/app/core/terminal/xterm/src/ui/custom_text_edit.dart
@@ -204,6 +204,16 @@ class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
 
   late var _currentEditingState = _initEditingState.copyWith();
 
+  /// The most recent text committed by the IME for this editing transaction.
+  ///
+  /// macOS can send the final, non-composing [TextEditingValue] more than once
+  /// while it settles a dead key or an accented character. Since a terminal
+  /// resets its hidden editing buffer after every commit, treating every one of
+  /// those callbacks as new text writes the same character to the PTY repeatedly.
+  /// The platform acknowledges the reset with [_initEditingState] (or starts a
+  /// new composing range), which opens the next transaction.
+  String? _committedText;
+
   @override
   TextEditingValue? get currentTextEditingValue {
     return _currentEditingState;
@@ -220,6 +230,7 @@ class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
 
     // Get input after composing is done
     if (!_currentEditingState.composing.isCollapsed) {
+      _committedText = null;
       final text = _currentEditingState.text;
       final composingText = _currentEditingState.composing.textInside(text);
       widget.onComposing(composingText);
@@ -228,14 +239,27 @@ class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
 
     widget.onComposing(null);
 
+    // This is the acknowledgement of the hidden buffer reset. It also makes a
+    // second, identical character typed later a distinct input transaction.
+    if (_currentEditingState.text == _initEditingState.text) {
+      _committedText = null;
+      return;
+    }
+
     if (_currentEditingState.text.length < _initEditingState.text.length) {
+      _committedText = null;
       widget.onDelete();
     } else {
       final textDelta = _currentEditingState.text.substring(
         _initEditingState.text.length,
       );
 
-      widget.onInsert(textDelta);
+      // IMEs may repeat the same committed value after the terminal has asked
+      // them to restore the empty editing state. Emit that commit only once.
+      if (textDelta != _committedText) {
+        _committedText = textDelta;
+        widget.onInsert(textDelta);
+      }
     }
 
     // Reset editing state if composing is done

--- a/cockpit/linux/CMakeLists.txt
+++ b/cockpit/linux/CMakeLists.txt
@@ -74,6 +74,16 @@ set_target_properties(${BINARY_NAME}
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# flutter_secure_storage_linux 1.x bundles an older nlohmann/json header. New
+# Clang versions warn about its pre-C++14 literal-operator syntax; plugins share
+# APPLY_STANDARD_SETTINGS, so our global -Werror turned that upstream warning
+# into a build failure. Keep warnings-as-errors for the app and every other
+# warning, but exempt this known third-party deprecation until the secure-storage
+# package can be upgraded as a compatible set.
+if(TARGET flutter_secure_storage_linux_plugin)
+  target_compile_options(flutter_secure_storage_linux_plugin PRIVATE
+    "$<$<CXX_COMPILER_ID:Clang>:-Wno-error=deprecated-literal-operator>")
+endif()
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build

--- a/cockpit/test/core/terminal/cockpit_terminal_input_test.dart
+++ b/cockpit/test/core/terminal/cockpit_terminal_input_test.dart
@@ -1,0 +1,33 @@
+import 'package:cockpit/app/core/terminal/cockpit_terminal.dart';
+import 'package:cockpit/app/core/terminal/xterm/xterm.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('commits an IME character only once', (tester) async {
+    final output = <String>[];
+    final terminal = Terminal(onOutput: output.add);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: CockpitTerminal(terminal, autofocus: true)),
+      ),
+    );
+    await tester.pump();
+
+    final textInput = tester.binding.testTextInput;
+    for (final character in ['~', '´', 'á', 'í']) {
+      final committed = TextEditingValue(
+        text: character,
+        selection: TextSelection.collapsed(offset: character.length),
+      );
+      textInput.updateEditingValue(committed);
+      textInput.updateEditingValue(committed);
+      textInput.updateEditingValue(committed);
+      textInput.updateEditingValue(TextEditingValue.empty);
+    }
+    await tester.pump();
+
+    expect(output, ['~', '´', 'á', 'í']);
+  });
+}


### PR DESCRIPTION
## Resumo
- evita reenvio de commits IME repetidos (dead keys e caracteres acentuados) ao PTY
- adiciona regressão para `~`, `´`, `á` e `í`
- corrige build Linux com Clang, mantendo `-Werror` fora do warning legado do `flutter_secure_storage_linux`

## Validação
- `flutter test test/core/terminal/cockpit_terminal_input_test.dart`
- `flutter analyze`
- `flutter build linux --debug`