### PR TITLE
feat(cockpit): detecta worktrees criadas por fora do app

### DIFF
--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -106,7 +106,8 @@ class CockpitViewModel extends ChangeNotifier {
       ..isSystemTerminal = isSystemTerminal
       ..selectedProjectId = (() => _selectedProjectId)
       ..pollTargets = _gitPollTargets
-      ..onStructuralFsChange = _bumpFileTree;
+      ..onStructuralFsChange = _bumpFileTree
+      ..onPoll = _reconcileOpenWorktrees;
     git.addListener(notifyListeners);
     realmCtrl.addListener(notifyListeners);
   }
@@ -3375,6 +3376,23 @@ class CockpitViewModel extends ChangeNotifier {
       final doc = _serializeLayout(projectId);
       if (doc.isNotEmpty) unawaited(_layoutStore.save(projectId, doc));
     });
+  }
+
+  /// Reconcilia as worktrees de TODOS os workspaces raiz abertos contra o git —
+  /// disparado a cada tick do poll do [GitController]. Pega worktrees criadas ou
+  /// removidas por fora (outro terminal, o terminal do próprio fork) sem exigir
+  /// reabrir o workspace. [_refreshWorktrees] deduplica e só notifica se a lista
+  /// mudou, então o custo em repos parados é nulo.
+  void _reconcileOpenWorktrees() {
+    // Snapshot: [_refreshWorktrees] muda [_projectList] (após um await), então
+    // não iteramos a lista viva.
+    final roots = _projectList
+        .where((p) => p.parentId == null && !p.isSystemTerminal)
+        .map((p) => p.id)
+        .toList();
+    for (final rootId in roots) {
+      unawaited(_refreshWorktrees(rootId));
+    }
   }
 
   /// Reconcilia as worktrees de um workspace raiz contra o git (decisões 4, 5,

--- a/cockpit/lib/app/cockpit/ui/viewmodels/git_controller.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/git_controller.dart
@@ -44,6 +44,10 @@ class GitController extends ChangeNotifier {
   /// tree observado — o VM bumpa a revisão da árvore de arquivos.
   VoidCallback? onStructuralFsChange;
 
+  /// Disparado uma vez por tick do poll — o VM dono reconcilia as worktrees
+  /// (que o GitController não conhece) contra o git. Só notifica se a lista mudou.
+  VoidCallback? onPoll;
+
   // ---- estado ---------------------------------------------------------------
 
   /// Estado git por **root path** (branch + sujos). Para workspace single-root
@@ -293,6 +297,7 @@ class GitController extends ChangeNotifier {
       for (final id in pollTargets?.call() ?? const <String>[]) {
         unawaited(refresh(id));
       }
+      onPoll?.call();
     });
   }
 

--- a/cockpit/pubspec.lock
+++ b/cockpit/pubspec.lock
@@ -313,7 +313,7 @@ packages:
     source: hosted
     version: "0.2.5+3"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/cockpit/pubspec.yaml
+++ b/cockpit/pubspec.yaml
@@ -171,6 +171,9 @@ dev_dependencies:
   # Usado só pelos testes vendorizados do emulador (core/terminal/xterm);
   # os .mocks.dart já vêm gerados — sem build_runner.
   mockito: ^5.4.0
+  # Relógio virtual para testes com Timer (ex.: poll periódico do GitController).
+  # Já vinha transitivo via flutter_test; declarado direto pra satisfazer o lint.
+  fake_async: ^1.3.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/cockpit/test/ui/git_controller_poll_test.dart
+++ b/cockpit/test/ui/git_controller_poll_test.dart
@@ -1,0 +1,52 @@
+import 'package:cockpit/app/cockpit/domain/contracts/git_command_runner.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/git_status_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_info.dart';
+import 'package:cockpit/app/cockpit/ui/viewmodels/git_controller.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Reader nulo — nenhuma pasta é repo git; o poll roda mas `refresh` é no-op.
+class _NullReader implements GitStatusReader {
+  @override
+  Future<GitInfo?> read(String path) async => null;
+}
+
+/// Runner que nunca é exercido neste teste (o poll só lê estado).
+class _UnusedRunner implements GitCommandRunner {
+  @override
+  GitRun run(String repoPath, List<String> args) =>
+      throw UnimplementedError();
+  @override
+  GitRun syncPullPush(String repoPath) => throw UnimplementedError();
+  @override
+  GitMergeOutcome mergeIntoParent(
+    String parentPath,
+    String worktreePath,
+    String worktreeBranch,
+  ) => throw UnimplementedError();
+}
+
+void main() {
+  test('startPoll dispara onPoll a cada tick (reconciliação de worktrees)', () {
+    fakeAsync((async) {
+      final git = GitController(_NullReader(), _UnusedRunner())
+        // Sem alvos de status: isola o teste no gancho onPoll.
+        ..pollTargets = (() => const <String>[]);
+
+      var ticks = 0;
+      git.onPoll = () => ticks++;
+
+      git.startPoll();
+      expect(ticks, 0, reason: 'nada dispara antes do primeiro intervalo');
+
+      // 3 intervalos de 3s = 3 ticks.
+      async.elapse(const Duration(seconds: 9));
+      expect(ticks, 3);
+
+      git.dispose();
+      // Após dispose o timer para → nenhum tick novo.
+      async.elapse(const Duration(seconds: 9));
+      expect(ticks, 3, reason: 'dispose cancela o poll');
+    });
+  });
+}


### PR DESCRIPTION
## Contexto

Hoje a Cockpit só descobre worktrees git quando o usuário dispara uma ação de UI (selecionar/adicionar workspace, criar/remover worktree, fim de turno de agente). Uma worktree criada por fora — `git worktree add` em outro terminal, ou no terminal do próprio fork — **não aparece na rail** até fechar e reabrir o workspace (ou trocar de workspace e voltar).

## Mudança

A lógica de reconciliação (`CockpitViewModel._refreshWorktrees`) já era completa e bidirecional; só nunca era disparada sozinha. Liguei-a ao **poll de segurança do git de 3s** que já roda no app:

- **`git_controller.dart`**: novo callback `onPoll` (mesmo padrão do `onStructuralFsChange` — o `GitController` segue sem conhecer `Project`/worktrees); `startPoll()` o invoca uma vez por tick.
- **`cockpit_viewmodel.dart`**: fia `onPoll = _reconcileOpenWorktrees`, que a cada tick reconcilia as worktrees de **todos os workspaces raiz abertos** (snapshot da lista para evitar modificação concorrente), reusando `_refreshWorktrees`.

`_refreshWorktrees` deduplica e só chama `notifyListeners()` quando a lista muda, então o custo em repos parados é nulo. Nenhuma mudança de UI foi necessária — a `ProjectsRail` já lê `worktreesOf` e reconstrói no notify.

## Resultado

Worktrees criadas/removidas por fora aparecem/somem na rail em até ~3s, para qualquer workspace aberto, sem reabrir.

## Testes

- Teste novo (`test/ui/git_controller_poll_test.dart`, `fake_async`) valida que `startPoll` dispara `onPoll` a cada tick e que `dispose` cancela o timer. Declarado `fake_async` em `dev_dependencies` (já era transitivo).
- `flutter analyze` limpo; suíte de git existente verde.
- Teste manual end-to-end validado (criar/remover worktree por fora reflete na rail).