### PR TITLE
add support to macOS with Intel processors using rosetta

### DIFF
--- a/cockpit/BUILD_X86_64_INTEL.md
+++ b/cockpit/BUILD_X86_64_INTEL.md
@@ -1,43 +1,122 @@
-# Binário X86_64
+# Build macOS universal — Apple Silicon e Intel
 
-O Cockpit.app é uma versão para a arquitetura x86_64, compilado a partir de um hardware Intel.
+Este projeto gera um único `Cockpit.app` compatível com os dois tipos de Mac:
 
-Processador: Intel(R) Core(TM) i7-14700K
-Placa de vídeo: AMD Radeon RX 6800 XT 16GB
-Memória: 64GB(4x16GB) DDR5 5200MHz
-OS: MacOS Tahoe 26.2
+| Computador do usuário                   | Arquitetura no app |
+| --------------------------------------- | ------------------ |
+| Mac com Apple Silicon (M1, M2, M3, M4…) | `arm64`            |
+| Mac Intel                               | `x86_64`           |
 
-Flutter 3.44.2 • channel stable • https://github.com/flutter/flutter.git
-Framework • revision c9a6c48423 (5 weeks ago) • 2026-06-10 15:52:41 -0700
-Engine • hash 04efd7c093d4e9281d5526ebcad6ecc60ba8badf (revision 77e2e94772) (1
-months ago) • 2026-06-10 19:59:06.000Z
-Tools • Dart 3.12.2 • DevTools 2.57.0
+O mantenedor faz as releases em **Apple Silicon**. Este é o fluxo principal e
+recomendado: nele o próprio Mac de build cria todas as fatias do aplicativo e
+dos helpers internos (`cockpit-cli` e `cockpit-hook`).
 
-Download [Cockpit.app](https://drive.google.com/drive/folders/14-dNbEAlk3LvVPS2tzT3tcsk02J8qpXJ?usp=sharing)
-https://drive.google.com/drive/folders/14-dNbEAlk3LvVPS2tzT3tcsk02J8qpXJ?usp=sharing
+> O arquivo mantém o nome histórico `BUILD_X86_64_INTEL.md`, mas não descreve
+> mais um build exclusivo para Intel: a release gerada é universal.
 
-[Video Testando Compilação](https://drive.google.com/file/d/1ofxiLO84ZQu3fN4-7iXUMdU9j5fsC2Xb/view?usp=sharing)
-https://drive.google.com/file/d/1ofxiLO84ZQu3fN4-7iXUMdU9j5fsC2Xb/view?usp=sharing
+## Fluxo principal: release em Apple Silicon
 
-Precisei executar os comandos abaixo após a compilação para conseguir executar o Cockpit.app sem a assinatura oficial, sem esses passos o app dava crash:
+### 1. Pré-requisitos (somente uma vez por máquina)
+
+Instale ou confirme:
+
+1. Xcode e as Command Line Tools.
+2. O Flutter **ARM** usado normalmente pelo projeto.
+3. Uma segunda instalação do Flutter **x64**, com a **mesma versão** do Flutter
+   ARM. Ela é usada apenas sob Rosetta para compilar a fatia Intel dos helpers.
+4. Rosetta 2:
 
 ```bash
-# Seta path do arquivo à variável APP
-APP="build/macos/Build/Products/Release/Cockpit.app"
-# Seta path do mktemp à variável ENT
-ENT="$(mktemp)"
-# Copia o arquivo Release.entitlements para a variável ENT
-cp macos/Runner/Release.entitlements "$ENT"
-# Adiciona a chave :com.apple.security.cs.disable-library-validation com valor true ao arquivo Release.entitlements
-# Usado para desabilitar a validação de bibliotecas
-# Necessário para que o arquivo seja executado em sistemas com macOS 13 ou superior
-/usr/libexec/PlistBuddy -c "Add :com.apple.security.cs.disable-library-validation bool true" "$ENT"
-# Assina o arquivo com o mktemp
-# Usado para que o arquivo seja executado em sistemas com macOS 13 ou superior
-# Necessário para que o arquivo seja executado em sistemas com macOS 13 ou superior
-codesign --force --deep --options runtime --entitlements "$ENT" --sign - "$APP"
-# Verifica a assinatura do arquivo
-# Usado para verificar se o arquivo foi assinado corretamente
-# Necessário para que o arquivo seja executado em sistemas com macOS 13 ou superior
-codesign -d --entitlements - "$APP" 2>&1
+softwareupdate --install-rosetta --agree-to-license
 ```
+
+O Flutter ARM e o Flutter x64 podem ficar em diretórios diferentes. Exemplo:
+
+```text
+/opt/flutter-arm64
+/opt/flutter-x64
+```
+
+Confirme que os dois Dart SDKs têm a mesma versão. Os comandos devem mostrar a
+mesma versão de Dart (por exemplo, `3.12.2`):
+
+```bash
+/opt/flutter-arm64/bin/dart --version
+arch -x86_64 /opt/flutter-x64/bin/dart --version
+```
+
+### 2. Preparar o terminal de release
+
+Na raiz deste repositório, selecione o Flutter ARM para o build e informe o
+Dart x64 complementar:
+
+```bash
+export FLUTTER_ROOT="/opt/flutter-arm64"
+export PATH="$FLUTTER_ROOT/bin:$PATH"
+export COCKPIT_DART_X64="/opt/flutter-x64/bin/dart"
+```
+
+Faça uma conferência rápida antes de compilar:
+
+```bash
+flutter --version
+arch -x86_64 "$COCKPIT_DART_X64" --version
+```
+
+Se houver divergência de versão do Dart, pare aqui e instale a versão x64 que
+corresponde ao Flutter ARM. O build detecta essa situação e falha de propósito.
+
+### 3. Compilar
+
+```bash
+flutter pub get
+flutter build macos --release
+```
+
+Durante o build:
+
+1. Flutter gera o aplicativo principal com `arm64` e `x86_64`.
+2. Os scripts `macos/build_cli.sh` e `macos/build_hook.sh` compilam os helpers
+   em `arm64` com o Dart nativo.
+3. Os mesmos scripts executam o Dart x64 sob Rosetta e compilam a fatia Intel.
+4. `lipo` une cada par de fatias em um único executável universal.
+5. A assinatura configurada pelo projeto é aplicada ao helper final.
+
+O resultado fica em:
+
+```text
+build/macos/Build/Products/Release/Cockpit.app
+```
+
+### 4. Validar antes de assinar ou distribuir
+
+```bash
+APP="build/macos/Build/Products/Release/Cockpit.app"
+
+lipo -verify_arch arm64 x86_64 "$APP/Contents/MacOS/Cockpit"
+lipo -verify_arch arm64 x86_64 "$APP/Contents/Resources/cockpit-cli"
+lipo -verify_arch arm64 x86_64 "$APP/Contents/Resources/cockpit-hook"
+codesign --verify --deep --strict --verbose=2 "$APP"
+```
+
+Os quatro comandos devem terminar sem erro. Os dois últimos executáveis são
+essenciais: sem eles, terminal, CLI interna e integração de hooks poderiam
+falhar em uma das arquiteturas mesmo que a janela principal abrisse.
+
+## Erros comuns
+
+| Mensagem ou sintoma                | Causa provável                                | Como resolver                                                        |
+| ---------------------------------- | --------------------------------------------- | -------------------------------------------------------------------- |
+| `COCKPIT_DART_X64` não definido    | Build Apple Silicon sem SDK x64 indicado      | Exporte o caminho para `flutter-x64/bin/dart`.                       |
+| Não foi possível executar SDK x64  | Rosetta ausente ou caminho incorreto          | Instale Rosetta e rode `arch -x86_64 "$COCKPIT_DART_X64" --version`. |
+| Versões Dart diferentes            | Flutter ARM e x64 não correspondem            | Instale o SDK x64 da mesma versão do Flutter ARM.                    |
+| `lipo -verify_arch` falha em Intel | Os helpers Intel têm apenas x64 por definição | Faça a release em Apple Silicon.                                     |
+
+## Referências no projeto
+
+- `macos/build_dart_helper.sh`: lógica compartilhada para criar helpers
+  universais.
+- `macos/build_cli.sh`: empacota a CLI interna.
+- `macos/build_hook.sh`: empacota o helper de hooks.
+- [`packaging/README.md`](packaging/README.md): assinatura, DMG, notarização e
+  publicação.

--- a/cockpit/macos/Runner.xcodeproj/project.pbxproj
+++ b/cockpit/macos/Runner.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/../tool/cockpit_hook.dart",
+				"$(SRCROOT)/../macos/build_dart_helper.sh",
 			);
 			name = "Build cockpit-hook helper";
 			outputPaths = (
@@ -402,6 +403,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/../tool/cockpit_cli.dart",
+				"$(SRCROOT)/../macos/build_dart_helper.sh",
 			);
 			name = "Build cockpit CLI";
 			outputPaths = (

--- a/cockpit/macos/build_cli.sh
+++ b/cockpit/macos/build_cli.sh
@@ -18,30 +18,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"   # cockpit/
 SRC="$ROOT/tool/cockpit_cli.dart"
 
-# Resolve o `dart`: 1) Flutter (FLUTTER_ROOT setado pelo Xcode), 2) PATH.
-resolve_dart() {
-  if [ -n "${FLUTTER_ROOT:-}" ] && [ -x "$FLUTTER_ROOT/bin/dart" ]; then
-    echo "$FLUTTER_ROOT/bin/dart"; return
-  fi
-  if command -v dart >/dev/null 2>&1; then command -v dart; return; fi
-  if command -v flutter >/dev/null 2>&1; then
-    echo "$(dirname "$(command -v flutter)")/dart"; return
-  fi
-  echo "[build_cli] erro: 'dart' não encontrado (defina FLUTTER_ROOT)" >&2
-  exit 1
-}
-
-compile() {
-  local out="$1"
-  mkdir -p "$(dirname "$out")"
-  echo "[build_cli] compilando $SRC -> $out"
-  "$(resolve_dart)" compile exe "$SRC" -o "$out"
-  chmod +x "$out"
-}
+source "$ROOT/macos/build_dart_helper.sh"
 
 mode="${1:-bundle}"
 if [ "$mode" = "dev" ]; then
-  compile "$HOME/.cockpit/bin-debug/cockpit"
+  echo "[build_cli] compilando para a arquitetura do host"
+  compile_dart_helper_for_host "$SRC" "$HOME/.cockpit/bin-debug/cockpit"
   echo "[build_cli] dev OK"
   exit 0
 fi
@@ -50,7 +32,8 @@ fi
 : "${BUILT_PRODUCTS_DIR:?precisa rodar pelo Xcode (BUILT_PRODUCTS_DIR ausente)}"
 : "${PRODUCT_NAME:?PRODUCT_NAME ausente}"
 DEST="$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Resources/cockpit-cli"
-compile "$DEST"
+echo "[build_cli] compilando helper universal -> $DEST"
+compile_universal_dart_helper "$SRC" "$DEST" "cockpit-cli"
 
 # Assinatura: mesma lógica do build_hook.sh (exe AOT do Dart precisa de
 # entitlements allow-jit/allow-unsigned-executable-memory sob hardened runtime).

--- a/cockpit/macos/build_dart_helper.sh
+++ b/cockpit/macos/build_dart_helper.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Funções compartilhadas para os executáveis Dart incluídos no bundle macOS.
+#
+# `dart compile exe` gera código para a arquitetura do SDK que o executa. Em
+# Apple Silicon, Rosetta permite executar um SDK x64 e, portanto, gerar ambas
+# as fatias localmente. Em Intel, os helpers são somente x64: esse fluxo não
+# produz uma release compatível com Apple Silicon.
+
+set -euo pipefail
+
+resolve_dart() {
+  if [ -n "${FLUTTER_ROOT:-}" ] && [ -x "$FLUTTER_ROOT/bin/dart" ]; then
+    echo "$FLUTTER_ROOT/bin/dart"
+    return
+  fi
+  if command -v dart >/dev/null 2>&1; then
+    command -v dart
+    return
+  fi
+  if command -v flutter >/dev/null 2>&1; then
+    echo "$(dirname "$(command -v flutter)")/dart"
+    return
+  fi
+  echo "[cockpit helper] erro: 'dart' não encontrado (defina FLUTTER_ROOT)" >&2
+  exit 1
+}
+
+dart_version() {
+  "$@" --version 2>&1 | sed -nE 's/^Dart SDK version: ([^ ]+).*/\1/p'
+}
+
+require_same_dart_version() {
+  local dart_arm="$1"
+  local dart_x64="$2"
+  local arm_version x64_version
+  arm_version="$(dart_version "$dart_arm")"
+  x64_version="$(dart_version arch -x86_64 "$dart_x64")"
+
+  if [ -z "$arm_version" ] || [ -z "$x64_version" ] || [ "$arm_version" != "$x64_version" ]; then
+    echo "[cockpit helper] erro: os SDKs Dart arm64 ($arm_version) e x64 ($x64_version) devem ter a mesma versão" >&2
+    exit 1
+  fi
+}
+
+# Para `flutter run`/testes locais: uma fatia do host é suficiente.
+compile_dart_helper_for_host() {
+  local source="$1"
+  local output="$2"
+  local dart
+  dart="$(resolve_dart)"
+  mkdir -p "$(dirname "$output")"
+  "$dart" compile exe "$source" -o "$output"
+  chmod +x "$output"
+}
+
+# Produz um executável universal para ser incluído num bundle de release.
+#
+# Ambiente em Apple Silicon:
+#   COCKPIT_DART_X64=/caminho/para/flutter-x64/bin/dart
+#
+compile_universal_dart_helper() {
+  local source="$1"
+  local output="$2"
+  local artifact_name="$3"
+  local dart host_arch temp arm_slice x64_slice
+  dart="$(resolve_dart)"
+  host_arch="$(uname -m)"
+  mkdir -p "$(dirname "$output")"
+
+  case "$host_arch" in
+    arm64)
+      : "${COCKPIT_DART_X64:?Defina COCKPIT_DART_X64 com um SDK Dart/Flutter x64 para Rosetta}"
+      if ! arch -x86_64 "$COCKPIT_DART_X64" --version >/dev/null 2>&1; then
+        echo "[cockpit helper] erro: não foi possível executar o SDK x64; instale Rosetta e confira COCKPIT_DART_X64" >&2
+        exit 1
+      fi
+      require_same_dart_version "$dart" "$COCKPIT_DART_X64"
+      temp="$(mktemp -d "${TMPDIR:-/tmp}/cockpit-helper.XXXXXX")"
+      arm_slice="$temp/$artifact_name-arm64"
+      x64_slice="$temp/$artifact_name-x86_64"
+      "$dart" compile exe "$source" -o "$arm_slice"
+      arch -x86_64 "$COCKPIT_DART_X64" compile exe "$source" -o "$x64_slice"
+      ;;
+    x86_64)
+      echo "[cockpit helper] build Intel: gerando $artifact_name apenas para x86_64" >&2
+      "$dart" compile exe "$source" -o "$output"
+      chmod +x "$output"
+      return
+      ;;
+    *)
+      echo "[cockpit helper] erro: arquitetura de host macOS não suportada: $host_arch" >&2
+      exit 1
+      ;;
+  esac
+
+  /usr/bin/lipo -create "$arm_slice" "$x64_slice" -output "$output"
+  chmod +x "$output"
+  /usr/bin/lipo -verify_arch arm64 x86_64 "$output"
+  rm -rf "$temp"
+}

--- a/cockpit/macos/build_hook.sh
+++ b/cockpit/macos/build_hook.sh
@@ -18,30 +18,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"   # cockpit/
 SRC="$ROOT/tool/cockpit_hook.dart"
 
-# Resolve o `dart`: 1) Flutter (FLUTTER_ROOT setado pelo Xcode), 2) PATH.
-resolve_dart() {
-  if [ -n "${FLUTTER_ROOT:-}" ] && [ -x "$FLUTTER_ROOT/bin/dart" ]; then
-    echo "$FLUTTER_ROOT/bin/dart"; return
-  fi
-  if command -v dart >/dev/null 2>&1; then command -v dart; return; fi
-  if command -v flutter >/dev/null 2>&1; then
-    echo "$(dirname "$(command -v flutter)")/dart"; return
-  fi
-  echo "[build_hook] erro: 'dart' não encontrado (defina FLUTTER_ROOT)" >&2
-  exit 1
-}
-
-compile() {
-  local out="$1"
-  mkdir -p "$(dirname "$out")"
-  echo "[build_hook] compilando $SRC -> $out"
-  "$(resolve_dart)" compile exe "$SRC" -o "$out"
-  chmod +x "$out"
-}
+source "$ROOT/macos/build_dart_helper.sh"
 
 mode="${1:-bundle}"
 if [ "$mode" = "dev" ]; then
-  compile "$HOME/.cockpit/bin/cockpit-hook"
+  echo "[build_hook] compilando para a arquitetura do host"
+  compile_dart_helper_for_host "$SRC" "$HOME/.cockpit/bin/cockpit-hook"
   echo "[build_hook] dev OK"
   exit 0
 fi
@@ -50,7 +32,8 @@ fi
 : "${BUILT_PRODUCTS_DIR:?precisa rodar pelo Xcode (BUILT_PRODUCTS_DIR ausente)}"
 : "${PRODUCT_NAME:?PRODUCT_NAME ausente}"
 DEST="$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Resources/cockpit-hook"
-compile "$DEST"
+echo "[build_hook] compilando helper universal -> $DEST"
+compile_universal_dart_helper "$SRC" "$DEST" "cockpit-hook"
 
 # Assinatura: exe AOT do Dart é morto sob hardened runtime ad-hoc. Então:
 # - dev/ad-hoc (sem identity ou '-'): assina PLANO (sem --options runtime).

--- a/cockpit/packaging/README.md
+++ b/cockpit/packaging/README.md
@@ -55,6 +55,13 @@ a API key do App Store Connect.
 cd cockpit
 
 # 1. Build universal (x86_64 + arm64 — default do Flutter macOS release).
+#
+# Os helpers Dart do Cockpit também são universais. Em Apple Silicon, instale
+# Rosetta e aponte para um SDK Flutter/Dart x64 da mesma versão:
+# export COCKPIT_DART_X64="/caminho/para/flutter-x64/bin/dart"
+#
+# Em Intel, os helpers são compilados somente para x86_64; esse não é um
+# caminho de release compatível com Apple Silicon. Veja docs/buildintel.md.
 flutter build macos --release
 APP="build/macos/Build/Products/Release/Cockpit.app"
 


### PR DESCRIPTION
# Build macOS universal para Intel e Apple Silicon

Este PR atualiza o processo de build macOS para que as releases feitas em Apple Silicon incluam compatibilidade nativa com Macs Intel (`x86_64`) e Apple Silicon (`arm64`), via Rosetta, que faz referência à issue #45.

Apenas a compilação em hardware intel(#45), não resolve devido ao auto-update do Cockpit.

## AVISO!!!
### Esta solução não foi testada com build em apple silicon(Não possuo), então é realmente muito necessário testar esta antes de completar o merge. Além do descritivo abaixo, todos os passos e orientações, constam no arquivo [BUILD_X86_64_INTEL](https://github.com/gilsongabriel/remote_pi/blob/feat/compatibility-intel/cockpit/BUILD_X86_64_INTEL.md). Ao @jacobaraujo7 e/ou outros colaboradores que queiram/possam testar essa solução em um hardware com apple silicon, e compartilhar comigo o app compilado, para testes no macos com intel, estou a disposição.

## Alterações

- Centralizada a compilação dos helpers Dart em `macos/build_dart_helper.sh`.
- Atualizados `macos/build_cli.sh` e `macos/build_hook.sh` para usar o fluxo
  compartilhado.
- Em Apple Silicon:
  - compila os helpers nativamente em `arm64`;
  - compila a fatia Intel com Dart/Flutter x64 executado via Rosetta;
  - une as duas fatias com `lipo`;
  - valida que os helpers finais possuem `arm64` e `x86_64`.
- Preservada a assinatura dos helpers após a geração universal.
- Adicionada dependência do script compartilhado nas fases de build do Xcode.
- Atualizada a documentação de build e empacotamento.

## Uso para release em Apple Silicon

```bash
export COCKPIT_DART_X64="/caminho/para/flutter-x64/bin/dart"
flutter build macos --release
```

Requer Rosetta e um SDK Flutter/Dart x64 na mesma versão do SDK ARM.

## Validação

```bash
lipo -verify_arch arm64 x86_64 "$APP/Contents/Resources/cockpit-cli"
lipo -verify_arch arm64 x86_64 "$APP/Contents/Resources/cockpit-hook"
codesign --verify --deep --strict --verbose=2 "$APP"
```

Builds executadas em hardware Intel continuam gerando helpers somente `x86_64` e não
devem ser distribuídas para Apple Silicon.