### PR TITLE
fix(cockpit): stabilize Linux task launch and hot restart

### DIFF
--- a/.cockpit/tasks.json
+++ b/.cockpit/tasks.json
@@ -37,7 +37,8 @@
       // dart-define just become args here — no stack-specific keys).
       "profiles": [
         { "name": "macos", "args": ["-d", "macos"] },
-        { "name": "windows", "args": ["-d", "windows"] }
+        { "name": "windows", "args": ["-d", "windows"] },
+        { "name": "linux", "args": ["-d", "linux"] }
       ]
     },
     {

--- a/cockpit/lib/app/bootstrapper.dart
+++ b/cockpit/lib/app/bootstrapper.dart
@@ -5,6 +5,7 @@ import 'package:cockpit/app/app_module.dart';
 import 'package:cockpit/app/app_widget.dart';
 import 'package:cockpit/app/cockpit/data/hooks/claude_hook_installer_impl.dart';
 import 'package:cockpit/app/cockpit/data/rpc/pi_process_registry.dart';
+import 'package:cockpit/app/cockpit/data/tasks/task_process_registry.dart';
 import 'package:cockpit/app/core/data/lsp/lsp_process_registry.dart';
 import 'package:cockpit/app/core/data/repositories/hive_settings_store.dart';
 import 'package:cockpit/app/core/data/setup/storage_location.dart';
@@ -96,10 +97,13 @@ class _CockpitBootstrapperState extends State<CockpitBootstrapper> {
         // lê do cache. Ver login_shell.dart / issue #42.
         await resolveLoginShell();
 
-        // Mata `pi --mode rpc` e language servers órfãos do ciclo anterior
-        // antes de qualquer novo spawn (hot restart e crash cobertos).
-        await PiProcessRegistry.cleanOrphans();
-        await LspProcessRegistry.cleanOrphans();
+        // Mata filhos órfãos desta instância ou de instâncias já encerradas,
+        // preservando agents/LSP/tasks de outros Cockpits ainda vivos.
+        await Future.wait([
+          PiProcessRegistry.cleanOrphans(),
+          LspProcessRegistry.cleanOrphans(),
+          TaskProcessRegistry.cleanOrphans(),
+        ]);
 
         // Hooks do Cockpit no ~/.claude/settings.json (idempotente) pra
         // sessões `claude` nas abas reportarem status de turno. Não-fatal.

--- a/cockpit/lib/app/cockpit/data/rpc/pi_process_registry.dart
+++ b/cockpit/lib/app/cockpit/data/rpc/pi_process_registry.dart
@@ -1,5 +1,8 @@
 import 'dart:io';
 
+import 'package:cockpit/app/core/data/process/owned_process_registry.dart';
+import 'package:cockpit/app/core/utils/user_home.dart';
+
 /// Registro persistente de PIDs de processos `pi --mode rpc` ativos.
 ///
 /// Problema: hot restart do `flutter run` reinicia a isolate Dart mas NÃO mata
@@ -23,10 +26,15 @@ import 'dart:io';
 class PiProcessRegistry {
   PiProcessRegistry._();
 
-  static String get _path {
-    final home = Platform.environment['HOME'] ?? '';
+  static String get _legacyPath {
+    final home = userHome() ?? '';
     return '$home/.pi/cockpit/agent-pids';
   }
+
+  static final OwnedProcessRegistry _registry = OwnedProcessRegistry(
+    category: 'agents',
+    legacyFiles: [_legacyPath],
+  );
 
   /// Mata todos os pi órfãos do ciclo anterior e limpa o registro.
   /// Deve ser chamado UMA VEZ por boot (em [setupDependencies]), antes de
@@ -34,31 +42,14 @@ class PiProcessRegistry {
   static Future<void> cleanOrphans() async {
     // Roda as duas buscas em paralelo para minimizar latência no boot.
     final results = await Future.wait([
-      _pidsFromRegistry(),
+      _registry.cleanOrphans().then((_) => const <int>[]),
       _orphanedPiChildren(),
     ]);
-    final toKill = <int>{...results[0], ...results[1]};
+    final toKill = <int>{...results[1]};
     for (final p in toKill) {
       try {
         Process.killPid(p, ProcessSignal.sigkill); // imediato, sem corrida
       } catch (_) {}
-    }
-  }
-
-  /// Lê os PIDs registrados no arquivo e apaga o arquivo. Cobre restarts
-  /// frios (cold) e crashes onde o processo pai morreu.
-  static Future<List<int>> _pidsFromRegistry() async {
-    try {
-      final file = File(_path);
-      if (!await file.exists()) return const <int>[];
-      final pids = (await file.readAsLines())
-          .map((l) => int.tryParse(l.trim()))
-          .whereType<int>()
-          .toList();
-      await file.delete();
-      return pids;
-    } catch (_) {
-      return const <int>[];
     }
   }
 
@@ -101,25 +92,11 @@ class PiProcessRegistry {
 
   /// Registra [pid] no arquivo. Chamado logo após o spawn bem-sucedido.
   static Future<void> register(int pid) async {
-    try {
-      final file = File(_path);
-      await file.parent.create(recursive: true);
-      await file.writeAsString('$pid\n', mode: FileMode.append);
-    } catch (_) {}
+    await _registry.register(pid);
   }
 
   /// Remove [pid] do arquivo. Chamado na saída limpa do processo.
   static Future<void> unregister(int pid) async {
-    try {
-      final file = File(_path);
-      if (!await file.exists()) return;
-      final lines = await file.readAsLines();
-      final kept = lines.where((l) => l.trim() != '$pid').toList();
-      if (kept.isEmpty) {
-        await file.delete();
-      } else {
-        await file.writeAsString('${kept.join('\n')}\n');
-      }
-    } catch (_) {}
+    await _registry.unregister(pid);
   }
 }

--- a/cockpit/lib/app/cockpit/data/tasks/pty_task_runner.dart
+++ b/cockpit/lib/app/cockpit/data/tasks/pty_task_runner.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:cockpit/app/cockpit/data/rpc/pi_process_registry.dart';
+import 'package:cockpit/app/cockpit/data/tasks/task_process_registry.dart';
 import 'package:cockpit/app/core/data/setup/remote_pi_resolver.dart';
 import 'package:cockpit/app/core/utils/login_shell.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/task_runner_gateway.dart';
@@ -92,7 +92,7 @@ class PtyTaskRunner implements TaskRunnerGateway {
       rethrow;
     }
     _starting.remove(def.id);
-    unawaited(PiProcessRegistry.register(pty.pid));
+    unawaited(TaskProcessRegistry.register(pty.pid));
 
     final initial = TaskRun(
       taskId: def.id,
@@ -234,6 +234,7 @@ class PtyTaskRunner implements TaskRunnerGateway {
       try {
         task.pty.kill(ProcessSignal.sigkill);
       } catch (_) {}
+      await TaskProcessRegistry.unregister(task.pty.pid);
       await task.outSub?.cancel();
       await task.out.close();
     }
@@ -247,7 +248,7 @@ class PtyTaskRunner implements TaskRunnerGateway {
     final task = _running.remove(taskId);
     if (task == null) return;
     stopWatch(taskId); // o processo morreu → nada pra recarregar
-    unawaited(PiProcessRegistry.unregister(task.pty.pid));
+    unawaited(TaskProcessRegistry.unregister(task.pty.pid));
     final TaskRunStatus status;
     if (task.stopping) {
       status = TaskRunStatus.stopped;

--- a/cockpit/lib/app/cockpit/data/tasks/task_process_registry.dart
+++ b/cockpit/lib/app/cockpit/data/tasks/task_process_registry.dart
@@ -1,0 +1,19 @@
+import 'package:cockpit/app/core/data/process/owned_process_registry.dart';
+
+/// Registro isolado dos processos raiz das tasks executadas em PTY.
+///
+/// Não usa o registry de agentes: um Cockpit iniciado por `flutter run` é filho
+/// da task do Cockpit pai e não pode interpretar esse PID como agente órfão.
+class TaskProcessRegistry {
+  TaskProcessRegistry._();
+
+  static final OwnedProcessRegistry _registry = OwnedProcessRegistry(
+    category: 'tasks',
+  );
+
+  static Future<void> cleanOrphans() => _registry.cleanOrphans();
+
+  static Future<void> register(int pid) => _registry.register(pid);
+
+  static Future<void> unregister(int pid) => _registry.unregister(pid);
+}

--- a/cockpit/lib/app/core/data/lsp/lsp_process_registry.dart
+++ b/cockpit/lib/app/core/data/lsp/lsp_process_registry.dart
@@ -1,4 +1,5 @@
-import 'dart:io';
+import 'package:cockpit/app/core/data/process/owned_process_registry.dart';
+import 'package:cockpit/app/core/utils/user_home.dart';
 
 /// Registro persistente de PIDs dos language servers (LSP) ativos.
 ///
@@ -11,51 +12,29 @@ import 'dart:io';
 class LspProcessRegistry {
   LspProcessRegistry._();
 
-  static String get _path {
-    final home = Platform.environment['HOME'] ?? '';
+  static String get _legacyPath {
+    final home = userHome() ?? '';
     return '$home/.pi/cockpit/lsp-pids';
   }
+
+  static final OwnedProcessRegistry _registry = OwnedProcessRegistry(
+    category: 'lsp',
+    legacyFiles: [_legacyPath],
+  );
 
   /// Mata os PIDs remanescentes do ciclo anterior e limpa o registro. Deve ser
   /// chamado UMA VEZ por boot, antes de qualquer spawn.
   static Future<void> cleanOrphans() async {
-    try {
-      final file = File(_path);
-      if (!await file.exists()) return;
-      final pids = (await file.readAsLines())
-          .map((l) => int.tryParse(l.trim()))
-          .whereType<int>();
-      await file.delete();
-      for (final p in pids) {
-        try {
-          Process.killPid(p, ProcessSignal.sigkill);
-        } catch (_) {}
-      }
-    } catch (_) {}
+    await _registry.cleanOrphans();
   }
 
   /// Registra [pid] no arquivo. Chamado logo após o spawn bem-sucedido.
   static Future<void> register(int pid) async {
-    try {
-      final file = File(_path);
-      await file.parent.create(recursive: true);
-      await file.writeAsString('$pid\n', mode: FileMode.append);
-    } catch (_) {}
+    await _registry.register(pid);
   }
 
   /// Remove [pid] do arquivo. Chamado na saída limpa do servidor.
   static Future<void> unregister(int pid) async {
-    try {
-      final file = File(_path);
-      if (!await file.exists()) return;
-      final kept = (await file.readAsLines())
-          .where((l) => l.trim() != '$pid')
-          .toList();
-      if (kept.isEmpty) {
-        await file.delete();
-      } else {
-        await file.writeAsString('${kept.join('\n')}\n');
-      }
-    } catch (_) {}
+    await _registry.unregister(pid);
   }
 }

--- a/cockpit/lib/app/core/data/process/owned_process_registry.dart
+++ b/cockpit/lib/app/core/data/process/owned_process_registry.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:cockpit/app/core/utils/user_home.dart';
+
+/// Persiste PIDs de processos filhos sem misturar instâncias do Cockpit.
+///
+/// Cada categoria grava um arquivo por PID proprietário:
+///
+/// ```text
+/// ~/.pi/cockpit/process-pids/<category>/<ownerPid>.pids
+/// ```
+///
+/// No boot, a instância limpa o próprio arquivo (hot restart) e arquivos de
+/// proprietários que já morreram (crash/cold restart). Arquivos pertencentes a
+/// outros Cockpits ainda vivos são preservados.
+class OwnedProcessRegistry {
+  OwnedProcessRegistry({
+    required this.category,
+    String? rootPath,
+    int? ownerPid,
+    Future<bool> Function(int pid)? isProcessAlive,
+    FutureOr<void> Function(int pid)? killProcess,
+    List<String> legacyFiles = const [],
+  }) : assert(RegExp(r'^[a-z0-9_-]+$').hasMatch(category)),
+       rootPath = rootPath ?? _defaultRootPath(),
+       ownerPid = ownerPid ?? pid,
+       _isProcessAlive = isProcessAlive ?? _defaultIsProcessAlive,
+       _killProcess = killProcess ?? _defaultKillProcess {
+    _legacyFiles.addAll(legacyFiles);
+  }
+
+  final String category;
+  final String rootPath;
+  final int ownerPid;
+  final Future<bool> Function(int pid) _isProcessAlive;
+  final FutureOr<void> Function(int pid) _killProcess;
+  final List<String> _legacyFiles = [];
+
+  Future<void> _ioChain = Future<void>.value();
+
+  String get _categoryPath => '$rootPath${Platform.pathSeparator}$category';
+
+  String _pathFor(int owner) =>
+      '$_categoryPath${Platform.pathSeparator}$owner.pids';
+
+  /// Registra um processo filho desta instância.
+  Future<void> register(int childPid) => _serialize(() async {
+    try {
+      final file = File(_pathFor(ownerPid));
+      await file.parent.create(recursive: true);
+      await file.writeAsString('$childPid\n', mode: FileMode.append);
+    } catch (_) {
+      // Registry é uma proteção best-effort; falha de IO não impede o spawn.
+    }
+  });
+
+  /// Remove um processo que já encerrou normalmente.
+  Future<void> unregister(int childPid) => _serialize(() async {
+    await _removePid(File(_pathFor(ownerPid)), childPid);
+  });
+
+  /// Limpa filhos do ciclo anterior sem tocar em outras instâncias vivas.
+  Future<void> cleanOrphans() => _serialize(() async {
+    await _cleanLegacyFiles();
+
+    final dir = Directory(_categoryPath);
+    if (!await dir.exists()) return;
+
+    try {
+      await for (final entity in dir.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final owner = _ownerFromPath(entity.path);
+        if (owner == null) continue;
+
+        final shouldClean =
+            owner == ownerPid || !await _safeIsProcessAlive(owner);
+        if (!shouldClean) continue;
+
+        await _reapFile(entity);
+      }
+    } catch (_) {
+      // Diretório removido/indisponível durante a varredura: best-effort.
+    }
+  });
+
+  Future<void> _cleanLegacyFiles() async {
+    for (final path in _legacyFiles) {
+      await _reapFile(File(path));
+    }
+  }
+
+  Future<void> _reapFile(File file) async {
+    try {
+      if (!await file.exists()) return;
+      final children = await _readPids(file);
+      // Remove antes do kill para nunca atingir um PID reutilizado num boot
+      // futuro caso o processo já tenha encerrado entre a leitura e o sinal.
+      await file.delete();
+      for (final child in children) {
+        try {
+          await _killProcess(child);
+        } catch (_) {}
+      }
+    } catch (_) {
+      // Arquivo concorrente/corrompido não pode derrubar o bootstrap.
+    }
+  }
+
+  Future<void> _removePid(File file, int childPid) async {
+    try {
+      if (!await file.exists()) return;
+      final kept = (await _readPids(file)).where((p) => p != childPid).toList();
+      if (kept.isEmpty) {
+        await file.delete();
+      } else {
+        await file.writeAsString('${kept.join('\n')}\n');
+      }
+    } catch (_) {}
+  }
+
+  Future<List<int>> _readPids(File file) async => (await file.readAsLines())
+      .map((line) => int.tryParse(line.trim()))
+      .whereType<int>()
+      .toSet()
+      .toList();
+
+  int? _ownerFromPath(String path) {
+    final name = path.split(Platform.pathSeparator).last;
+    final match = RegExp(r'^(\d+)\.pids$').firstMatch(name);
+    return match == null ? null : int.tryParse(match.group(1)!);
+  }
+
+  Future<bool> _safeIsProcessAlive(int processPid) async {
+    try {
+      return await _isProcessAlive(processPid);
+    } catch (_) {
+      // Em dúvida, preserva: matar processo de outra instância é pior que
+      // deixar um órfão para uma limpeza posterior.
+      return true;
+    }
+  }
+
+  Future<void> _serialize(Future<void> Function() operation) {
+    final result = _ioChain.then((_) => operation());
+    _ioChain = result.catchError((_) {});
+    return result;
+  }
+
+  static String _defaultRootPath() {
+    final home = userHome() ?? '';
+    return '$home${Platform.pathSeparator}.pi${Platform.pathSeparator}'
+        'cockpit${Platform.pathSeparator}process-pids';
+  }
+
+  static Future<bool> _defaultIsProcessAlive(int processPid) async {
+    if (processPid == pid) return true;
+    if (Platform.isWindows) {
+      final result = await Process.run('tasklist', [
+        '/FI',
+        'PID eq $processPid',
+        '/FO',
+        'CSV',
+        '/NH',
+      ]);
+      if (result.exitCode != 0) return true;
+      final output = (result.stdout as String).trim();
+      return RegExp('"$processPid"(?:,|\\s)').hasMatch(output);
+    }
+
+    final result = await Process.run('ps', ['-p', '$processPid', '-o', 'pid=']);
+    if (result.exitCode != 0) return false;
+    return (result.stdout as String).trim() == '$processPid';
+  }
+
+  static void _defaultKillProcess(int processPid) {
+    Process.killPid(processPid, ProcessSignal.sigkill);
+  }
+}

--- a/cockpit/pubspec.lock
+++ b/cockpit/pubspec.lock
@@ -713,10 +713,11 @@ packages:
   media_kit:
     dependency: "direct main"
     description:
-      name: media_kit
-      sha256: ae9e79597500c7ad6083a3c7b7b7544ddabfceacce7ae5c9709b0ec16a5d6643
-      url: "https://pub.dev"
-    source: hosted
+      path: media_kit
+      ref: "44ba261"
+      resolved-ref: "44ba261c463f5e2cef926d35438a95ee63cc5cf9"
+      url: "https://github.com/media-kit/media-kit.git"
+    source: git
     version: "1.2.6"
   media_kit_libs_android_video:
     dependency: transitive

--- a/cockpit/pubspec.yaml
+++ b/cockpit/pubspec.yaml
@@ -237,6 +237,16 @@ flutter:
 # Público + HTTPS pra funcionar no macOS E no Windows. Voltar pro pub quando o
 # upstream publicar os fixes.
 dependency_overrides:
+  # media_kit 1.2.6 chama `quit` em handles mpv antigos durante hot restart
+  # antes de limpar o wakeup callback da isolate anterior, causando SIGABRT no
+  # Flutter 3.38+ (`Callback invoked after it has been deleted`, upstream
+  # #1314). O fix oficial foi mergeado em #1416, mas ainda não saiu no pub.dev.
+  # Remover este override quando uma release posterior a 1.2.6 contiver o fix.
+  media_kit:
+    git:
+      url: https://github.com/media-kit/media-kit.git
+      ref: 44ba261
+      path: media_kit
   flterm:
     git:
       url: https://github.com/jacobaraujo7/libghostty.git

--- a/cockpit/test/core/process/owned_process_registry_test.dart
+++ b/cockpit/test/core/process/owned_process_registry_test.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:cockpit/app/core/data/process/owned_process_registry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('owned_process_registry_test');
+  });
+
+  tearDown(() async {
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  File ownerFile(String category, int owner) => File(
+    '${tmp.path}${Platform.pathSeparator}$category'
+    '${Platform.pathSeparator}$owner.pids',
+  );
+
+  Future<void> seed(String category, int owner, List<int> children) async {
+    final file = ownerFile(category, owner);
+    await file.parent.create(recursive: true);
+    await file.writeAsString('${children.join('\n')}\n');
+  }
+
+  test(
+    'register/unregister ficam isolados por categoria e proprietário',
+    () async {
+      final agents = OwnedProcessRegistry(
+        category: 'agents',
+        rootPath: tmp.path,
+        ownerPid: 101,
+      );
+      final tasks = OwnedProcessRegistry(
+        category: 'tasks',
+        rootPath: tmp.path,
+        ownerPid: 101,
+      );
+
+      await agents.register(11);
+      await agents.register(12);
+      await tasks.register(21);
+      await agents.unregister(11);
+
+      expect(await ownerFile('agents', 101).readAsLines(), ['12']);
+      expect(await ownerFile('tasks', 101).readAsLines(), ['21']);
+    },
+  );
+
+  test('cleanOrphans limpa instância atual e proprietários mortos', () async {
+    await seed('tasks', 101, [11]);
+    await seed('tasks', 202, [22]);
+    await seed('tasks', 303, [33]);
+    final killed = <int>[];
+    final registry = OwnedProcessRegistry(
+      category: 'tasks',
+      rootPath: tmp.path,
+      ownerPid: 101,
+      isProcessAlive: (owner) async => owner == 202,
+      killProcess: killed.add,
+    );
+
+    await registry.cleanOrphans();
+
+    expect(killed, unorderedEquals([11, 33]));
+    expect(await ownerFile('tasks', 101).exists(), isFalse);
+    expect(await ownerFile('tasks', 202).readAsLines(), ['22']);
+    expect(await ownerFile('tasks', 303).exists(), isFalse);
+  });
+
+  test('Cockpit filho preserva a task do Cockpit pai vivo', () async {
+    final parent = OwnedProcessRegistry(
+      category: 'tasks',
+      rootPath: tmp.path,
+      ownerPid: 100,
+    );
+    await parent.register(999);
+    final killed = <int>[];
+    final child = OwnedProcessRegistry(
+      category: 'tasks',
+      rootPath: tmp.path,
+      ownerPid: 200,
+      isProcessAlive: (owner) async => owner == 100,
+      killProcess: killed.add,
+    );
+
+    await child.cleanOrphans();
+
+    expect(killed, isEmpty);
+    expect(await ownerFile('tasks', 100).readAsLines(), ['999']);
+  });
+
+  test('falha ao verificar proprietário preserva seus processos', () async {
+    await seed('lsp', 202, [22]);
+    final killed = <int>[];
+    final registry = OwnedProcessRegistry(
+      category: 'lsp',
+      rootPath: tmp.path,
+      ownerPid: 101,
+      isProcessAlive: (_) => throw const FileSystemException('ps unavailable'),
+      killProcess: killed.add,
+    );
+
+    await registry.cleanOrphans();
+
+    expect(killed, isEmpty);
+    expect(await ownerFile('lsp', 202).readAsLines(), ['22']);
+  });
+
+  test('arquivo legado é consumido uma única vez', () async {
+    final legacy = File('${tmp.path}${Platform.pathSeparator}agent-pids');
+    await legacy.writeAsString('41\n42\ninvalid\n');
+    final killed = <int>[];
+    final registry = OwnedProcessRegistry(
+      category: 'agents',
+      rootPath: tmp.path,
+      ownerPid: 101,
+      legacyFiles: [legacy.path],
+      killProcess: killed.add,
+    );
+
+    await registry.cleanOrphans();
+    await registry.cleanOrphans();
+
+    expect(killed, [41, 42]);
+    expect(await legacy.exists(), isFalse);
+  });
+}


### PR DESCRIPTION
## Contexto

Foi adicionado um profile Linux à task do Cockpit para executar `flutter run -d linux`. O build terminava com sucesso, mas o processo encerrava logo depois do bootstrap e o painel mostrava `finished`.

Depois de corrigir esse encerramento, o hot restart (`R`) revelou um segundo problema independente: o processo abortava com `Callback invoked after it has been deleted` dentro do lifecycle nativo do `media_kit`.

## Causas raiz

### Encerramento da task Linux

O `PtyTaskRunner` registrava o PID de toda task no `PiProcessRegistry`, cujo arquivo global deveria conter apenas processos `pi --mode rpc`. Quando o Cockpit iniciado pela task entrava no bootstrap, `PiProcessRegistry.cleanOrphans()` interpretava o `flutter run` do Cockpit pai como órfão e o matava.

O formato global também fazia duas instâncias legítimas do Cockpit compartilharem os registries de agents e LSP, permitindo que uma instância limpasse processos ainda vivos da outra.

### Crash no hot restart

O `media_kit 1.2.6` enviava `quit` para handles antigos do mpv antes de remover o wakeup callback associado à isolate Dart anterior. No Flutter 3.38+, o mpv podia invocar esse callback depois que seu trampoline já havia sido destruído, causando SIGABRT e perda da conexão com o device.

O upstream corrigiu esse problema em [media-kit/media-kit#1416](https://github.com/media-kit/media-kit/pull/1416), commit `44ba261c463f5e2cef926d35438a95ee63cc5cf9`.

## O que mudou

- Adiciona o profile `linux` à task versionada do Cockpit.
- Introduz `OwnedProcessRegistry`, que separa os PIDs por categoria e pelo PID da instância proprietária:
  - `agents/<ownerPid>.pids`
  - `lsp/<ownerPid>.pids`
  - `tasks/<ownerPid>.pids`
- Mantém a limpeza anti-órfãos:
  - limpa processos da própria instância em hot restart;
  - limpa processos de proprietários que já morreram após crash/cold restart;
  - preserva processos pertencentes a outros Cockpits ainda vivos;
  - em caso de falha ao verificar o proprietário, prefere preservar o processo.
- Migra e consome uma vez os arquivos legados `agent-pids` e `lsp-pids`.
- Cria `TaskProcessRegistry` e remove o acoplamento incorreto entre tasks e `PiProcessRegistry`.
- Faz o bootstrap limpar agents, LSP e tasks em paralelo, cada um no próprio namespace.
- Garante que `PtyTaskRunner` remova o PID do registry tanto na saída normal quanto no descarte explícito.
- Fixa temporariamente `media_kit` no commit upstream que limpa o wakeup callback antes de enviar `quit`. O override possui comentário para ser removido quando uma release posterior à `1.2.6` publicar o fix.

## Impacto

- `flutter run -d linux` permanece vivo depois do build e abre o Cockpit normalmente.
- O hot restart deixa de abortar por callback FFI da isolate anterior.
- Instâncias simultâneas do Cockpit não matam tasks, agents ou language servers umas das outras.
- A proteção contra processos órfãos após hot restart, crash ou atualização continua ativa.
- Não há mudança no schema público do `tasks.json` nem em `TaskRunnerGateway`.

## Validação

- `flutter test test/core/process/owned_process_registry_test.dart test/tasks/watch_match_test.dart` — 9 testes passaram.
- Regressão explícita: um Cockpit filho preserva a task pertencente ao Cockpit pai vivo.
- Cobertura de isolamento por categoria/owner, limpeza de owner atual ou morto, preservação em erro de liveness e migração do arquivo legado.
- `flutter analyze` — nenhum erro ou warning novo; permanecem 36 infos preexistentes de `prefer_initializing_formals`.
- Execução manual Linux: build e bootstrap concluíram; o hot restart completou e a VM permaneceu conectada, sem o SIGABRT original.
- A suíte completa avançou, mas mantém duas diferenças golden preexistentes/ambientais em `text_scale_factor@1x.png` e `text_scale_factor@2x.png` (0,06% de pixels), sem relação com esta alteração.
