### PR TITLE
feat(cockpit): adiciona Ghostty como motor de terminal padrão

### DIFF
--- a/cockpit/CLAUDE.md
+++ b/cockpit/CLAUDE.md
@@ -52,8 +52,8 @@ nossa) e quem é pacote externo:
 
 | Motor | Onde | Origem / nota |
 |---|---|---|
-| **Emulador de terminal** (VT/ANSI) | `lib/app/core/terminal/xterm/` | **Nosso** — absorvido do fork do `xterm.dart` 4.0 (upstream morto); Dart puro. Testes em `test/core/terminal/xterm/` |
-| **Render do terminal** (view/painter/gesture, cache de Picture por linha) | `lib/app/core/terminal/cockpit_terminal*.dart` | **Nosso** — fork interno do view do xterm. Ver `core/terminal/CLAUDE.md` |
+| **Emulador de terminal** (VT/ANSI) | `libghostty` + `lib/app/core/terminal/xterm/` | Ghostty é o padrão de buffers novos; o xterm absorvido continua disponível e é usado por layouts legados |
+| **Render do terminal** | `flterm` + `lib/app/core/terminal/cockpit_terminal*.dart` | `flterm` renderiza Ghostty; a view/painter interna permanece integral para xterm. Ver `core/terminal/CLAUDE.md` |
 | **PTY** (spawn nativo de shell — forkpty/ConPTY) | `plugins/cockpit_pty/` | **Nosso** — plugin C/FFI absorvido do `kyroon_pty` v1.0.6, renomeado; não publicado |
 | **Markdown** (GFM + code do agente/viewer) | pacote `gpt_markdown` ^1.1.8 (pub.dev) | Externo (upstream ativo). O **frontmatter** YAML é nosso: `core/ui/widgets/markdown_frontmatter.dart` (pré-processamento no `AgentMarkdown`) |
 | **Syntax highlight** (léxico, ~190 linguagens) | pacote `highlight` ^0.7.0 + `core/ui/widgets/code_highlight.dart` (tema/integração) | Externo; decisão do plano LSP: highlight léxico mantido (LSP não colore) |

--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -75,6 +75,12 @@ class _CockpitPageState extends State<CockpitPage> {
       if (!mounted) return;
       context.pushNamed(RoutePaths.settings);
     };
+    // O motor/perfil precisam chegar antes do init: ele já pode restaurar ou
+    // criar terminais, e a preferência do usuário deve valer desde o 1º buffer.
+    final initialSettings = context.read<SettingsController>().settings;
+    context.read<CockpitViewModel>()
+      ..setDefaultTerminalProfileId(initialSettings.defaultTerminalProfileId)
+      ..setDefaultTerminalEngine(initialSettings.terminalEngine);
     // Dispara o carregamento inicial dos ViewModels page-scoped ao montar a rota.
     // Os módulos provêm via `.new`, então não encadeiam mais `..init()`/`..check()`.
     context.read<CockpitViewModel>().init();
@@ -179,6 +185,7 @@ class _CockpitPageState extends State<CockpitPage> {
     _vm.setDefaultTerminalProfileId(
       _settings!.settings.defaultTerminalProfileId,
     );
+    _vm.setDefaultTerminalEngine(_settings!.settings.terminalEngine);
   }
 
   /// Espelha o toggle "Show Cockpit terminal" (Configurações › General) para a

--- a/cockpit/lib/app/cockpit/ui/session/task_output_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/task_output_session.dart
@@ -1,5 +1,5 @@
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
-import 'package:cockpit/app/core/terminal/xterm/xterm.dart';
+import 'package:cockpit/app/core/terminal/terminal_controller.dart';
 
 /// Aba **read-only** que visualiza o output de uma task. É leve e descartável:
 /// o [terminal] não é dela — vive no `TaskTerminalStore` —, então abrir/fechar
@@ -26,7 +26,7 @@ class TaskOutputSession extends PaneItem {
   final String taskId;
 
   /// Terminal compartilhado (dono = `TaskTerminalStore`). **Não** dar dispose.
-  final Terminal terminal;
+  final CockpitTerminalController terminal;
 
   final String _label;
 

--- a/cockpit/lib/app/cockpit/ui/session/task_terminal_store.dart
+++ b/cockpit/lib/app/cockpit/ui/session/task_terminal_store.dart
@@ -4,7 +4,8 @@ import 'dart:convert';
 import 'package:cockpit/app/cockpit/domain/contracts/task_runner_gateway.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_scrollback_store.dart';
 import 'package:cockpit/app/cockpit/domain/entities/task_run.dart';
-import 'package:cockpit/app/core/terminal/xterm/xterm.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/terminal/terminal_controller.dart';
 
 /// Mantém **um emulador [Terminal] por task**, alimentado continuamente pelo
 /// output do runner — independente de haver ou não uma aba aberta. É isso que
@@ -37,7 +38,7 @@ class TaskTerminalStore {
   /// Teto do histórico persistido por task (~256 KB de output decodificado).
   static const int _kMaxRecordChars = 256 * 1024;
 
-  final _terminals = <String, Terminal>{};
+  final _terminals = <String, CockpitTerminalController>{};
   final _outSubs = <String, StreamSubscription<String>>{};
   final _lastPid = <String, int?>{};
   final _record = <String, StringBuffer>{};
@@ -48,11 +49,21 @@ class TaskTerminalStore {
   /// primeira criação, semeia de forma assíncrona o output salvo em disco.
   /// Terminal já existente da task, sem criar um vazio (leitura via CLI
   /// `cockpit read-task` — criar aqui registraria um buffer fantasma).
-  Terminal? existingTerminal(String taskId) => _terminals[taskId];
+  TerminalEngine _defaultEngine = TerminalEngine.ghostty;
 
-  Terminal terminalFor(String taskId) => _terminals.putIfAbsent(taskId, () {
-    final term = Terminal(maxLines: 10000);
-    term.onResize = (w, h, pw, ph) => _runner.resize(taskId, h, w);
+  /// Vale só para buffers criados depois da troca; tasks já existentes mantêm
+  /// o controller e o estado em memória.
+  void setDefaultEngine(TerminalEngine engine) => _defaultEngine = engine;
+
+  CockpitTerminalController? existingTerminal(String taskId) =>
+      _terminals[taskId];
+
+  CockpitTerminalController terminalFor(
+    String taskId, {
+    TerminalEngine? engine,
+  }) => _terminals.putIfAbsent(taskId, () {
+    final term = createTerminalController(engine ?? _defaultEngine);
+    term.onResize = (columns, rows) => _runner.resize(taskId, rows, columns);
     unawaited(_seed(taskId, term));
     return term;
   });
@@ -60,7 +71,7 @@ class TaskTerminalStore {
   /// Reproduz o output salvo no terminal recém-criado (restore). `\x1bc` (RIS)
   /// limpa qualquer modo residual em que a task morreu. No-op se um run já
   /// começou a escrever (corrida com o `_onRun`) ou não há nada salvo.
-  Future<void> _seed(String taskId, Terminal term) async {
+  Future<void> _seed(String taskId, CockpitTerminalController term) async {
     final raw = await _scrollback.load(
       projectId: _kTasksProject,
       sessionId: taskId,
@@ -68,7 +79,7 @@ class TaskTerminalStore {
     if (raw == null || raw.isEmpty) return;
     if (_outSubs.containsKey(taskId)) return; // run vivo já alimenta o terminal
     if (_record[taskId]?.isNotEmpty ?? false) return;
-    term.write('\x1bc$raw');
+    term.restore('\x1bc$raw');
     (_record[taskId] ??= StringBuffer()).write(raw);
   }
 
@@ -146,6 +157,9 @@ class TaskTerminalStore {
       s.cancel();
     }
     _outSubs.clear();
+    for (final terminal in _terminals.values) {
+      terminal.dispose();
+    }
     _terminals.clear();
   }
 }

--- a/cockpit/lib/app/cockpit/ui/session/terminal_read_window.dart
+++ b/cockpit/lib/app/cockpit/ui/session/terminal_read_window.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
-import 'package:cockpit/app/core/terminal/xterm/xterm.dart';
+import 'package:cockpit/app/core/terminal/terminal_controller.dart';
+import 'package:cockpit/app/core/terminal/xterm/xterm.dart' as xterm;
 
 /// Extrai uma janela de linhas do buffer ativo de um [Terminal] pra CLI
 /// `cockpit read-pane`/`read-task` (cobre o alt-screen de TUIs — lê o que está
@@ -10,7 +11,7 @@ import 'package:cockpit/app/core/terminal/xterm/xterm.dart';
 /// do buffer; default = fim (tail). `offset` pula N linhas a partir da âncora.
 /// A saída é sempre cronológica — os args só escolhem a janela.
 Map<String, dynamic> readTerminalWindow(
-  Terminal term,
+  Object term,
   Map<String, dynamic> args,
 ) {
   const maxLines = 2000;
@@ -25,10 +26,17 @@ Map<String, dynamic> readTerminalWindow(
   };
   final fromStart = args['fromStart'] == true;
 
-  final buf = term.buffer.lines;
+  final buf = switch (term) {
+    final CockpitTerminalController controller => controller.plainLines(),
+    final xterm.Terminal terminal => [
+      for (var i = 0; i < terminal.buffer.lines.length; i++)
+        terminal.buffer.lines[i].getText(),
+    ],
+    _ => throw ArgumentError.value(term, 'term', 'unsupported terminal'),
+  };
   // Total efetivo: ignora o vazio do viewport abaixo da última linha escrita.
   var total = buf.length;
-  while (total > 0 && buf[total - 1].getText().isEmpty) {
+  while (total > 0 && buf[total - 1].isEmpty) {
     total--;
   }
 
@@ -39,7 +47,7 @@ Map<String, dynamic> readTerminalWindow(
   final out = StringBuffer();
   for (var i = start; i < end; i++) {
     if (i > start) out.write('\n');
-    out.write(buf[i].getText());
+    out.write(buf[i]);
   }
   return <String, dynamic>{
     'text': base64.encode(utf8.encode(out.toString())),

--- a/cockpit/lib/app/cockpit/ui/session/terminal_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/terminal_session.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_gateway.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_scrollback_store.dart';
 import 'package:cockpit/app/core/domain/entities/terminal_profile.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/terminal/terminal_controller.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
 import 'package:cockpit/app/cockpit/ui/session/terminal_input.dart';
 import 'package:flutter/foundation.dart';
@@ -30,25 +32,27 @@ class TerminalSession extends PaneItem {
     TerminalScrollbackStore? scrollbackStore,
     String? replay,
     String? startupCommand,
+    TerminalEngine engine = TerminalEngine.xterm,
   }) : _gateway = gateway,
        _scrollback = scrollbackStore,
        _title = title ?? 'New terminal' {
     // O `ShiftEnterInputHandler` (antes do padrão) faz Shift+Enter virar quebra
     // de linha nos harnesses (claude, codex, pi) em vez de submeter; ele lê o
     // estado do kitty keyboard protocol que `_kitty` rastreia pela saída do PTY.
-    terminal = Terminal(
-      maxLines: 10000,
-      inputHandler: CascadeInputHandler([
+    terminal = createTerminalController(
+      engine,
+      xtermInputHandler: CascadeInputHandler([
         ShiftEnterInputHandler(_kitty),
         defaultInputHandler,
       ]),
     );
 
-    // Replay do scrollback salvo (restauração): escreve o histórico ANTES de
-    // subir o shell, então a saída viva nasce logo abaixo. Síncrono → a ordem
-    // (histórico, depois prompt novo) é garantida. O `\x1bc` que limpa o estado
-    // (alt-screen residual) já vem embutido em `replay` (montado na VM).
-    if (replay != null && replay.isNotEmpty) terminal.write(replay);
+    // Replay do scrollback salvo (restauração): entra na fila ANTES de subir o
+    // shell, então a saída viva nasce logo abaixo. No Ghostty a fila só é
+    // aplicada após o primeiro resize da view, evitando interpretar posições
+    // gravadas numa grade provisória de 80 colunas. O `\x1bc` que limpa estado
+    // residual já vem embutido em `replay` (montado na VM).
+    if (replay != null && replay.isNotEmpty) terminal.restore(replay);
 
     // Sobe o shell e liga os dois lados. O `.cast<List<int>>()` re-vincula o
     // tipo do stream (o PTY emite Uint8List) para o `utf8.decoder` aceitar e
@@ -70,14 +74,14 @@ class TerminalSession extends PaneItem {
           _trackCwd(data); // rastreia o cwd vivo (OSC 7) pra restaurar nele.
         });
     terminal.onOutput = (data) {
-      _maybeInterrupt(data);
-      _gateway.write(utf8.encode(data));
+      final text = utf8.decode(data, allowMalformed: true);
+      _maybeInterrupt(text);
+      _gateway.write(data);
     };
-    terminal.onResize = (width, height, pixelWidth, pixelHeight) =>
-        _gateway.resize(height, width);
+    terminal.onResize = (columns, rows) => _gateway.resize(rows, columns);
     // Programas mudam o título da janela via OSC 0/2 (ex.: shell mostra o cwd,
     // `vim`/`ssh` mostram o arquivo/host). Refletimos isso no nome da aba.
-    terminal.onTitleChange = (osc) => rename(_shortTitle(osc));
+    terminal.onTitleChanged = (osc) => rename(_shortTitle(osc));
 
     // Restauração de aba que rodava um harness (ex.: `claude --resume <sid>`):
     // digita o comando no shell novo. Espera o shell de login (`-l`, que lê
@@ -263,7 +267,7 @@ class TerminalSession extends PaneItem {
   String? _cwd;
   String? get currentDirectory => _cwd;
   String _title;
-  late final Terminal terminal;
+  late final CockpitTerminalController terminal;
   StreamSubscription<String>? _sub;
 
   @override
@@ -369,6 +373,7 @@ class TerminalSession extends PaneItem {
     ); // best-effort: persiste o estado final (inclui app-quit).
     await _sub?.cancel();
     await _gateway.kill();
+    terminal.dispose();
     super.dispose();
   }
 }

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -22,6 +22,7 @@ import 'package:cockpit/app/cockpit/domain/contracts/session_history.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_gateway_factory.dart';
 import 'package:cockpit/app/core/domain/contracts/terminal_profile_resolver.dart';
 import 'package:cockpit/app/core/domain/entities/terminal_profile.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_status_server.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/workspace_layout_store.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/worktree_manager.dart';
@@ -277,6 +278,13 @@ class CockpitViewModel extends ChangeNotifier {
   /// de plataforma. Síncrono — o cache do resolver é aquecido no boot (`main`).
   TerminalProfile get defaultTerminalProfile =>
       _terminalProfiles.effectiveDefault(_defaultTerminalProfileId);
+
+  TerminalEngine _defaultTerminalEngine = TerminalEngine.ghostty;
+
+  void setDefaultTerminalEngine(TerminalEngine engine) {
+    _defaultTerminalEngine = engine;
+    _taskTerminals.setDefaultEngine(engine);
+  }
 
   /// Perfis descobertos, para o seletor ao lado do `+`. Já aquecidos no boot.
   List<TerminalProfile> get terminalProfiles =>
@@ -2665,6 +2673,7 @@ class CockpitViewModel extends ChangeNotifier {
     // Plano 50: `null` = o padrão efetivo (o que o `+` abre hoje). A fatia 3
     // (dropdown do `+`) passa um perfil específico sem mexer no padrão global.
     TerminalProfile? profile,
+    TerminalEngine? engine,
   }) {
     final t = TerminalSession(
       id: id,
@@ -2672,6 +2681,7 @@ class CockpitViewModel extends ChangeNotifier {
       workingDirectory: cwd,
       gateway: _terminalFactory.create(),
       profile: profile ?? defaultTerminalProfile,
+      engine: engine ?? _defaultTerminalEngine,
       title: title,
       // Persistência do scrollback: grava a saída pra replay no próximo boot.
       scrollbackStore: _scrollback,
@@ -3041,6 +3051,11 @@ class CockpitViewModel extends ChangeNotifier {
           // Re-arma a trava ANTES de o shell subir e re-emitir OSC-title: o nome
           // manual continua vencendo o título dinâmico após o reinício.
           manualLabel: desc['label'] as String?,
+          engine: _enumByName(
+            TerminalEngine.values,
+            desc['engine'],
+            TerminalEngine.xterm,
+          ),
         );
         return true;
       case 'viewer':
@@ -3105,7 +3120,14 @@ class CockpitViewModel extends ChangeNotifier {
           projectId: project.id,
           taskId: taskId,
           label: desc['label'] as String? ?? taskId,
-          terminal: _taskTerminals.terminalFor(taskId),
+          terminal: _taskTerminals.terminalFor(
+            taskId,
+            engine: _enumByName(
+              TerminalEngine.values,
+              desc['engine'],
+              TerminalEngine.xterm,
+            ),
+          ),
           workingDirectory: project.path,
         );
         return true;
@@ -3294,6 +3316,7 @@ class CockpitViewModel extends ChangeNotifier {
         'type': 'terminal',
         'sub': _subOf(s.workingDirectory, project.path),
         'title': s.title,
+        'engine': s.terminal.engine.name,
         // Rótulo manual travado (se houver): persiste com o descritor da aba,
         // que no restore é re-hidratado pela mesma chave de sessão → o nome
         // estável sobrevive ao reinício e à re-emissão de OSC-title do shell.
@@ -3331,6 +3354,7 @@ class CockpitViewModel extends ChangeNotifier {
         'type': 'task_output',
         'taskId': s.taskId,
         'label': s.label,
+        'engine': s.terminal.engine.name,
       };
     }
     final a = s as AgentSession;

--- a/cockpit/lib/app/cockpit/ui/widgets/adaptive_terminal_pane.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/adaptive_terminal_pane.dart
@@ -1,0 +1,158 @@
+import 'package:cockpit/app/core/terminal/ghostty_font_family.dart';
+import 'package:cockpit/app/core/terminal/terminal_controller.dart';
+import 'package:cockpit/app/core/terminal/xterm/xterm.dart' as xterm;
+import 'package:flterm/flterm.dart' as ghost;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'terminal_pane.dart';
+
+/// Renderiza o controller com a view nativa do motor que o criou.
+class AdaptiveTerminalPane extends StatelessWidget {
+  const AdaptiveTerminalPane({
+    super.key,
+    required this.terminal,
+    required this.focusNode,
+    required this.textStyle,
+    required this.theme,
+    this.onKeyEvent,
+    this.onPaste,
+    this.onOpenFile,
+    this.readOnly = false,
+  });
+
+  final CockpitTerminalController terminal;
+  final FocusNode focusNode;
+  final xterm.TerminalStyle textStyle;
+  final xterm.TerminalTheme theme;
+  final KeyEventResult Function(KeyEvent event)? onKeyEvent;
+  final VoidCallback? onPaste;
+  final void Function(String path, {int? line})? onOpenFile;
+  final bool readOnly;
+
+  @override
+  Widget build(BuildContext context) => switch (terminal) {
+    final XtermTerminalController value => TerminalPane(
+      terminal: value.terminal,
+      focusNode: focusNode,
+      textStyle: textStyle,
+      theme: theme,
+      hardwareKeyboardOnly: readOnly,
+      onKeyEvent: onKeyEvent ?? (_) => KeyEventResult.ignored,
+      onOpenFile: onOpenFile,
+    ),
+    final GhosttyTerminalController value => _GhosttyPane(
+      terminal: value,
+      focusNode: focusNode,
+      textStyle: textStyle,
+      theme: theme,
+      onPaste: onPaste,
+      onOpenFile: onOpenFile,
+      readOnly: readOnly,
+    ),
+  };
+}
+
+final class _CockpitPasteIntent extends Intent {
+  const _CockpitPasteIntent();
+}
+
+class _GhosttyPane extends StatelessWidget {
+  const _GhosttyPane({
+    required this.terminal,
+    required this.focusNode,
+    required this.textStyle,
+    required this.theme,
+    required this.onPaste,
+    required this.onOpenFile,
+    required this.readOnly,
+  });
+
+  final GhosttyTerminalController terminal;
+  final FocusNode focusNode;
+  final xterm.TerminalStyle textStyle;
+  final xterm.TerminalTheme theme;
+  final VoidCallback? onPaste;
+  final void Function(String path, {int? line})? onOpenFile;
+  final bool readOnly;
+
+  @override
+  Widget build(BuildContext context) {
+    final shortcuts = <ShortcutActivator, Intent>{};
+    if (!readOnly && onPaste != null) {
+      shortcuts[const SingleActivator(LogicalKeyboardKey.keyV, meta: true)] =
+          const _CockpitPasteIntent();
+      shortcuts[const SingleActivator(LogicalKeyboardKey.keyV, control: true)] =
+          const _CockpitPasteIntent();
+    }
+
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        _CockpitPasteIntent: CallbackAction<_CockpitPasteIntent>(
+          onInvoke: (_) {
+            onPaste?.call();
+            return null;
+          },
+        ),
+      },
+      child: ghost.TerminalView(
+        controller: terminal.controller,
+        focusNode: focusNode,
+        showKeyboard: !readOnly,
+        padding: EdgeInsets.zero,
+        scrollPhysics: const ClampingScrollPhysics(),
+        shortcuts: shortcuts,
+        theme: _ghosttyTheme(theme, textStyle),
+        linkSettings: ghost.LinkSettings(onActivate: (link) => _openLink(link)),
+      ),
+    );
+  }
+
+  void _openLink(ghost.ActivatedLink link) {
+    final file = link.file;
+    if (file != null && onOpenFile != null) {
+      onOpenFile!(file.path, line: file.line);
+      return;
+    }
+    final uri = link.uri;
+    if (uri != null) {
+      launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}
+
+ghost.TerminalTheme _ghosttyTheme(
+  xterm.TerminalTheme source,
+  xterm.TerminalStyle style,
+) => ghost.TerminalTheme(
+  palette: ghost.ColorPalette(
+    ansiColors: [
+      source.black,
+      source.red,
+      source.green,
+      source.yellow,
+      source.blue,
+      source.magenta,
+      source.cyan,
+      source.white,
+      source.brightBlack,
+      source.brightRed,
+      source.brightGreen,
+      source.brightYellow,
+      source.brightBlue,
+      source.brightMagenta,
+      source.brightCyan,
+      source.brightWhite,
+    ],
+    background: source.background,
+    foreground: source.foreground,
+  ),
+  cursor: ghost.CursorTheme(color: ghost.DynamicColor.fixed(source.cursor)),
+  selection: ghost.SelectionTheme(
+    background: ghost.DynamicColor.fixed(source.selection),
+  ),
+  fontFamily: resolveGhosttyFontFamily(style.fontFamily),
+  fontFamilyFallback: style.fontFamilyFallback,
+  fontSize: style.fontSize,
+);

--- a/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
@@ -26,7 +26,7 @@ import 'package:cockpit/app/cockpit/ui/widgets/db_engine_icon.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/db_mongo_view.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/db_redis_table.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/file_viewer.dart';
-import 'package:cockpit/app/cockpit/ui/widgets/terminal_pane.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/adaptive_terminal_pane.dart';
 import 'package:cockpit/app/core/ui/file_icons/file_icons.dart';
 import 'package:cockpit/app/core/ui/themes/terminal_theme.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
@@ -1305,10 +1305,11 @@ class _PaneBodyState extends State<_PaneBody> {
         color: context.colors.panel,
         child: Padding(
           padding: const EdgeInsets.fromLTRB(10, 8, 0, 8),
-          child: TerminalPane(
+          child: AdaptiveTerminalPane(
             terminal: item.terminal,
             focusNode: _terminalFocus,
             onKeyEvent: (_) => KeyEventResult.ignored,
+            readOnly: true,
             theme: cockpitTerminalThemeFor(Theme.of(context).brightness),
             textStyle: termStyle,
           ),
@@ -1331,12 +1332,13 @@ class _PaneBodyState extends State<_PaneBody> {
           color: context.colors.panel,
           child: Padding(
             padding: const EdgeInsets.fromLTRB(10, 8, 0, 8),
-            child: TerminalPane(
+            child: AdaptiveTerminalPane(
               terminal: item.terminal,
               focusNode: _terminalFocus,
               // Intercepta o atalho de colar pra suportar IMAGEM do clipboard
               // (o paste padrão do xterm só cola texto). Ver `_onTerminalKey`.
               onKeyEvent: (event) => _onTerminalKey(event, item),
+              onPaste: item.pasteFromClipboard,
               // Cmd+clique num caminho de arquivo do buffer → abre no FileViewer,
               // resolvido contra o cwd vivo do shell (OSC 7).
               onOpenFile: (path, {line}) =>

--- a/cockpit/lib/app/core/domain/entities/app_settings.dart
+++ b/cockpit/lib/app/core/domain/entities/app_settings.dart
@@ -6,6 +6,9 @@ enum AppThemeMode { system, light, dark }
 /// variante light/dark, resolvida pelo brilho do app.
 enum SyntaxThemeId { one, dracula, github }
 
+/// Motor VT usado por terminais criados daqui pra frente.
+enum TerminalEngine { ghostty, xterm }
+
 /// Preferências do app, persistidas localmente (Hive). Imutável; mudanças via
 /// [copyWith]. Fontes vazias (`null`) = usar os defaults do design.
 class AppSettings {
@@ -31,6 +34,7 @@ class AppSettings {
     this.treeVisible = false,
     this.showCockpit = true,
     this.defaultTerminalProfileId,
+    this.terminalEngine = TerminalEngine.ghostty,
   });
 
   final AppThemeMode themeMode;
@@ -115,6 +119,10 @@ class AppSettings {
   /// re-descobertos a cada boot, e um `id` que sumiu degrada pro fallback.
   final String? defaultTerminalProfileId;
 
+  /// Motor padrão de novas abas/buffers. Abas existentes guardam o próprio
+  /// motor no descritor de layout e não são recriadas ao trocar esta opção.
+  final TerminalEngine terminalEngine;
+
   AppSettings copyWith({
     AppThemeMode? themeMode,
     String? interfaceFont,
@@ -141,6 +149,7 @@ class AppSettings {
     bool? showCockpit,
     String? defaultTerminalProfileId,
     bool clearDefaultTerminalProfileId = false,
+    TerminalEngine? terminalEngine,
   }) {
     return AppSettings(
       themeMode: themeMode ?? this.themeMode,
@@ -170,6 +179,7 @@ class AppSettings {
       defaultTerminalProfileId: clearDefaultTerminalProfileId
           ? null
           : (defaultTerminalProfileId ?? this.defaultTerminalProfileId),
+      terminalEngine: terminalEngine ?? this.terminalEngine,
     );
   }
 
@@ -202,6 +212,7 @@ class AppSettings {
     // plataforma. Nada a migrar (plano 50).
     if (defaultTerminalProfileId != null)
       'terminal.default_profile_id': defaultTerminalProfileId,
+    'terminal.engine': terminalEngine.name,
   };
 
   factory AppSettings.fromJson(Map<dynamic, dynamic> json) {
@@ -240,6 +251,11 @@ class AppSettings {
       treeVisible: json['treeVisible'] as bool? ?? false,
       showCockpit: json['showCockpit'] as bool? ?? true,
       defaultTerminalProfileId: str(json['terminal.default_profile_id']),
+      terminalEngine: _enumByName(
+        TerminalEngine.values,
+        json['terminal.engine'],
+        TerminalEngine.ghostty,
+      ),
     );
   }
 }

--- a/cockpit/lib/app/core/terminal/CLAUDE.md
+++ b/cockpit/lib/app/core/terminal/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Tudo de terminal num lugar só:
 
+- **`terminal_controller.dart`** — contrato comum e adapters dos dois motores.
+- **Ghostty** — `libghostty` mantém o estado VT nativo e `flterm` fornece a
+  view Flutter. É o padrão para buffers novos; o motor escolhido é persistido
+  por aba/task.
 - **`xterm/`** — emulador VT **absorvido** (2026-07-19) do fork
   `jacobaraujo7/xterm.dart` (upstream TerminalStudio/xterm.dart 4.0.0, parado).
   Dart puro, zero nativo. Razões da absorção: upstream sem manutenção, o app já
@@ -12,7 +16,7 @@ Tudo de terminal num lugar só:
   (`custom_text_edit.dart`). Removidos na absorção (não usados): zmodem,
   suggestion, debugger_view.
 - **`cockpit_terminal*.dart`** — view/render próprios (cache de `ui.Picture`
-  por linha, gesture, painter), que consomem o emulador acima.
+  por linha, gesture, painter), preservados para o adapter xterm.
 
 Testes do emulador: `test/core/terminal/xterm/` (suíte do upstream adaptada;
 2 casos de `getText()` com wrap já falhavam no fork e estão `skip: true`).

--- a/cockpit/lib/app/core/terminal/ghostty_font_family.dart
+++ b/cockpit/lib/app/core/terminal/ghostty_font_family.dart
@@ -1,0 +1,21 @@
+import 'system_monospace_resolver_stub.dart'
+    if (dart.library.io) 'system_monospace_resolver_io.dart';
+
+/// Resolve o alias genérico usado pela configuração padrão do Ghostty.
+///
+/// O Ghostty nativo entrega `monospace` ao resolvedor de fontes da plataforma
+/// (Fontconfig no Linux). O Flutter pode tratar esse texto como uma família
+/// literal e então medir a célula com uma fonte diferente da usada para pintar
+/// os glifos. Converter apenas o alias mantém fonte e métricas alinhadas sem
+/// alterar famílias escolhidas explicitamente pelo usuário.
+String resolveGhosttyFontFamily(
+  String requested, {
+  String? Function()? systemMonospaceResolver,
+}) {
+  final family = requested.trim();
+  if (family.toLowerCase() != 'monospace') return family;
+
+  final resolved = (systemMonospaceResolver ?? resolveSystemMonospaceFamily)()
+      ?.trim();
+  return resolved == null || resolved.isEmpty ? family : resolved;
+}

--- a/cockpit/lib/app/core/terminal/ghostty_sgr_weight_normalizer.dart
+++ b/cockpit/lib/app/core/terminal/ghostty_sgr_weight_normalizer.dart
@@ -1,0 +1,62 @@
+/// Normaliza SGR bold para o peso base antes de o VT chegar ao `flterm`.
+///
+/// O renderer do `flterm` 0.0.4 fixa SGR 1 em `FontWeight.bold` (700), sem um
+/// knob separado para o peso de destaque. No rasterizador do Flutter esse peso
+/// fica perceptivelmente mais forte que no Ghostty nativo. SGR 22 mantém cor e
+/// demais atributos, mas volta ao peso regular configurado no tema.
+final class GhosttySgrWeightNormalizer {
+  String _pending = '';
+
+  String add(String chunk) {
+    if (chunk.isEmpty) return '';
+    final input = '$_pending$chunk';
+    _pending = '';
+    final output = StringBuffer();
+    var index = 0;
+
+    while (index < input.length) {
+      if (input.codeUnitAt(index) != 0x1b) {
+        output.writeCharCode(input.codeUnitAt(index));
+        index++;
+        continue;
+      }
+
+      if (index + 1 >= input.length) {
+        _pending = input.substring(index);
+        break;
+      }
+      if (input.codeUnitAt(index + 1) != 0x5b) {
+        output.writeCharCode(0x1b);
+        index++;
+        continue;
+      }
+
+      var end = index + 2;
+      while (end < input.length) {
+        final code = input.codeUnitAt(end);
+        if (code >= 0x40 && code <= 0x7e) break;
+        end++;
+      }
+      if (end >= input.length) {
+        _pending = input.substring(index);
+        break;
+      }
+
+      final finalByte = input.codeUnitAt(end);
+      if (finalByte != 0x6d) {
+        output.write(input.substring(index, end + 1));
+        index = end + 1;
+        continue;
+      }
+
+      final parameters = input.substring(index + 2, end).split(';');
+      output
+        ..write('\x1b[')
+        ..writeAll(parameters.map((value) => value == '1' ? '22' : value), ';')
+        ..write('m');
+      index = end + 1;
+    }
+
+    return output.toString();
+  }
+}

--- a/cockpit/lib/app/core/terminal/system_monospace_resolver_io.dart
+++ b/cockpit/lib/app/core/terminal/system_monospace_resolver_io.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+String? resolveSystemMonospaceFamily() => _systemMonospaceFamily;
+
+final String? _systemMonospaceFamily = _resolveSystemMonospaceFamily();
+
+String? _resolveSystemMonospaceFamily() {
+  if (Platform.isMacOS) return 'Menlo';
+  if (Platform.isWindows) return 'Consolas';
+  if (!Platform.isLinux) return null;
+
+  try {
+    final result = Process.runSync('fc-match', const [
+      '--format=%{family[0]}',
+      'monospace',
+    ]);
+    if (result.exitCode != 0) return null;
+
+    final family = (result.stdout as String).trim();
+    return family.isEmpty ? null : family;
+  } on ProcessException {
+    return null;
+  }
+}

--- a/cockpit/lib/app/core/terminal/system_monospace_resolver_stub.dart
+++ b/cockpit/lib/app/core/terminal/system_monospace_resolver_stub.dart
@@ -1,0 +1,1 @@
+String? resolveSystemMonospaceFamily() => null;

--- a/cockpit/lib/app/core/terminal/terminal_controller.dart
+++ b/cockpit/lib/app/core/terminal/terminal_controller.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/terminal/ghostty_sgr_weight_normalizer.dart';
+import 'package:cockpit/app/core/terminal/xterm/xterm.dart' as xterm;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flterm/flterm.dart' as ghost;
+import 'package:libghostty/libghostty.dart' show FormatterFormat;
+
+typedef TerminalResizeCallback = void Function(int columns, int rows);
+
+/// API comum entre o xterm absorvido e o libghostty.
+///
+/// O modelo concreto continua exposto nos adapters para as views específicas;
+/// sessão, task store e CLI usam apenas esta superfície.
+sealed class CockpitTerminalController {
+  TerminalEngine get engine;
+
+  ValueChanged<Uint8List>? onOutput;
+  TerminalResizeCallback? onResize;
+  ValueChanged<String>? onTitleChanged;
+
+  void write(String data);
+  void restore(String data);
+  void paste(String text);
+  List<String> plainLines();
+  void dispose();
+}
+
+final class XtermTerminalController implements CockpitTerminalController {
+  XtermTerminalController({xterm.TerminalInputHandler? inputHandler})
+    : terminal = xterm.Terminal(maxLines: 10000, inputHandler: inputHandler) {
+    terminal.onOutput = (data) => onOutput?.call(utf8.encode(data));
+    terminal.onResize = (columns, rows, _, _) => onResize?.call(columns, rows);
+    terminal.onTitleChange = (title) => onTitleChanged?.call(title);
+  }
+
+  final xterm.Terminal terminal;
+
+  @override
+  TerminalEngine get engine => TerminalEngine.xterm;
+
+  @override
+  ValueChanged<Uint8List>? onOutput;
+
+  @override
+  TerminalResizeCallback? onResize;
+
+  @override
+  ValueChanged<String>? onTitleChanged;
+
+  @override
+  void write(String data) => terminal.write(data);
+
+  @override
+  void restore(String data) => write(data);
+
+  @override
+  void paste(String text) => terminal.paste(text);
+
+  @override
+  List<String> plainLines() {
+    final lines = terminal.buffer.lines;
+    return [for (var i = 0; i < lines.length; i++) lines[i].getText()];
+  }
+
+  @override
+  void dispose() {}
+}
+
+final class GhosttyTerminalController implements CockpitTerminalController {
+  GhosttyTerminalController()
+    : controller = ghost.TerminalController(
+        config: const ghost.TerminalConfig(
+          cols: 80,
+          rows: 25,
+          scrollbackLimit: 10 * 1024 * 1024,
+        ),
+      ) {
+    controller.onOutput = (data) => onOutput?.call(data);
+    controller.onResize = (columns, rows) {
+      final isInitialResize = !_hasInitialResize;
+      _hasInitialResize = true;
+      if (isInitialResize &&
+          SchedulerBinding.instance.schedulerPhase ==
+              SchedulerPhase.persistentCallbacks) {
+        // flterm reports its grid size from performLayout. Restored OSC state
+        // can notify TerminalView, so applying it here would call setState
+        // while the render tree is still being laid out.
+        _deferWritesUntilPostFrame = true;
+      }
+      onResize?.call(columns, rows);
+
+      if (!isInitialResize) return;
+      if (_deferWritesUntilPostFrame) {
+        SchedulerBinding.instance.addPostFrameCallback((_) {
+          _flushPendingWrites();
+        });
+      } else {
+        _flushPendingWrites();
+      }
+    };
+    controller.onTitleChanged = () => onTitleChanged?.call(controller.title);
+  }
+
+  final ghost.TerminalController controller;
+
+  @override
+  TerminalEngine get engine => TerminalEngine.ghostty;
+
+  @override
+  ValueChanged<Uint8List>? onOutput;
+
+  @override
+  TerminalResizeCallback? onResize;
+
+  @override
+  ValueChanged<String>? onTitleChanged;
+
+  final GhosttySgrWeightNormalizer _weightNormalizer =
+      GhosttySgrWeightNormalizer();
+  bool _hasInitialResize = false;
+  bool _deferWritesUntilPostFrame = false;
+  bool _disposed = false;
+  List<String>? _pendingRestore;
+
+  @override
+  void write(String data) {
+    if (_deferWritesUntilPostFrame ||
+        (!_hasInitialResize && _pendingRestore != null)) {
+      (_pendingRestore ??= <String>[]).add(data);
+      return;
+    }
+    _writeNow(data);
+  }
+
+  @override
+  void restore(String data) {
+    if (_hasInitialResize && !_deferWritesUntilPostFrame) {
+      _writeNow(data);
+      return;
+    }
+    (_pendingRestore ??= <String>[]).add(data);
+  }
+
+  void _flushPendingWrites() {
+    if (_disposed) return;
+    _deferWritesUntilPostFrame = false;
+    final pending = _pendingRestore;
+    _pendingRestore = null;
+    if (pending == null) return;
+    for (final data in pending) {
+      _writeNow(data);
+    }
+  }
+
+  void _writeNow(String data) {
+    final normalized = _weightNormalizer.add(data);
+    if (normalized.isEmpty) return;
+    controller.write(Uint8List.fromList(utf8.encode(normalized)));
+  }
+
+  @override
+  void paste(String text) => controller.paste(text);
+
+  @override
+  List<String> plainLines() {
+    final formatter = controller.createFormatter(
+      format: FormatterFormat.plain,
+      unwrap: false,
+      trim: false,
+    );
+    try {
+      return const LineSplitter().convert(formatter.format());
+    } finally {
+      formatter.dispose();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    controller.dispose();
+  }
+}
+
+CockpitTerminalController createTerminalController(
+  TerminalEngine engine, {
+  xterm.TerminalInputHandler? xtermInputHandler,
+}) => switch (engine) {
+  TerminalEngine.ghostty => GhosttyTerminalController(),
+  TerminalEngine.xterm => XtermTerminalController(
+    inputHandler: xtermInputHandler,
+  ),
+};

--- a/cockpit/lib/app/core/terminal/xterm/src/utils/circular_buffer.dart
+++ b/cockpit/lib/app/core/terminal/xterm/src/utils/circular_buffer.dart
@@ -38,6 +38,22 @@ class IndexAwareCircularBuffer<T extends IndexedItem> {
   @pragma('vm:prefer-inline')
   void _adoptChild(int index, T child) {
     final cyclicIndex = _getCyclicIndex(index);
+
+    // Assignments used by Buffer.scrollUp/scrollDown move an item that is
+    // already in this buffer. Swap it with the displaced item so that neither
+    // object is temporarily stored in two slots with only one owner index.
+    if (identical(child._owner, this)) {
+      final oldIndex = child.index;
+      if (oldIndex == index) return;
+
+      final oldCyclicIndex = _getCyclicIndex(oldIndex);
+      final displacedChild = _array[cyclicIndex];
+      _array[cyclicIndex] = child.._move(index);
+      _array[oldCyclicIndex] = displacedChild;
+      displacedChild?._move(oldIndex);
+      return;
+    }
+
     _array[cyclicIndex]?._detach();
     _array[cyclicIndex] = child.._attach(this, index);
   }

--- a/cockpit/lib/app/core/ui/settings_controller.dart
+++ b/cockpit/lib/app/core/ui/settings_controller.dart
@@ -42,6 +42,9 @@ class SettingsController extends ChangeNotifier {
     _apply(_settings.copyWith(terminalFont: font, clearTerminalFont: empty));
   }
 
+  void setTerminalEngine(TerminalEngine engine) =>
+      _apply(_settings.copyWith(terminalEngine: engine));
+
   /// Define (ou limpa, se `null`/vazio) o perfil de terminal padrão do `+`
   /// (plano 50). Limpar = voltar ao fallback de plataforma.
   void setDefaultTerminalProfileId(String? id) {

--- a/cockpit/lib/app/settings/ui/settings_page.dart
+++ b/cockpit/lib/app/settings/ui/settings_page.dart
@@ -190,15 +190,12 @@ class _CategoryNav extends StatelessWidget {
             selected: selected == _Category.appearance,
             onTap: () => onSelect(_Category.appearance),
           ),
-          // Só no Windows: é onde há escolha real de shell (PowerShell/cmd/WSL).
-          // No POSIX o terminal é o login shell do usuário — nada a configurar.
-          if (Platform.isWindows)
-            _NavItem(
-              icon: Icons.terminal_outlined,
-              label: 'Terminal',
-              selected: selected == _Category.terminal,
-              onTap: () => onSelect(_Category.terminal),
-            ),
+          _NavItem(
+            icon: Icons.terminal_outlined,
+            label: 'Terminal',
+            selected: selected == _Category.terminal,
+            onTap: () => onSelect(_Category.terminal),
+          ),
           _NavItem(
             icon: Icons.code,
             label: 'Language',
@@ -650,10 +647,7 @@ class _StorageSectionState extends State<_StorageSection> {
 
 // Aparência
 // ---------------------------------------------------------------------------
-/// **Terminal** (plano 50) — escolhe o shell que o `+` abre por padrão.
-///
-/// Só existe no Windows (a aba é ocultada fora dele): no POSIX o terminal é o
-/// login shell do usuário e não há escolha a fazer.
+/// **Terminal** — escolhe o motor VT e, no Windows, o shell padrão.
 ///
 /// O padrão é gravado **por id** (`defaultTerminalProfileId`), nunca o objeto:
 /// os perfis são re-descobertos a cada boot. Sem escolha (ou com um id que
@@ -689,17 +683,28 @@ class _TerminalPanel extends StatelessWidget {
                 child: _Card(
                   children: [
                     _Row(
-                      title: 'Shell',
+                      title: 'Engine',
                       description:
-                          'Which shell new terminal tabs open. The arrow next '
-                          'to + still opens any other one, just for that tab.',
-                      trailing: _TerminalProfileDropdown(
-                        profiles: profiles,
-                        value: effective,
-                        onChanged: (p) =>
-                            controller.setDefaultTerminalProfileId(p.id),
+                          'Used by new terminal tabs and task output buffers. '
+                          'Open tabs keep their current engine.',
+                      trailing: _TerminalEngineDropdown(
+                        value: controller.settings.terminalEngine,
+                        onChanged: controller.setTerminalEngine,
                       ),
                     ),
+                    if (Platform.isWindows)
+                      _Row(
+                        title: 'Shell',
+                        description:
+                            'Which shell new terminal tabs open. The arrow next '
+                            'to + still opens any other one, just for that tab.',
+                        trailing: _TerminalProfileDropdown(
+                          profiles: profiles,
+                          value: effective,
+                          onChanged: (p) =>
+                              controller.setDefaultTerminalProfileId(p.id),
+                        ),
+                      ),
                   ],
                 ),
               ),
@@ -722,6 +727,37 @@ class _TerminalPanel extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _TerminalEngineDropdown extends StatelessWidget {
+  const _TerminalEngineDropdown({required this.value, required this.onChanged});
+
+  final TerminalEngine value;
+  final ValueChanged<TerminalEngine> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    String label(TerminalEngine engine) => switch (engine) {
+      TerminalEngine.ghostty => 'Ghostty',
+      TerminalEngine.xterm => 'xterm',
+    };
+
+    return _DropdownChip(
+      icon: Icons.terminal,
+      label: label(value),
+      onTap: () async {
+        final picked = await showAppMenu<TerminalEngine>(
+          context,
+          minWidth: 180,
+          items: [
+            for (final engine in TerminalEngine.values)
+              AppMenuItem(value: engine, label: label(engine)),
+          ],
+        );
+        if (picked != null) onChanged(picked);
+      },
     );
   }
 }

--- a/cockpit/pubspec.lock
+++ b/cockpit/pubspec.lock
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   code_builder:
     dependency: transitive
     description:
@@ -352,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  flterm:
+    dependency: "direct main"
+    description:
+      name: flterm
+      sha256: d903c7c768f067bcd4e1f00494366522f177ae367fa79b6e9665787ae1463939
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -552,10 +560,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.2"
   http:
     dependency: transitive
     description:
@@ -660,6 +668,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  libghostty:
+    dependency: "direct main"
+    description:
+      name: libghostty
+      sha256: f6ab633e97d201bdaf48ad830eb0c61fd0361b79e1be2e1d00027ca1bb08fa30
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.11"
   lints:
     dependency: transitive
     description:
@@ -772,14 +788,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.7.0"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.6"
   nested:
     dependency: transitive
     description:
@@ -792,10 +800,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
+      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
       url: "https://pub.dev"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.1"
   package_config:
     dependency: transitive
     description:

--- a/cockpit/pubspec.yaml
+++ b/cockpit/pubspec.yaml
@@ -19,7 +19,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.14.7+36
 
 environment:
-  sdk: ^3.11.5
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -85,6 +86,12 @@ dependencies:
   # jacobaraujo7/kyroon_pty v1.0.6 (ver plugins/cockpit_pty/pubspec.yaml).
   cockpit_pty:
     path: plugins/cockpit_pty
+
+  # Motor VT alternativo baseado no Ghostty. `libghostty` fornece os bindings
+  # nativos e `flterm` a view Flutter oficial do mesmo repositório. Pins exatos:
+  # ambos são pré-1.0 e mudam API em releases menores.
+  libghostty: 0.0.11
+  flterm: 0.0.4
 
   # Wave 2 — viewer de arquivo: renderiza SVG no pane (PNG/JPEG via Image.file).
   flutter_svg: ^2.0.10

--- a/cockpit/test/core/terminal/ghostty_font_family_test.dart
+++ b/cockpit/test/core/terminal/ghostty_font_family_test.dart
@@ -1,0 +1,36 @@
+import 'package:cockpit/app/core/terminal/ghostty_font_family.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveGhosttyFontFamily', () {
+    test('resolves the generic monospace alias through the platform', () {
+      expect(
+        resolveGhosttyFontFamily(
+          'monospace',
+          systemMonospaceResolver: () => 'Noto Sans Mono',
+        ),
+        'Noto Sans Mono',
+      );
+    });
+
+    test('keeps an explicitly selected family unchanged', () {
+      expect(
+        resolveGhosttyFontFamily(
+          'MesloLGS Nerd Font Mono',
+          systemMonospaceResolver: () => 'Noto Sans Mono',
+        ),
+        'MesloLGS Nerd Font Mono',
+      );
+    });
+
+    test('falls back to the generic alias when resolution is unavailable', () {
+      expect(
+        resolveGhosttyFontFamily(
+          ' monospace ',
+          systemMonospaceResolver: () => null,
+        ),
+        'monospace',
+      );
+    });
+  });
+}

--- a/cockpit/test/core/terminal/ghostty_sgr_weight_normalizer_test.dart
+++ b/cockpit/test/core/terminal/ghostty_sgr_weight_normalizer_test.dart
@@ -1,0 +1,24 @@
+import 'package:cockpit/app/core/terminal/ghostty_sgr_weight_normalizer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late GhosttySgrWeightNormalizer normalizer;
+
+  setUp(() => normalizer = GhosttySgrWeightNormalizer());
+
+  test('demotes SGR bold while preserving other attributes', () {
+    expect(
+      normalizer.add('\x1b[1;31mBold red\x1b[0m'),
+      '\x1b[22;31mBold red\x1b[0m',
+    );
+  });
+
+  test('handles an SGR sequence split across PTY chunks', () {
+    expect(normalizer.add('before\x1b[1;'), 'before');
+    expect(normalizer.add('36mafter'), '\x1b[22;36mafter');
+  });
+
+  test('does not change non-SGR control sequences', () {
+    expect(normalizer.add('\x1b[2K\x1b[4H'), '\x1b[2K\x1b[4H');
+  });
+}

--- a/cockpit/test/core/terminal/terminal_controller_test.dart
+++ b/cockpit/test/core/terminal/terminal_controller_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/terminal/terminal_controller.dart';
+import 'package:flterm/flterm.dart' as ghost;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  for (final engine in TerminalEngine.values) {
+    group('${engine.name} terminal controller', () {
+      late CockpitTerminalController terminal;
+
+      setUp(() => terminal = createTerminalController(engine));
+      tearDown(() => terminal.dispose());
+
+      test('renders VT output as plain text', () {
+        terminal.write('\x1b[31mhello\x1b[0m');
+
+        expect(terminal.plainLines().join('\n'), contains('hello'));
+      });
+
+      test('paste emits bytes for the PTY', () {
+        final output = <int>[];
+        terminal.onOutput = output.addAll;
+
+        terminal.paste('olá');
+
+        expect(utf8.decode(output), 'olá');
+      });
+
+      test('reports OSC title changes', () {
+        String? title;
+        terminal.onTitleChanged = (value) => title = value;
+
+        terminal.write('\x1b]0;workspace\x07');
+
+        expect(title, 'workspace');
+      });
+
+      test('restores persisted output', () {
+        terminal.restore('restored');
+
+        if (terminal case final GhosttyTerminalController ghostty) {
+          expect(terminal.plainLines().join('\n'), isNot(contains('restored')));
+          ghostty.controller.onResize?.call(120, 40);
+        }
+
+        expect(terminal.plainLines().join('\n'), contains('restored'));
+      });
+    });
+  }
+
+  testWidgets('Ghostty restores OSC state after the initial layout', (
+    tester,
+  ) async {
+    final terminal = GhosttyTerminalController();
+    addTearDown(terminal.dispose);
+    terminal.restore('\x1b]7;file:///tmp\x07restored');
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 800,
+          height: 600,
+          child: ghost.TerminalView(controller: terminal.controller),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(terminal.controller.pwd, 'file:///tmp');
+    expect(terminal.plainLines().join('\n'), contains('restored'));
+  });
+}

--- a/cockpit/test/core/terminal/xterm/src/core/buffer/buffer_test.dart
+++ b/cockpit/test/core/terminal/xterm/src/core/buffer/buffer_test.dart
@@ -117,6 +117,18 @@ void main() {
     });
   });
 
+  test('can insert after scrolling a partial margin', () {
+    final terminal = Terminal()..resize(10, 5);
+
+    terminal.buffer.setVerticalMargins(1, 3);
+    terminal.buffer.scrollUp(1);
+
+    terminal.buffer.setVerticalMargins(0, 1);
+    terminal.buffer.setCursor(0, 1);
+
+    expect(terminal.buffer.index, returnsNormally);
+  });
+
   group('Buffer.deleteLines()', () {
     test('works', () {
       final terminal = Terminal();

--- a/cockpit/test/core/terminal/xterm/src/utils/circular_buffer_test.dart
+++ b/cockpit/test/core/terminal/xterm/src/utils/circular_buffer_test.dart
@@ -135,6 +135,53 @@ void main() {
       expect(cl[5], 50.indexed);
     });
 
+    test("setting an attached item preserves ownership during a shift", () {
+      final cl = IndexAwareCircularBuffer<IndexedValue<int>>(5);
+      final items = List.generate(7, IndexedValue.new);
+      cl.pushAll(items.take(5));
+
+      // Buffer.scrollUp performs this kind of in-place shift.
+      for (var i = 0; i < 4; i++) {
+        cl[i] = cl[i + 1];
+      }
+      cl[4] = items[5];
+
+      for (var i = 0; i < cl.length; i++) {
+        expect(cl[i].attached, isTrue);
+        expect(cl[i].index, i);
+      }
+
+      // Moving the shifted entries used to call _move on a detached item.
+      cl.insert(1, items[6]);
+
+      expect(cl.toList().map((item) => item.value), [6, 2, 3, 4, 5]);
+      for (var i = 0; i < cl.length; i++) {
+        expect(cl[i].attached, isTrue);
+        expect(cl[i].index, i);
+      }
+    });
+
+    test(
+      "setting attached items preserves ownership during a reverse shift",
+      () {
+        final cl = IndexAwareCircularBuffer<IndexedValue<int>>(5);
+        final items = List.generate(6, IndexedValue.new);
+        cl.pushAll(items.take(5));
+
+        // Buffer.scrollDown performs this kind of in-place reverse shift.
+        for (var i = 4; i > 0; i--) {
+          cl[i] = cl[i - 1];
+        }
+        cl[0] = items[5];
+
+        expect(cl.toList().map((item) => item.value), [5, 0, 1, 2, 3]);
+        for (var i = 0; i < cl.length; i++) {
+          expect(cl[i].attached, isTrue);
+          expect(cl[i].index, i);
+        }
+      },
+    );
+
     test("clear works", () {
       final cl = IndexAwareCircularBuffer<IndexedValue<int>>(10);
       cl.pushAll(

--- a/cockpit/test/domain/app_settings_terminal_engine_test.dart
+++ b/cockpit/test/domain/app_settings_terminal_engine_test.dart
@@ -1,0 +1,29 @@
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppSettings · terminal.engine', () {
+    test('Ghostty is the default for new terminals', () {
+      expect(const AppSettings().terminalEngine, TerminalEngine.ghostty);
+      expect(
+        AppSettings.fromJson(const <String, dynamic>{}).terminalEngine,
+        TerminalEngine.ghostty,
+      );
+    });
+
+    test('round-trips both engines', () {
+      for (final engine in TerminalEngine.values) {
+        final settings = AppSettings(terminalEngine: engine);
+        expect(AppSettings.fromJson(settings.toJson()).terminalEngine, engine);
+      }
+    });
+
+    test('copyWith changes only the default engine', () {
+      const settings = AppSettings(terminalFont: 'Menlo');
+      final changed = settings.copyWith(terminalEngine: TerminalEngine.xterm);
+
+      expect(changed.terminalEngine, TerminalEngine.xterm);
+      expect(changed.terminalFont, 'Menlo');
+    });
+  });
+}

--- a/cockpit/test/widget_test.dart
+++ b/cockpit/test/widget_test.dart
@@ -8,9 +8,12 @@ import 'package:cockpit/app/core/domain/entities/setup_check.dart';
 import 'package:cockpit/app/cockpit/ui/viewmodels/setup_viewmodel.dart';
 import 'package:cockpit/app/core/ui/file_icons/file_icon.dart';
 import 'package:cockpit/app/core/ui/file_icons/file_icon_map.g.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('split tree', () {
     test('leaves enumera todas as folhas', () {
       final tree = SplitPane(
@@ -224,6 +227,18 @@ void main() {
       expect(open, isNot(closed));
       expect(folderIconName('xyz-unknown'), kDefaultFolderIcon);
       expect(folderIconName('xyz-unknown', open: true), kDefaultFolderOpenIcon);
+    });
+
+    test('assets usados pela árvore de arquivos estão no bundle', () async {
+      for (final asset in [
+        'folder-robot.svg',
+        'folder-src.svg',
+        'folder-packages.svg',
+        'zip.svg',
+      ]) {
+        final data = await rootBundle.load('assets/file_icons/$asset');
+        expect(data.lengthInBytes, greaterThan(0), reason: asset);
+      }
     });
   });
 


### PR DESCRIPTION
## Resumo

Esta PR adiciona o Ghostty como motor VT padrão dos novos terminais e buffers de saída de tasks do Cockpit. O xterm interno continua disponível como alternativa e como caminho de compatibilidade para layouts antigos.

A integração usa `libghostty` para o estado/emulação VT e `flterm` para a view Flutter. Ela não abre o aplicativo Ghostty externo: o terminal continua embutido na própria interface do Cockpit.

## Motivação

O Cockpit dependia diretamente do fork interno do xterm para emulação, renderização e leitura do buffer. Isso tornava sessões, tasks, persistência e UI acopladas a uma implementação específica.

O Ghostty oferece um core moderno e embutível, com foco em compatibilidade VT, Unicode e desempenho. Sua arquitetura separa o core (`libghostty`) da camada de interface, o que combina bem com o Cockpit: podemos aproveitar a emulação do Ghostty sem abandonar a UI, os temas, os atalhos e os fluxos próprios do projeto.

## O que foi alterado

### Abstração dos motores

- cria `CockpitTerminalController`, uma interface comum para escrita, restauração, paste, resize, título OSC, leitura de linhas e descarte;
- implementa adapters para Ghostty e xterm;
- mantém o xterm absorvido no repositório, permitindo fallback e comparação durante a adoção;
- adapta sessões de terminal, buffers de tasks e comandos `read-pane`/`read-task` para consumirem a interface comum;
- garante o `dispose` dos controllers nativos quando sessões e stores são encerrados.

### Renderização e interação

- adiciona `AdaptiveTerminalPane`, que escolhe a view correta conforme o controller da sessão;
- converte o tema existente do Cockpit para a paleta, cursor e seleção do `flterm`;
- preserva paste de texto/imagem, foco, modo read-only e abertura de URLs/arquivos;
- mantém o renderer próprio atual para sessões xterm.

### Preferência e compatibilidade

- adiciona `TerminalEngine { ghostty, xterm }` às configurações persistidas;
- torna Ghostty o padrão para novos terminais e novos buffers de tasks;
- disponibiliza a escolha do motor em **Settings > Terminal** em todas as plataformas;
- aplica a troca somente a buffers criados depois da alteração; abas abertas não são recriadas;
- persiste o motor em cada descritor de terminal/task no layout;
- restaura layouts antigos sem a chave `engine` como xterm, preservando o comportamento anterior de quem já usa o app.

### Ajustes específicos da integração

- posterga o replay do scrollback do Ghostty até o primeiro resize real da view, evitando interpretar estado OSC numa grade provisória e evitando atualização durante o layout do Flutter;
- resolve o alias genérico `monospace` pela fonte do sistema (`fc-match` no Linux, com fallbacks por plataforma), mantendo métricas e desenho dos glifos alinhados;
- normaliza SGR bold antes do `flterm` 0.0.4 para evitar peso visual excessivo sem perder cor ou outros atributos;
- fixa `libghostty` em `0.0.11` e `flterm` em `0.0.4`, pois ambos ainda têm API pré-1.0;
- atualiza os requisitos para Dart `^3.12.0` e Flutter `>=3.44.0`.

## Benefícios para o projeto

- **Core VT moderno e reutilizável:** o Cockpit passa a consumir uma biblioteca projetada para embedding, em vez de depender de uma única implementação Dart em todas as camadas.
- **Evolução gradual:** a abstração permite manter Ghostty e xterm lado a lado, reduzindo o risco de migração e facilitando diagnósticos e rollback por usuário.
- **Melhor isolamento arquitetural:** sessões, tasks, persistência e CLI deixam de conhecer detalhes do buffer do xterm.
- **Consistência entre terminal interativo e tasks:** ambos usam a mesma escolha de motor e o mesmo contrato de leitura/restauração.
- **Base para compatibilidade terminal mais ampla:** o core do Ghostty traz uma implementação VT exercitada pelo emulador principal, incluindo sequências modernas e tratamento de Unicode.

## Por que isso é especialmente útil no Linux/Wayland

Em Wayland não existe o modelo de reparenting de janelas do X11. Integrar um emulador externo dentro do Cockpit exigiria contornos frágeis ou uma janela separada. Esta implementação usa o `libghostty` como biblioteca e renderiza o terminal dentro da mesma árvore Flutter do aplicativo, portanto:

- não depende de embutir uma janela X11 nem força um caminho via XWayland;
- mantém foco, teclado, clipboard, links, temas e layout sob o controle da mesma aplicação;
- funciona naturalmente com tiling compositors, escalas fracionárias e o ciclo de vida da janela já usado pelo Cockpit;
- permite aproveitar o core do Ghostty sem exigir que o usuário instale ou abra um segundo emulador.

O build Linux de debug foi gerado com sucesso nesta branch, validando a resolução das dependências nativas e o empacotamento da aplicação.

> Nota: esta PR integra o core do Ghostty e a view Flutter. Ela não incorpora automaticamente todos os recursos da aplicação standalone do Ghostty nem deve ser interpretada como adoção do renderer GTK/OpenGL completo do aplicativo externo.

## Atualização — correção do buffer xterm

Ao restaurar ou alimentar sessões xterm, operações de scroll podiam atribuir a mesma `BufferLine` a dois slots do buffer circular. A atribuição seguinte destacava o item compartilhado, mas mantinha uma referência stale no array; uma inserção posterior então chamava `_move()` sobre um item sem owner, causando `Null check operator used on a null value` ou `assert(attached)`.

A correção faz atribuições de itens já pertencentes ao mesmo buffer trocarem os slots de forma atômica, preservando owner e índice de ambos. Foram adicionadas regressões para scroll em ambas as direções e para inserção após scroll de margem parcial, que reproduz o caminho de `Buffer.index()` observado no crash.

Também foi adicionada uma verificação dos SVGs usados pela árvore de arquivos no bundle Flutter. Os assets reportados existem e são carregáveis; as mensagens de asset ausente observadas durante o diagnóstico vinham de uma instância/bundle antigo.

Validação adicional:

- 60 testes focados aprovados e 2 skips preexistentes;
- replay das cinco sessões reais persistidas da worktree concluído sem exception;
- `git diff --check` aprovado.

## Testes e validação

- `dart format` nos 20 arquivos Dart alterados/adicionados: sem mudanças pendentes;
- `flutter analyze --no-fatal-infos`: sem erros ou warnings (permanecem 35 sugestões `info` já existentes no projeto);
- 27 testes focados em Ghostty, xterm, persistência da preferência e leitura do terminal: todos aprovados;
- `flutter build linux --debug`: concluído com sucesso;
- `git diff --check`: aprovado.

A suíte completa também foi exercitada. Ela expôs três testes fora do código alterado:

- dois goldens do `TerminalView.textScaler` do xterm apresentaram diferenças de 0,06% e 0,13% com o Flutter 3.44;
- o teste `no macOS não desenha nada` de `window_menu_bar_test.dart` espera comportamento de macOS, mas falha quando executado isoladamente no host Linux.

Os testes novos e os fluxos diretamente afetados por esta PR estão verdes.

## Roteiro sugerido para revisão

1. revisar o contrato e os adapters em `terminal_controller.dart`;
2. revisar `AdaptiveTerminalPane` e o mapeamento de tema/interações;
3. revisar a propagação do motor em sessões, task store e persistência do layout;
4. revisar a configuração/migração e os testes adicionados;
5. validar manualmente uma sessão Ghostty e uma sessão xterm em Linux/Wayland.

## Referências

- [Arquitetura e objetivos do Ghostty](https://ghostty.org/docs/about)
- [Suporte oficial do Ghostty a Linux, Wayland e X11](https://ghostty.org/docs/linux)
- [libghostty como biblioteca embutível](https://github.com/ghostty-org/ghostty)

