### PR TITLE
feat(cockpit): confirma antes de mover arquivo/pasta no Files

### DIFF
--- a/cockpit/lib/app/cockpit/ui/widgets/file_tree_panel.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_tree_panel.dart
@@ -507,15 +507,24 @@ class _FileTreePanelState extends State<FileTreePanel> {
 
   // ---- mover (drag-and-drop) ------------------------------------------------
 
-  /// Drop de [path] numa pasta [targetDir]: move mantendo o nome. A validação
-  /// (mesma pasta = no-op, pasta dentro de si mesma) fica na VM; falha vira
-  /// dialog. A seleção segue o novo caminho.
+  /// Drop de [path] numa pasta [targetDir]: move mantendo o nome. Confirma
+  /// sempre antes de tocar o disco. A validação (mesma pasta = no-op, pasta
+  /// dentro de si mesma) fica na VM; falha vira dialog. A seleção segue o
+  /// novo caminho.
   Future<void> _requestMove(String path, String targetDir) async {
+    final name = path.split('/').where((p) => p.isNotEmpty).last;
+    final destName = targetDir.split('/').where((p) => p.isNotEmpty).lastOrNull;
+    final ok = await showConfirmDialog(
+      context,
+      title: 'Move?',
+      message: 'Move “$name” to “${destName ?? '/'}”?',
+      confirmLabel: 'Move',
+    );
+    if (!ok || !mounted) return;
     final r = await widget.onMove(path, targetDir);
     if (!mounted) return;
     r.fold((_) {
       if (_selectedPath != null && _isUnder(_selectedPath!, path)) {
-        final name = path.split('/').where((p) => p.isNotEmpty).last;
         setState(() => _selectedPath = '$targetDir/$name');
       }
     }, (e) => showInfoDialog(context, title: 'Could not move', message: e));
@@ -578,9 +587,7 @@ class _FileTreePanelState extends State<FileTreePanel> {
     // Copiar / recortar / colar (Cmd no macOS, Ctrl no resto). Paste dispensa
     // seleção (cai na raiz); copy/cut exigem um item selecionado.
     final mod = HardwareKeyboard.instance;
-    final accel = Platform.isMacOS
-        ? mod.isMetaPressed
-        : mod.isControlPressed;
+    final accel = Platform.isMacOS ? mod.isMetaPressed : mod.isControlPressed;
     if (accel) {
       if (key == LogicalKeyboardKey.keyC && _selectedPath != null) {
         _copySelected();
@@ -756,9 +763,8 @@ class _FileTreePanelState extends State<FileTreePanel> {
                       ? Icons.view_list_outlined
                       : Icons.account_tree_outlined,
                   tooltip: _sourceControlTree ? 'View as List' : 'View as Tree',
-                  onTap: () => setState(
-                    () => _sourceControlTree = !_sourceControlTree,
-                  ),
+                  onTap: () =>
+                      setState(() => _sourceControlTree = !_sourceControlTree),
                 ),
               ],
             ),
@@ -810,19 +816,19 @@ class _FileTreePanelState extends State<FileTreePanel> {
                             vertical: 8,
                             horizontal: 6,
                           ),
-                            // Árvore única da raiz do workspace, mesmo em
-                            // multi-root — a coloração git resolve a root dona
-                            // por caminho absoluto, e a divisão por repo vive
-                            // no Source Control (lá é onde importa).
-                            child: _DirView(
-                              path: widget.rootPath,
-                              rootPath: widget.rootPath,
-                              depth: 0,
-                              refreshToken: _refreshToken,
-                              edit: edit,
-                            ),
+                          // Árvore única da raiz do workspace, mesmo em
+                          // multi-root — a coloração git resolve a root dona
+                          // por caminho absoluto, e a divisão por repo vive
+                          // no Source Control (lá é onde importa).
+                          child: _DirView(
+                            path: widget.rootPath,
+                            rootPath: widget.rootPath,
+                            depth: 0,
+                            refreshToken: _refreshToken,
+                            edit: edit,
                           ),
                         ),
+                      ),
                     ),
                   ),
           ),
@@ -1255,7 +1261,10 @@ class _RowState extends State<_Row> {
     // "Create agent" só quando agentes estão ligados (Settings → General →
     // "Enable agents"). "Create terminal" segue sempre. Lido na hora do menu
     // pra refletir o toggle atual.
-    final agentsEnabled = context.read<SettingsController>().settings.enableAgent;
+    final agentsEnabled = context
+        .read<SettingsController>()
+        .settings
+        .enableAgent;
     showAppMenu<String>(
       context,
       minWidth: 220,
@@ -1324,11 +1333,7 @@ class _RowState extends State<_Row> {
           label: 'Copy',
           icon: Icons.copy_all_outlined,
         ),
-        const AppMenuItem(
-          value: 'cut',
-          label: 'Cut',
-          icon: Icons.content_cut,
-        ),
+        const AppMenuItem(value: 'cut', label: 'Cut', icon: Icons.content_cut),
         AppMenuItem(
           value: 'paste',
           label: 'Paste',


### PR DESCRIPTION
## O que
Adiciona confirmação antes de mover arquivo/pasta via drag-and-drop no painel Files do Cockpit — o mesmo padrão de confirmação que já existia pra delete, agora também pro move.

## Problema
`_requestMove` (disparado pelo `DragTarget` da `FileTreePanel` ao soltar um item numa pasta) chamava `widget.onMove` direto, sem chance de cancelar. Um drag acidental (comum em árvore de arquivos densa, pastas aninhadas) já movia o arquivo de vez — sem diálogo, sem undo. `_requestDelete` já tinha essa proteção; `_requestMove` não.

## Como funciona
```
Drag solta item em pasta (DragTarget.onAcceptWithDetails)
  → _requestMove(path, targetDir)
    → showConfirmDialog("Move?", 'Move "<nome>" to "<destino>"?', confirmLabel: "Move")
      → cancelou ou !mounted → return (nada acontece)
      → confirmou → widget.onMove(path, targetDir) (fluxo original, inalterado)
```
- `showConfirmDialog` é o mesmo helper de `confirm_dialog.dart` já usado por `_requestDelete` (AlertDialog temático do Cockpit, botões Cancel/confirmLabel).
- Nome de origem e destino extraídos do path pra mensagem (`path.split('/').where(isNotEmpty).last`; destino cai pra `'/'` quando é a raiz do workspace).
- Comportamento pós-move (seguir seleção pro novo caminho, erro → `showInfoDialog`) não mudou — só ganhou o gate de confirmação antes.
- Diferença de `_requestDelete`: delete usa `danger: true` e mensagem que varia por plataforma (Lixeira no macOS vs. permanente); move não é destrutivo (reversível arrastando de volta), então sem `danger` e mensagem única.

## Arquivos
- `cockpit/lib/app/cockpit/ui/widgets/file_tree_panel.dart` — `_requestMove` ganha o `showConfirmDialog` antes do `onMove`; resto do diff é reflow do `dart format` em trechos vizinhos (accel ternário, menu item `cut`, etc.), sem mudança de comportamento.

## Verificação
- ✅ `dart format` no arquivo — limpo.
- ✅ `flutter analyze` no arquivo — limpo (0 errors/warnings novos; avisos pré-existentes no arquivo — ex. `_buildTree`, contagem de classes — não são desta mudança).
- ✅ `flutter test test/ui/file_tree_panel_test.dart` — 2/2 passam. Nenhum teste existente exercita o fluxo de drag-and-drop/`_requestMove` (só stubavam `onMove`), então a suíte não quebrou mas também não cobre o diálogo novo.

## O que continua sem verificação
- Teste automatizado do fluxo de confirmação em si (simular `Draggable`/`DragTarget` ou chamar `_requestMove` isolado e checar o dialog) — não existia infraestrutura de teste pra drag-and-drop no arquivo; ficaria como follow-up se quiser cobertura.
- Verificação manual no app rodando (drag-and-drop real na árvore) não foi feita nesta sessão — só via análise de código + testes automatizados.