### PR TITLE
Corrige entrada repetida no terminal

### DIFF
--- a/cockpit/lib/app/core/terminal/xterm/src/ui/custom_text_edit.dart
+++ b/cockpit/lib/app/core/terminal/xterm/src/ui/custom_text_edit.dart
@@ -135,7 +135,19 @@ class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
 
   KeyEventResult _onKeyEvent(FocusNode focusNode, KeyEvent event) {
     if (_currentEditingState.composing.isCollapsed) {
-      return widget.onKeyEvent(focusNode, event);
+      final result = widget.onKeyEvent(focusNode, event);
+
+      // A printable key delegated to text input starts a new transaction. The
+      // platform may not acknowledge our hidden-buffer reset before the next
+      // identical key, so editing values alone cannot distinguish that press
+      // from a duplicate IME callback.
+      if (result == KeyEventResult.ignored &&
+          (event is KeyDownEvent || event is KeyRepeatEvent) &&
+          event.character?.isNotEmpty == true) {
+        _committedText = null;
+      }
+
+      return result;
     }
 
     return KeyEventResult.skipRemainingHandlers;

--- a/cockpit/test/core/terminal/cockpit_terminal_input_test.dart
+++ b/cockpit/test/core/terminal/cockpit_terminal_input_test.dart
@@ -1,6 +1,7 @@
 import 'package:cockpit/app/core/terminal/cockpit_terminal.dart';
 import 'package:cockpit/app/core/terminal/xterm/xterm.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -29,5 +30,45 @@ void main() {
     await tester.pump();
 
     expect(output, ['~', '´', 'á', 'í']);
+  });
+
+  testWidgets('commits consecutive identical characters', (tester) async {
+    final output = <String>[];
+    final terminal = Terminal(onOutput: output.add);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: CockpitTerminal(terminal, autofocus: true)),
+      ),
+    );
+    await tester.pump();
+
+    final textInput = tester.binding.testTextInput;
+    const inputs = <(LogicalKeyboardKey, String)>[
+      (LogicalKeyboardKey.period, '.'),
+      (LogicalKeyboardKey.comma, ','),
+      (LogicalKeyboardKey.semicolon, ';'),
+      (LogicalKeyboardKey.semicolon, ':'),
+      (LogicalKeyboardKey.bracketLeft, '['),
+      (LogicalKeyboardKey.bracketRight, ']'),
+    ];
+
+    for (final (key, character) in inputs) {
+      final committed = TextEditingValue(
+        text: character,
+        selection: TextSelection.collapsed(offset: character.length),
+      );
+
+      for (var press = 0; press < 2; press++) {
+        await tester.sendKeyDownEvent(key, character: character);
+        textInput.updateEditingValue(committed);
+        textInput.updateEditingValue(committed);
+        textInput.updateEditingValue(committed);
+        await tester.sendKeyUpEvent(key);
+      }
+    }
+    await tester.pump();
+
+    expect(output.join(), '..,,;;::[[]]');
   });
 }


### PR DESCRIPTION
## Resumo

- reinicia a transação de entrada de texto do terminal antes de cada tecla imprimível encaminhada ao Flutter
- cobre caracteres de pontuação idênticos consecutivos, inclusive os digitados com Shift

## Motivo

O buffer oculto de entrada de texto podia manter o caractere confirmado anteriormente enquanto a reinicialização da plataforma ainda estava pendente. Assim, um caractere idêntico repetido era confundido com um callback duplicado do IME e descartado.

## Impacto

Agora é possível digitar caracteres imprimíveis idênticos consecutivos no terminal de forma confiável.

## Validação

- `flutter test test/core/terminal/cockpit_terminal_input_test.dart`
