### PR TITLE
  feat(cockpit): add update check frequency settings

### DIFF
--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -84,7 +84,9 @@ class _CockpitPageState extends State<CockpitPage> {
     // Dispara o carregamento inicial dos ViewModels page-scoped ao montar a rota.
     // Os módulos provêm via `.new`, então não encadeiam mais `..init()`/`..check()`.
     context.read<CockpitViewModel>().init();
-    context.read<UpdateViewModel>().check();
+    final updateVm = context.read<UpdateViewModel>();
+    updateVm.attachSettings(_settings!);
+    updateVm.check();
     // Publica o estado do workspace no menu File (New Agent / New Terminal): só
     // habilitam quando há workspace ativo. Re-sincroniza a cada mudança da VM.
     _workspaceMenu = context.read<WorkspaceMenuBridge>();

--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -85,7 +85,7 @@ class _CockpitPageState extends State<CockpitPage> {
     // Os módulos provêm via `.new`, então não encadeiam mais `..init()`/`..check()`.
     context.read<CockpitViewModel>().init();
     final updateVm = context.read<UpdateViewModel>();
-    updateVm.attachSettings(_settings!);
+    updateVm.attachSettings(context.read<SettingsController>());
     updateVm.check();
     // Publica o estado do workspace no menu File (New Agent / New Terminal): só
     // habilitam quando há workspace ativo. Re-sincroniza a cada mudança da VM.

--- a/cockpit/lib/app/cockpit/ui/viewmodels/update_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/update_viewmodel.dart
@@ -7,6 +7,8 @@ import 'package:cockpit/app/cockpit/domain/contracts/url_opener.dart';
 import 'package:cockpit/app/cockpit/domain/entities/update_info.dart';
 import 'package:cockpit/app/cockpit/domain/value_objects/semver.dart';
 import 'package:cockpit/app/cockpit/domain/value_objects/update_target.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/ui/settings_controller.dart';
 import 'package:flutter/foundation.dart';
 
 /// Dono do mini card de atualização do rail. Tem **dois modos**, decididos pela
@@ -29,7 +31,8 @@ class UpdateViewModel extends ChangeNotifier {
     this._dismissed,
     this._opener,
     this._target,
-    this._selfUpdater, {
+    this._selfUpdater,
+    this._settingsController, {
     this.fallbackUrl = _kFallbackUrl,
   });
 
@@ -38,6 +41,7 @@ class UpdateViewModel extends ChangeNotifier {
   final UrlOpener _opener;
   final UpdateTarget _target;
   final SelfUpdater _selfUpdater;
+  final SettingsController _settingsController;
 
   /// Versão do app rodando (de package_info, resolvida no boot).
   String get currentVersion => _target.version;
@@ -143,12 +147,29 @@ class UpdateViewModel extends ChangeNotifier {
       await _selfUpdater.checkForUpdates(inBackground: false);
       return;
     }
-    await _runCheck();
+    await _runCheck(force: true);
   }
 
   /// Uma passada de checagem (boot ou periódica).
-  Future<void> _runCheck() async {
+  Future<void> _runCheck({bool force = false}) async {
     if (_disposed) return;
+
+    final freq = _settingsController.settings.updateCheckFrequency;
+    if (!force) {
+      if (freq == UpdateCheckFrequency.never) return;
+      
+      final lastCheck = _settingsController.settings.lastUpdateCheckTime;
+      if (lastCheck != null) {
+        final now = DateTime.now();
+        final diff = now.difference(lastCheck);
+        if (freq == UpdateCheckFrequency.daily && diff.inDays < 1) return;
+        if (freq == UpdateCheckFrequency.weekly && diff.inDays < 7) return;
+        if (freq == UpdateCheckFrequency.monthly && diff.inDays < 30) return;
+      }
+    }
+
+    _settingsController.setLastUpdateCheckTime(DateTime.now());
+
     if (isSelfUpdate) {
       _selfSub ??= _selfUpdater.changes.listen(_onSelfUpdateChange);
       if (!_selfInitialized) {

--- a/cockpit/lib/app/cockpit/ui/viewmodels/update_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/update_viewmodel.dart
@@ -31,8 +31,7 @@ class UpdateViewModel extends ChangeNotifier {
     this._dismissed,
     this._opener,
     this._target,
-    this._selfUpdater,
-    this._settingsController, {
+    this._selfUpdater, {
     this.fallbackUrl = _kFallbackUrl,
   });
 
@@ -41,7 +40,11 @@ class UpdateViewModel extends ChangeNotifier {
   final UrlOpener _opener;
   final UpdateTarget _target;
   final SelfUpdater _selfUpdater;
-  final SettingsController _settingsController;
+  SettingsController? _settingsController;
+
+  void attachSettings(SettingsController controller) {
+    _settingsController = controller;
+  }
 
   /// Versão do app rodando (de package_info, resolvida no boot).
   String get currentVersion => _target.version;
@@ -154,11 +157,11 @@ class UpdateViewModel extends ChangeNotifier {
   Future<void> _runCheck({bool force = false}) async {
     if (_disposed) return;
 
-    final freq = _settingsController.settings.updateCheckFrequency;
+    final freq = _settingsController?.settings.updateCheckFrequency ?? UpdateCheckFrequency.never;
     if (!force) {
       if (freq == UpdateCheckFrequency.never) return;
       
-      final lastCheck = _settingsController.settings.lastUpdateCheckTime;
+      final lastCheck = _settingsController?.settings.lastUpdateCheckTime;
       if (lastCheck != null) {
         final now = DateTime.now();
         final diff = now.difference(lastCheck);
@@ -168,7 +171,7 @@ class UpdateViewModel extends ChangeNotifier {
       }
     }
 
-    _settingsController.setLastUpdateCheckTime(DateTime.now());
+    _settingsController?.setLastUpdateCheckTime(DateTime.now());
 
     if (isSelfUpdate) {
       _selfSub ??= _selfUpdater.changes.listen(_onSelfUpdateChange);

--- a/cockpit/lib/app/core/domain/entities/app_settings.dart
+++ b/cockpit/lib/app/core/domain/entities/app_settings.dart
@@ -9,6 +9,8 @@ enum SyntaxThemeId { one, dracula, github }
 /// Motor VT usado por terminais criados daqui pra frente.
 enum TerminalEngine { ghostty, xterm }
 
+enum UpdateCheckFrequency { daily, weekly, monthly, never }
+
 /// Preferências do app, persistidas localmente (Hive). Imutável; mudanças via
 /// [copyWith]. Fontes vazias (`null`) = usar os defaults do design.
 class AppSettings {
@@ -35,6 +37,8 @@ class AppSettings {
     this.showCockpit = true,
     this.defaultTerminalProfileId,
     this.terminalEngine = TerminalEngine.ghostty,
+    this.updateCheckFrequency = UpdateCheckFrequency.daily,
+    this.lastUpdateCheckTime,
   });
 
   final AppThemeMode themeMode;
@@ -123,6 +127,12 @@ class AppSettings {
   /// motor no descritor de layout e não são recriadas ao trocar esta opção.
   final TerminalEngine terminalEngine;
 
+  /// Frequência de verificação de atualizações.
+  final UpdateCheckFrequency updateCheckFrequency;
+
+  /// Data da última verificação de atualização.
+  final DateTime? lastUpdateCheckTime;
+
   AppSettings copyWith({
     AppThemeMode? themeMode,
     String? interfaceFont,
@@ -150,6 +160,8 @@ class AppSettings {
     String? defaultTerminalProfileId,
     bool clearDefaultTerminalProfileId = false,
     TerminalEngine? terminalEngine,
+    UpdateCheckFrequency? updateCheckFrequency,
+    DateTime? lastUpdateCheckTime,
   }) {
     return AppSettings(
       themeMode: themeMode ?? this.themeMode,
@@ -180,6 +192,8 @@ class AppSettings {
           ? null
           : (defaultTerminalProfileId ?? this.defaultTerminalProfileId),
       terminalEngine: terminalEngine ?? this.terminalEngine,
+      updateCheckFrequency: updateCheckFrequency ?? this.updateCheckFrequency,
+      lastUpdateCheckTime: lastUpdateCheckTime ?? this.lastUpdateCheckTime,
     );
   }
 
@@ -213,6 +227,8 @@ class AppSettings {
     if (defaultTerminalProfileId != null)
       'terminal.default_profile_id': defaultTerminalProfileId,
     'terminal.engine': terminalEngine.name,
+    'updateCheckFrequency': updateCheckFrequency.name,
+    if (lastUpdateCheckTime != null) 'lastUpdateCheckTime': lastUpdateCheckTime!.toIso8601String(),
   };
 
   factory AppSettings.fromJson(Map<dynamic, dynamic> json) {
@@ -256,6 +272,14 @@ class AppSettings {
         json['terminal.engine'],
         TerminalEngine.ghostty,
       ),
+      updateCheckFrequency: _enumByName(
+        UpdateCheckFrequency.values,
+        json['updateCheckFrequency'],
+        UpdateCheckFrequency.daily,
+      ),
+      lastUpdateCheckTime: json['lastUpdateCheckTime'] != null
+          ? DateTime.tryParse(json['lastUpdateCheckTime'] as String)
+          : null,
     );
   }
 }

--- a/cockpit/lib/app/core/ui/settings_controller.dart
+++ b/cockpit/lib/app/core/ui/settings_controller.dart
@@ -111,6 +111,12 @@ class SettingsController extends ChangeNotifier {
   void setShowCockpit(bool value) =>
       _apply(_settings.copyWith(showCockpit: value));
 
+  void setUpdateCheckFrequency(UpdateCheckFrequency frequency) =>
+      _apply(_settings.copyWith(updateCheckFrequency: frequency));
+
+  void setLastUpdateCheckTime(DateTime time) =>
+      _apply(_settings.copyWith(lastUpdateCheckTime: time));
+
   /// Persiste a visibilidade dos painéis do shell (rail de projetos + árvore de
   /// arquivos) para restaurar no próximo boot. Não faz `notifyListeners` porque
   /// a fonte de verdade em runtime é a `CockpitViewModel` — aqui só grava.

--- a/cockpit/lib/app/settings/ui/settings_page.dart
+++ b/cockpit/lib/app/settings/ui/settings_page.dart
@@ -400,6 +400,21 @@ class _GeneralPanel extends StatelessWidget {
                   ],
                 ),
               ),
+              _Section(
+                label: 'Updates',
+                child: _Card(
+                  children: [
+                    _Row(
+                      title: 'Check for updates',
+                      description: 'How often Cockpit should look for new versions.',
+                      trailing: _UpdateCheckDropdown(
+                        value: s.updateCheckFrequency,
+                        onChanged: controller.setUpdateCheckFrequency,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
               const _StorageSection(),
               const _DiagnosticsSection(),
             ],
@@ -1465,6 +1480,41 @@ class _SyntaxDropdown extends StatelessWidget {
       label: _labels[value]!,
       onTap: () async {
         final picked = await showAppMenu<SyntaxThemeId>(
+          context,
+          minWidth: 180,
+          items: [
+            for (final e in _labels.entries)
+              AppMenuItem(
+                value: e.key,
+                label: e.value,
+                selected: e.key == value,
+              ),
+          ],
+        );
+        if (picked != null) onChanged(picked);
+      },
+    );
+  }
+}
+
+class _UpdateCheckDropdown extends StatelessWidget {
+  const _UpdateCheckDropdown({required this.value, required this.onChanged});
+  final UpdateCheckFrequency value;
+  final ValueChanged<UpdateCheckFrequency> onChanged;
+
+  static const _labels = <UpdateCheckFrequency, String>{
+    UpdateCheckFrequency.daily: 'Daily',
+    UpdateCheckFrequency.weekly: 'Weekly',
+    UpdateCheckFrequency.monthly: 'Monthly',
+    UpdateCheckFrequency.never: 'Never',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return _DropdownChip(
+      label: _labels[value]!,
+      onTap: () async {
+        final picked = await showAppMenu<UpdateCheckFrequency>(
           context,
           minWidth: 180,
           items: [

--- a/cockpit/test/ui/update_viewmodel_test.dart
+++ b/cockpit/test/ui/update_viewmodel_test.dart
@@ -115,8 +115,8 @@ void main() {
         _FakeOpener(),
         _kWindowsTarget,
         updater,
-        SettingsController(_FakeSettingsStore()),
       );
+      vm.attachSettings(SettingsController(_FakeSettingsStore()));
     });
     tearDown(() {
       vm.dispose();
@@ -226,8 +226,8 @@ void main() {
         _FakeOpener(),
         _kWindowsTarget,
         updater,
-        SettingsController(_FakeSettingsStore()),
       );
+      vm.attachSettings(SettingsController(_FakeSettingsStore()));
     });
     tearDown(() {
       vm.dispose();

--- a/cockpit/test/ui/update_viewmodel_test.dart
+++ b/cockpit/test/ui/update_viewmodel_test.dart
@@ -6,8 +6,19 @@ import 'package:cockpit/app/cockpit/domain/contracts/update_checker.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/url_opener.dart';
 import 'package:cockpit/app/cockpit/domain/entities/update_info.dart';
 import 'package:cockpit/app/cockpit/domain/value_objects/update_target.dart';
+import 'package:cockpit/app/core/domain/contracts/settings_store.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/ui/settings_controller.dart';
 import 'package:cockpit/app/cockpit/ui/viewmodels/update_viewmodel.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class _FakeSettingsStore implements SettingsStore {
+  @override
+  Future<AppSettings> load() async => const AppSettings();
+
+  @override
+  Future<void> save(AppSettings settings) async {}
+}
 
 /// Motor de self-update controlável: os testes empurram fases à mão, como o
 /// Sparkle/WinSparkle fariam.
@@ -104,6 +115,7 @@ void main() {
         _FakeOpener(),
         _kWindowsTarget,
         updater,
+        SettingsController(_FakeSettingsStore()),
       );
     });
     tearDown(() {
@@ -214,6 +226,7 @@ void main() {
         _FakeOpener(),
         _kWindowsTarget,
         updater,
+        SettingsController(_FakeSettingsStore()),
       );
     });
     tearDown(() {


### PR DESCRIPTION

## O que este PR adiciona?

Adiciona uma nova configuração na tela de **Settings -> Updates** que permite ao usuário controlar a frequência
  com que o Cockpit busca por novas atualizações.
    As opções adicionadas são:
    - **Daily** (Diariamente)
    - **Weekly** (Semanalmente)
    - **Monthly** (Mensalmente)
    - **Never** (Nunca)

## Por que foi adicionado?

Para dar controle ao usuário sobre o auto-updater. Anteriormente o aplicativo buscava novas atualizações toda
  vez que abria e, também, automaticamente a cada 6 horas no background. Agora, com essa configuração, a
  verificação passa a ser condicional, poupando solicitações na rede e evitando notificações persistentes caso o
  usuário não tenha interesse em baixar novas versões no momento.

*Nota técnica:* A checagem manual (`Check for updates` pelo menu superior) ignora essa preferência e força a
  checagem, pra que o usuário sempre tenha uma porta de saída caso a configuração esteja em "Never".
