### PR TITLE
fix(cockpit): impede congelamento ao fechar Worktree no Linux

### DIFF
--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -3452,7 +3452,14 @@ class CockpitViewModel extends ChangeNotifier {
       unawaited(git.refresh(f.id));
     }
 
-    if (switched) await _activateProject(_selectedProjectId!);
+    if (switched) {
+      // O watcher Linux da worktree recebe onDone assim que o `git worktree
+      // remove` apaga a pasta. Move-o explicitamente pro pai antes de qualquer
+      // restauração assíncrona; deixá-lo apontado pro path sumido fazia o
+      // recovery tentar observar a mesma pasta indefinidamente no build AOT.
+      git.watchProject(_selectedProjectId);
+      await _activateProject(_selectedProjectId!);
+    }
     if (switched || !listEquals(oldSig, newSig)) notifyListeners();
   }
 

--- a/cockpit/lib/app/cockpit/ui/viewmodels/git_controller.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/git_controller.dart
@@ -13,6 +13,8 @@ import 'package:cockpit/app/cockpit/domain/entities/git_file_status.dart';
 import 'package:cockpit/app/cockpit/domain/entities/git_info.dart';
 import 'package:flutter/foundation.dart';
 
+typedef DirectoryWatch = Stream<FileSystemEvent> Function(String path);
+
 /// Estado git do shell, extraído do `CockpitViewModel` (refactor 2026-07-19):
 /// info/árvore por **root path**, roots derivadas por projeto, watcher de
 /// filesystem do projeto selecionado, poll de segurança e comandos git.
@@ -21,10 +23,21 @@ import 'package:flutter/foundation.dart';
 /// (path/gates/alvos de poll) pelos campos de callback abaixo, logo após a
 /// construção. Worktrees e diff viewer seguem no VM (mexem em projeto/pane).
 class GitController extends ChangeNotifier {
-  GitController(this._reader, this._runner);
+  GitController(
+    this._reader,
+    this._runner, {
+    DirectoryWatch? directoryWatch,
+    Duration watchRetryDelay = const Duration(milliseconds: 500),
+  }) : _directoryWatch = directoryWatch ?? _defaultDirectoryWatch,
+       _watchRetryDelay = watchRetryDelay;
 
   final GitStatusReader _reader;
   final GitCommandRunner _runner;
+  final DirectoryWatch _directoryWatch;
+  final Duration _watchRetryDelay;
+
+  static Stream<FileSystemEvent> _defaultDirectoryWatch(String path) =>
+      Directory(path).watch(recursive: true);
 
   // ---- contexto injetado pelo VM dono (mesma vida page-scoped) -------------
 
@@ -70,6 +83,7 @@ class GitController extends ChangeNotifier {
   /// Recriado ao trocar de projeto; debounce junta rajadas de eventos.
   StreamSubscription<FileSystemEvent>? _gitWatch;
   Timer? _gitWatchDebounce;
+  Timer? _gitWatchRetry;
   String? _gitWatchPath;
 
   /// Debounce próprio da árvore de arquivos: eventos **estruturais**
@@ -248,6 +262,7 @@ class GitController extends ChangeNotifier {
     if (projectId != null && (isSystemTerminal?.call(projectId) ?? false)) {
       _gitWatch?.cancel();
       _gitWatchDebounce?.cancel();
+      _gitWatchRetry?.cancel();
       _gitWatch = null;
       _gitWatchPath = null;
       return;
@@ -256,34 +271,44 @@ class GitController extends ChangeNotifier {
     if (path == _gitWatchPath) return; // já observando este projeto
     _gitWatch?.cancel();
     _gitWatchDebounce?.cancel();
+    _gitWatchRetry?.cancel();
     _gitWatch = null;
     _gitWatchPath = path;
     if (path == null || projectId == null) return;
     try {
-      _gitWatch = Directory(path)
-          .watch(recursive: true)
-          .listen(
-            (event) => _onFsEvent(projectId, event),
-            // A subscription pode morrer sozinha (erro de FSEvents, limite de
-            // FDs, dir recriada). Sem isso o guard `path == _gitWatchPath`
-            // impediria o re-arm e as updates ao vivo parariam de vez — o poll
-            // ainda cobre, mas re-armamos pra manter a latência baixa.
-            onError: (_) => _rearmWatch(path),
-            onDone: () => _rearmWatch(path),
-            cancelOnError: true,
-          );
+      _gitWatch = _directoryWatch(path).listen(
+        (event) => _onFsEvent(projectId, event),
+        // A subscription pode morrer sozinha (erro de FSEvents/inotify, limite
+        // de FDs, dir recriada). O retry é atrasado: reabrir imediatamente uma
+        // pasta removida cria um loop de erro/re-arm que monopoliza o event loop
+        // (caso exato de remover a worktree selecionada no Linux release).
+        onError: (_) => _scheduleWatchRetry(path),
+        onDone: () => _scheduleWatchRetry(path),
+        cancelOnError: true,
+      );
     } catch (_) {
-      _gitWatchPath = null; // pasta inacessível → sem watcher (só poll/manual)
+      _scheduleWatchRetry(path);
     }
   }
 
-  /// Re-arma o watcher se a subscription do projeto [path] morreu enquanto ele
-  /// ainda é o observado. Zera o guard pra [watchProject] não sair cedo.
-  void _rearmWatch(String path) {
+  /// Re-arma o watcher com backoff se a subscription do projeto [path] morreu.
+  ///
+  /// No Linux, observar uma pasta inexistente falha de forma assíncrona e
+  /// imediata. Sem o atraso, `onError → watchProject → onError` vira um loop
+  /// apertado que impede a UI e até a continuação de `git worktree remove` de
+  /// rodarem. No disparo também recalculamos a seleção: durante o atraso a
+  /// worktree removida pode ter devolvido o foco ao workspace pai.
+  void _scheduleWatchRetry(String path) {
     if (_gitWatchPath != path) return; // já trocaram de projeto → ignora
     _gitWatch = null;
-    _gitWatchPath = null;
-    watchProject(selectedProjectId?.call());
+    _gitWatchRetry?.cancel();
+    _gitWatchRetry = Timer(_watchRetryDelay, () {
+      _gitWatchRetry = null;
+      if (_gitWatchPath != path) return;
+      final selected = selectedProjectId?.call();
+      _gitWatchPath = null; // libera o guard de [watchProject]
+      watchProject(selected);
+    });
   }
 
   /// (Re)inicia o poll periódico de git dos [pollTargets]. Ver [_gitPoll].
@@ -377,6 +402,7 @@ class GitController extends ChangeNotifier {
   void dispose() {
     _gitWatch?.cancel();
     _gitWatchDebounce?.cancel();
+    _gitWatchRetry?.cancel();
     _fileTreeWatchDebounce?.cancel();
     _gitPoll?.cancel();
     super.dispose();

--- a/cockpit/test/ui/git_controller_test.dart
+++ b/cockpit/test/ui/git_controller_test.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:cockpit/app/cockpit/domain/contracts/git_command_runner.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/git_status_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_info.dart';
+import 'package:cockpit/app/cockpit/ui/viewmodels/git_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _NoopStatusReader implements GitStatusReader {
+  @override
+  Future<GitInfo?> read(String path) async => null;
+}
+
+class _NoopCommandRunner implements GitCommandRunner {
+  Never _unused() => throw UnimplementedError();
+
+  @override
+  GitMergeOutcome mergeIntoParent(
+    String parentPath,
+    String worktreePath,
+    String worktreeBranch,
+  ) => _unused();
+
+  @override
+  GitRun run(String repoPath, List<String> args) => _unused();
+
+  @override
+  GitRun syncPullPush(String repoPath) => _unused();
+}
+
+void main() {
+  test('watch failure retries with backoff instead of spinning', () async {
+    var attempts = 0;
+    final git = GitController(
+      _NoopStatusReader(),
+      _NoopCommandRunner(),
+      directoryWatch: (_) {
+        attempts++;
+        return Stream<FileSystemEvent>.error(
+          const FileSystemException('directory disappeared'),
+        );
+      },
+      watchRetryDelay: const Duration(milliseconds: 80),
+    );
+    addTearDown(git.dispose);
+    git
+      ..resolvePath = ((_) => '/missing/worktree')
+      ..selectedProjectId = (() => 'fork')
+      ..watchProject('fork');
+
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(attempts, 1);
+
+    await Future<void>.delayed(const Duration(milliseconds: 90));
+    expect(attempts, 2);
+  });
+
+  test(
+    'retry follows a selection that moved to the parent workspace',
+    () async {
+      final watched = <String>[];
+      var selected = 'fork';
+      final parentEvents = StreamController<FileSystemEvent>();
+      addTearDown(parentEvents.close);
+      final git = GitController(
+        _NoopStatusReader(),
+        _NoopCommandRunner(),
+        directoryWatch: (path) {
+          watched.add(path);
+          if (path == '/gone/worktree') {
+            return Stream<FileSystemEvent>.error(
+              const FileSystemException('directory disappeared'),
+            );
+          }
+          return parentEvents.stream;
+        },
+        watchRetryDelay: const Duration(milliseconds: 30),
+      );
+      addTearDown(git.dispose);
+      git
+        ..resolvePath = ((id) => id == 'fork' ? '/gone/worktree' : '/repo')
+        ..selectedProjectId = (() => selected)
+        ..watchProject('fork');
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      selected = 'parent';
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+
+      expect(watched, ['/gone/worktree', '/repo']);
+    },
+  );
+}


### PR DESCRIPTION
## Resumo

- limita a frequência de recuperação do watcher quando a pasta observada desaparece
- move o watcher ativo de volta para o workspace pai após remover a Worktree selecionada
- adiciona testes de regressão para o intervalo entre tentativas e a troca para o workspace pai

## Causa raiz

O pacote do AUR apenas reempacota o build release oficial do Linux. Portanto, a diferença relevante de execução está no modo release/AOT, e não em código específico do pacote.

Quando `git worktree remove` excluía a Worktree selecionada, o Linux encerrava o watcher recursivo da pasta. O Cockpit recriava imediatamente o watcher apontando para o caminho que acabara de desaparecer. O novo watcher falhava de imediato e disparava outra tentativa, produzindo um loop assíncrono apertado que monopolizava o event loop do Flutter.

No build release otimizado, esse loop impedia a continuação da remoção de trocar a seleção para o workspace pai, deixando o aplicativo permanentemente sem resposta. No modo debug/JIT, a execução mais lenta mascarava a condição de corrida.

O watcher agora aguarda um intervalo limitado antes de tentar novamente e recalcula o projeto selecionado antes de ser rearmado. A reconciliação também move o watcher imediatamente para o workspace pai quando a Worktree removida estava selecionada.

## Impacto para o usuário

Fechar uma Worktree no aplicativo Linux instalado não congela mais o Cockpit. A interface permanece responsiva e a seleção retorna ao workspace pai.

## Validação

- `flutter test test/ui/git_controller_test.dart test/data/worktree_manager_impl_test.dart`
- `flutter analyze lib/app/cockpit/ui/viewmodels/git_controller.dart lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart test/ui/git_controller_test.dart`
- `flutter build linux --release`
- `git diff --check`
