### PR TITLE
fix(cockpit): avoid UI freeze under busy TUI output

### DIFF
--- a/cockpit/lib/app/cockpit/data/tasks/pty_task_runner.dart
+++ b/cockpit/lib/app/cockpit/data/tasks/pty_task_runner.dart
@@ -79,6 +79,8 @@ class PtyTaskRunner implements TaskRunnerGateway {
         environment: env,
         rows: 24,
         columns: 80,
+        // Mesmo backpressure dos terminais interativos (plan/57).
+        ackRead: true,
       );
     } catch (_) {
       _starting.remove(def.id);
@@ -105,9 +107,11 @@ class PtyTaskRunner implements TaskRunnerGateway {
     _emit(initial);
 
     // Fan-out do output: alimenta o terminal e o detector de progresso.
+    // `ackRead` libera o próximo chunk só depois do fan-out (backpressure).
     task.outSub = pty.output.listen((bytes) {
       task.out.add(bytes);
       _detectProgress(task, bytes);
+      pty.ackRead();
     });
 
     unawaited(pty.exitCode.then((code) => _onExit(def.id, code)));

--- a/cockpit/lib/app/cockpit/data/terminal/pty_terminal_gateway.dart
+++ b/cockpit/lib/app/cockpit/data/terminal/pty_terminal_gateway.dart
@@ -26,6 +26,10 @@ class PtyTerminalGateway implements TerminalGateway {
       environment: _terminalEnv(extraEnv),
       rows: rows,
       columns: columns,
+      // Backpressure: a thread nativa só lê o próximo chunk depois de
+      // [acknowledgeOutput]. Evita saturar o isolate principal sob TUI busy
+      // (claude/htop/lazygit) — ver plan/57.
+      ackRead: true,
     );
   }
 
@@ -39,6 +43,9 @@ class PtyTerminalGateway implements TerminalGateway {
 
   @override
   void resize(int rows, int columns) => _pty?.resize(rows, columns);
+
+  @override
+  void acknowledgeOutput() => _pty?.ackRead();
 
   @override
   Future<void> kill() async {

--- a/cockpit/lib/app/cockpit/domain/contracts/terminal_gateway.dart
+++ b/cockpit/lib/app/cockpit/domain/contracts/terminal_gateway.dart
@@ -30,4 +30,8 @@ abstract class TerminalGateway {
 
   /// Mata o shell limpo (sem órfão).
   Future<void> kill();
+
+  /// Libera o próximo chunk do PTY quando o spawn usa backpressure (`ackRead`).
+  /// Fakes / gateways sem flow control devem implementar como no-op.
+  void acknowledgeOutput();
 }

--- a/cockpit/lib/app/cockpit/ui/session/pty_output_coalescer.dart
+++ b/cockpit/lib/app/cockpit/ui/session/pty_output_coalescer.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/scheduler.dart';
+
+/// Acumula saída decodificada do PTY e libera um batch por frame.
+///
+/// Combina com `ackRead` no PTY nativo:
+/// - enquanto o buffer está sob [maxPendingChars], chama [onAcknowledge] a
+///   cada chunk para encher o batch até o próximo vsync;
+/// - acima do cap, pausa o ack até o flush (backpressure real);
+/// - no flush, entrega o batch via [onFlush] e retoma o ack se estava pausado.
+///
+/// [scheduleFlush] é injetável nos testes (default = um callback por frame).
+class PtyOutputCoalescer {
+  PtyOutputCoalescer({
+    required this.onFlush,
+    required this.onAcknowledge,
+    this.maxPendingChars = 128 * 1024,
+    void Function(void Function() flush)? scheduleFlush,
+  }) : _scheduleFlush = scheduleFlush ?? _scheduleOnNextFrame;
+
+  /// Cap do buffer pendente (~128 KiB). Acima disso o ack pausa até o flush.
+  final int maxPendingChars;
+
+  /// Recebe o texto coalescido (um batch por frame, em uso normal).
+  final void Function(String batch) onFlush;
+
+  /// Libera o próximo chunk do PTY (`TerminalGateway.acknowledgeOutput`).
+  final void Function() onAcknowledge;
+
+  final void Function(void Function() flush) _scheduleFlush;
+
+  final StringBuffer _pending = StringBuffer();
+  bool _flushScheduled = false;
+  bool _ackPaused = false;
+  bool _disposed = false;
+
+  /// Caracteres ainda não flushados (exposto pra testes).
+  int get pendingLength => _pending.length;
+
+  /// `true` enquanto o ack está suspenso por cap (exposto pra testes).
+  bool get ackPaused => _ackPaused;
+
+  static void _scheduleOnNextFrame(void Function() flush) {
+    SchedulerBinding.instance.scheduleFrameCallback((_) => flush());
+    SchedulerBinding.instance.scheduleFrame();
+  }
+
+  /// Enfileira [data] e agenda flush se ainda não houver um pendente.
+  void add(String data) {
+    if (_disposed || data.isEmpty) return;
+    _pending.write(data);
+    if (_pending.length < maxPendingChars) {
+      onAcknowledge();
+    } else {
+      _ackPaused = true;
+    }
+    if (_flushScheduled) return;
+    _flushScheduled = true;
+    _scheduleFlush(_flush);
+  }
+
+  void _flush() {
+    if (_disposed) return;
+    _flushScheduled = false;
+    final batch = _pending.toString();
+    _pending.clear();
+    if (batch.isNotEmpty) onFlush(batch);
+    if (_ackPaused) {
+      _ackPaused = false;
+      onAcknowledge();
+    }
+  }
+
+  /// Descarta o agendamento; flusha o restante de forma síncrona.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _flushScheduled = false;
+    final batch = _pending.toString();
+    _pending.clear();
+    if (batch.isNotEmpty) onFlush(batch);
+    _ackPaused = false;
+  }
+}

--- a/cockpit/lib/app/cockpit/ui/session/terminal_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/terminal_session.dart
@@ -7,6 +7,7 @@ import 'package:cockpit/app/core/domain/entities/terminal_profile.dart';
 import 'package:cockpit/app/core/domain/entities/app_settings.dart';
 import 'package:cockpit/app/core/terminal/terminal_controller.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
+import 'package:cockpit/app/cockpit/ui/session/pty_output_coalescer.dart';
 import 'package:cockpit/app/cockpit/ui/session/terminal_input.dart';
 import 'package:flutter/foundation.dart';
 import 'package:pasteboard/pasteboard.dart';
@@ -64,15 +65,21 @@ class TerminalSession extends PaneItem {
       columns: 80,
       extraEnv: spawnEnv,
     );
+    // Coalesce + backpressure (plan/57): um `terminal.write` por frame e
+    // `acknowledgeOutput` com cap, pra TUI busy não saturar o isolate principal.
+    _coalescer = PtyOutputCoalescer(
+      onAcknowledge: _gateway.acknowledgeOutput,
+      onFlush: (batch) {
+        _kitty.feed(batch); // observa push/pop do kitty antes de renderizar.
+        terminal.write(batch);
+        _record(batch); // grava o scrollback pra replay no próximo boot.
+        _trackCwd(batch); // rastreia o cwd vivo (OSC 7) pra restaurar nele.
+      },
+    );
     _sub = _gateway.output
         .cast<List<int>>()
         .transform(const Utf8Decoder(allowMalformed: true))
-        .listen((data) {
-          _kitty.feed(data); // observa push/pop do kitty antes de renderizar.
-          terminal.write(data);
-          _record(data); // grava o scrollback pra replay no próximo boot.
-          _trackCwd(data); // rastreia o cwd vivo (OSC 7) pra restaurar nele.
-        });
+        .listen(_coalescer.add);
     terminal.onOutput = (data) {
       final text = utf8.decode(data, allowMalformed: true);
       _maybeInterrupt(text);
@@ -240,6 +247,7 @@ class TerminalSession extends PaneItem {
 
   final TerminalGateway _gateway;
   final KittyKeyboardTracker _kitty = KittyKeyboardTracker();
+  late final PtyOutputCoalescer _coalescer;
 
   // --- Persistência do scrollback (replay no próximo boot) --------------------
   // Grava a saída DECODIFICADA (após o `Utf8Decoder` em streaming → sem cortar
@@ -384,6 +392,7 @@ class TerminalSession extends PaneItem {
       _flush(),
     ); // best-effort: persiste o estado final (inclui app-quit).
     await _sub?.cancel();
+    _coalescer.dispose();
     await _gateway.kill();
     terminal.dispose();
     super.dispose();

--- a/cockpit/test/session/pty_output_coalescer_test.dart
+++ b/cockpit/test/session/pty_output_coalescer_test.dart
@@ -1,0 +1,105 @@
+import 'package:cockpit/app/cockpit/ui/session/pty_output_coalescer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Agenda o flush sob controle do teste (não depende de vsync).
+class _ManualScheduler {
+  void Function()? pending;
+
+  void schedule(void Function() flush) {
+    pending = flush;
+  }
+
+  void run() {
+    final fn = pending;
+    pending = null;
+    fn?.call();
+  }
+}
+
+void main() {
+  test('N chunks sob o cap → um flush + ack por chunk', () {
+    final scheduler = _ManualScheduler();
+    final flushes = <String>[];
+    var acks = 0;
+
+    final coalescer = PtyOutputCoalescer(
+      maxPendingChars: 1024,
+      onFlush: flushes.add,
+      onAcknowledge: () => acks++,
+      scheduleFlush: scheduler.schedule,
+    );
+
+    coalescer
+      ..add('a')
+      ..add('b')
+      ..add('c');
+
+    expect(flushes, isEmpty);
+    expect(acks, 3);
+    expect(coalescer.pendingLength, 3);
+    expect(scheduler.pending, isNotNull);
+
+    scheduler.run();
+
+    expect(flushes, ['abc']);
+    expect(coalescer.pendingLength, 0);
+    expect(coalescer.ackPaused, isFalse);
+    // Sem ack extra no flush (nunca pausou).
+    expect(acks, 3);
+
+    coalescer.dispose();
+  });
+
+  test('estouro do cap pausa ack até o flush', () {
+    final scheduler = _ManualScheduler();
+    final flushes = <String>[];
+    var acks = 0;
+
+    final coalescer = PtyOutputCoalescer(
+      maxPendingChars: 4,
+      onFlush: flushes.add,
+      onAcknowledge: () => acks++,
+      scheduleFlush: scheduler.schedule,
+    );
+
+    coalescer.add('ab'); // len 2 < 4 → ack
+    expect(acks, 1);
+    expect(coalescer.ackPaused, isFalse);
+
+    coalescer.add('cd'); // len 4 >= 4 → pausa
+    expect(acks, 1);
+    expect(coalescer.ackPaused, isTrue);
+
+    coalescer.add('e'); // ainda pausado, sem ack
+    expect(acks, 1);
+
+    scheduler.run();
+
+    expect(flushes, ['abcde']);
+    expect(coalescer.ackPaused, isFalse);
+    // Flush retoma com um ack.
+    expect(acks, 2);
+
+    coalescer.dispose();
+  });
+
+  test('dispose flusha o restante síncrono', () {
+    final scheduler = _ManualScheduler();
+    final flushes = <String>[];
+
+    final coalescer = PtyOutputCoalescer(
+      onFlush: flushes.add,
+      onAcknowledge: () {},
+      scheduleFlush: scheduler.schedule,
+    );
+
+    coalescer.add('pending');
+    expect(flushes, isEmpty);
+
+    coalescer.dispose();
+    expect(flushes, ['pending']);
+    // Segundo dispose é no-op.
+    coalescer.dispose();
+    expect(flushes, ['pending']);
+  });
+}

--- a/cockpit/test/session/terminal_status_test.dart
+++ b/cockpit/test/session/terminal_status_test.dart
@@ -25,6 +25,8 @@ class _NoopGateway implements TerminalGateway {
   @override
   void resize(int rows, int columns) {}
   @override
+  void acknowledgeOutput() {}
+  @override
   Future<void> kill() async {
     await _out.close();
   }


### PR DESCRIPTION
## Resumo
- Abas de terminal (e PTYs de task) passam a usar backpressure nativo `ackRead`, para um TUI ocupado não inundar a fila de eventos do Dart.
- Sessões interativas coalescem a saída decodificada do PTY em um `terminal.write` por frame via `PtyOutputCoalescer` (cap de 128 KiB pendente), mantendo o shell do Cockpit responsivo ao voltar o foco durante Claude Code e outros TUIs.
- Inclui cobertura unitária do coalesce + pausa de ack; atualiza o fake do gateway com o novo contrato `acknowledgeOutput()`.

## Contexto
No Linux (Wayland + GPU híbrida), alternar para outro app e voltar ao Cockpit enquanto um TUI redesenhava com intensidade podia congelar a aplicação inteira (abas, árvore de arquivos, workspace) até o TUI ficar idle. Causa: chunks ilimitados do PTY processados de forma síncrona no isolate principal (parse VT + notify/paint), com backlog grande no resume do foco.