### PR TITLE
fix(cockpit): barras de scroll duplicadas no editor + cargo no CMake

### DIFF
--- a/cockpit/CLAUDE.md
+++ b/cockpit/CLAUDE.md
@@ -71,6 +71,20 @@ virou módulo/plugin interno; o resto vem do pub.dev.
 
 ## Comandos
 
+### Pré-requisitos de build (além do Flutter SDK)
+
+O build desktop **não é só Dart** — ele compila dois motores nativos junto, e
+sem eles o `flutter run/build` falha antes de chegar no app:
+
+| Ferramenta | Por quê | Sem ela |
+|---|---|---|
+| **Rust** (`cargo`, via [rustup](https://rustup.rs)) | a CLI interna (`cli/`) é um crate Rust, compilado por macOS/Linux/Windows e empacotado ao lado do binário | build para no alvo `cockpit-cli` |
+| **Zig 0.16.0** | `hooks.user_defines.libghostty.source: compile` no pubspec compila a dylib do Ghostty (0.15.x não serve) | falha no build hook do `libghostty` |
+
+O `cargo` é resolvido pelo PATH e, como fallback, em `~/.cargo/bin` — o mesmo
+lugar onde o rustup instala. Isso cobre IDE/launcher que não herda o PATH do
+shell de login; se faltar mesmo, o CMake para no configure com a causa.
+
 - `flutter pub get` — instala deps
 - `flutter analyze` — lint estático (deve passar zero issues)
 - `flutter test` — testes

--- a/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:cockpit/app/core/domain/entities/lsp_diagnostic.dart';
+import 'package:cockpit/app/core/ui/clamping_scroll_behavior.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/app_tooltip.dart';
 import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
@@ -75,6 +76,21 @@ class CodeEditor extends StatefulWidget {
 
   @override
   State<CodeEditor> createState() => _CodeEditorState();
+}
+
+/// Mantém a física global clamp, mas não desenha barras automáticas.
+///
+/// Um simples `copyWith(scrollbars: false)` não basta para o [TextField]:
+/// internamente, o Flutter reativa scrollbars quando o campo é multilinha.
+class _CodeEditorScrollBehavior extends ClampingScrollBehavior {
+  const _CodeEditorScrollBehavior();
+
+  @override
+  Widget buildScrollbar(
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) => child;
 }
 
 class _CodeEditorState extends State<CodeEditor> {
@@ -590,108 +606,114 @@ class _CodeEditorState extends State<CodeEditor> {
       child: Scrollbar(
         controller: _vertical,
         notificationPredicate: (n) => n.metrics.axis == Axis.vertical,
-        // O padding de 14px é um frame FIXO fora dos dois scrolls (gutter e
-        // campo), pra ambos começarem o conteúdo em y=0 e rolarem em lockstep
-        // sem que o inset de topo desalinhe ao rolar.
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 14),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Gutter — scroll próprio (travado ao input) espelhando `_vertical`.
-              //
-              // `ListView.builder` (e não `Column`): com uma Column, um arquivo
-              // de 5k linhas materializava 5000 Rows+Texts A CADA rebuild — e
-              // rebuild acontece até quando o mouse cruza uma linha (o tooltip
-              // de diagnostic faz setState). Virtualizado, só as ~40 linhas
-              // visíveis são construídas, e `severityForLine` (que varre os
-              // diagnostics) roda só pra elas.
-              //
-              // `itemExtent: _lineHeight` é o que mantém o alinhamento 1:1 com
-              // o texto — mesma métrica que o campo usa por linha — e ainda dá
-              // scroll O(1) (o `jumpTo` do `_syncGutter` não precisa medir os
-              // itens anteriores). Largura fixa porque a ListView, ao contrário
-              // da Column dentro do SingleChildScrollView, não é intrínseca:
-              // sem isso o gutter esticaria e comeria o campo.
-              Padding(
-                padding: const EdgeInsets.only(left: 14, right: 14),
-                child: SizedBox(
-                  width: _iconSlot + _digitsWidth,
-                  child: ListView.builder(
-                    controller: _gutter,
-                    physics: const NeverScrollableScrollPhysics(),
-                    padding: EdgeInsets.zero,
-                    itemExtent: _lineHeight,
-                    itemCount: lineCount,
-                    itemBuilder: (context, i) => _gutterLine(i + 1, numStyle),
+        // O shadcn adiciona uma scrollbar vertical automática a cada Scrollable
+        // desktop. Gutter e TextField precisam de scrolls próprios para ficarem
+        // sincronizados, mas suas barras duplicariam a barra deste painel.
+        child: ScrollConfiguration(
+          behavior: const _CodeEditorScrollBehavior(),
+          // O padding de 14px é um frame FIXO fora dos dois scrolls (gutter e
+          // campo), pra ambos começarem o conteúdo em y=0 e rolarem em lockstep
+          // sem que o inset de topo desalinhe ao rolar.
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Gutter — scroll próprio (travado ao input) espelhando `_vertical`.
+                //
+                // `ListView.builder` (e não `Column`): com uma Column, um arquivo
+                // de 5k linhas materializava 5000 Rows+Texts A CADA rebuild — e
+                // rebuild acontece até quando o mouse cruza uma linha (o tooltip
+                // de diagnostic faz setState). Virtualizado, só as ~40 linhas
+                // visíveis são construídas, e `severityForLine` (que varre os
+                // diagnostics) roda só pra elas.
+                //
+                // `itemExtent: _lineHeight` é o que mantém o alinhamento 1:1 com
+                // o texto — mesma métrica que o campo usa por linha — e ainda dá
+                // scroll O(1) (o `jumpTo` do `_syncGutter` não precisa medir os
+                // itens anteriores). Largura fixa porque a ListView, ao contrário
+                // da Column dentro do SingleChildScrollView, não é intrínseca:
+                // sem isso o gutter esticaria e comeria o campo.
+                Padding(
+                  padding: const EdgeInsets.only(left: 14, right: 14),
+                  child: SizedBox(
+                    width: _iconSlot + _digitsWidth,
+                    child: ListView.builder(
+                      controller: _gutter,
+                      physics: const NeverScrollableScrollPhysics(),
+                      padding: EdgeInsets.zero,
+                      itemExtent: _lineHeight,
+                      itemCount: lineCount,
+                      itemBuilder: (context, i) => _gutterLine(i + 1, numStyle),
+                    ),
                   ),
                 ),
-              ),
-              Container(width: 1, color: syntax.base.withValues(alpha: 0.15)),
-              Expanded(
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    // Largura mínima = viewport (menos o padding H). Sem isso, o
-                    // IntrinsicWidth colapsa o campo a ~0 quando o arquivo está
-                    // vazio (recém-criado) → sem área pra clicar/digitar.
-                    final minWidth = (constraints.maxWidth - 30).clamp(
-                      0.0,
-                      double.infinity,
-                    );
-                    return SingleChildScrollView(
-                      controller: _horizontal,
-                      scrollDirection: Axis.horizontal,
-                      padding: const EdgeInsets.only(left: 14, right: 16),
-                      // `TextField` (e não `EditableText` cru) pra ganhar os
-                      // gestos de seleção do desktop: arrastar com o mouse,
-                      // duplo-clique, Cmd+A. O highlight vem do `buildTextSpan`
-                      // do controller; a decoração é zerada (sem borda/fundo).
-                      child: ConstrainedBox(
-                        constraints: BoxConstraints(minWidth: minWidth),
-                        child: IntrinsicWidth(
-                          child: TextField(
-                            controller: widget.controller,
-                            focusNode: widget.focusNode,
-                            // O campo é o DONO do scroll vertical (scroll interno)
-                            // → fica parado no espaço global e a âncora da seleção
-                            // não escorrega durante o auto-scroll do drag.
-                            scrollController: _vertical,
-                            style: codeStyle,
-                            cursorColor: syntax.base,
-                            maxLines: null,
-                            minLines: null,
-                            // Preenche a altura do viewport e rola o conteúdo
-                            // internamente; o gutter espelha via `_syncGutter`.
-                            expands: true,
-                            keyboardType: TextInputType.multiline,
-                            // `onTap` do próprio TextField dispara DEPOIS que o
-                            // toque já moveu `controller.selection` pra posição
-                            // clicada (comportamento interno do EditableText) —
-                            // por isso lemos a seleção aqui, não num
-                            // GestureDetector externo (que veria a seleção ANTIGA,
-                            // antes do TextField processar o tap).
-                            onTap: _definitionModeActive
-                                ? _onDefinitionTap
-                                : null,
-                            // TextField sempre define seu PRÓPRIO cursor (I-beam)
-                            // por padrão — sobrescreve o `MouseRegion` externo, que
-                            // nunca vencia a resolução de cursor (o descendente mais
-                            // específico ganha). Precisa ser setado aqui pra virar
-                            // clicável de fato durante o hover de definition.
-                            mouseCursor: _defCursor,
-                            decoration: const InputDecoration(
-                              isCollapsed: true,
-                              border: InputBorder.none,
-                              contentPadding: EdgeInsets.zero,
+                Container(width: 1, color: syntax.base.withValues(alpha: 0.15)),
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      // Largura mínima = viewport (menos o padding H). Sem isso, o
+                      // IntrinsicWidth colapsa o campo a ~0 quando o arquivo está
+                      // vazio (recém-criado) → sem área pra clicar/digitar.
+                      final minWidth = (constraints.maxWidth - 30).clamp(
+                        0.0,
+                        double.infinity,
+                      );
+                      return SingleChildScrollView(
+                        controller: _horizontal,
+                        scrollDirection: Axis.horizontal,
+                        padding: const EdgeInsets.only(left: 14, right: 16),
+                        // `TextField` (e não `EditableText` cru) pra ganhar os
+                        // gestos de seleção do desktop: arrastar com o mouse,
+                        // duplo-clique, Cmd+A. O highlight vem do `buildTextSpan`
+                        // do controller; a decoração é zerada (sem borda/fundo).
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(minWidth: minWidth),
+                          child: IntrinsicWidth(
+                            child: TextField(
+                              controller: widget.controller,
+                              focusNode: widget.focusNode,
+                              // O campo é o DONO do scroll vertical (scroll interno)
+                              // → fica parado no espaço global e a âncora da seleção
+                              // não escorrega durante o auto-scroll do drag.
+                              scrollController: _vertical,
+                              style: codeStyle,
+                              cursorColor: syntax.base,
+                              maxLines: null,
+                              minLines: null,
+                              // Preenche a altura do viewport e rola o conteúdo
+                              // internamente; o gutter espelha via `_syncGutter`.
+                              expands: true,
+                              keyboardType: TextInputType.multiline,
+                              // `onTap` do próprio TextField dispara DEPOIS que o
+                              // toque já moveu `controller.selection` pra posição
+                              // clicada (comportamento interno do EditableText) —
+                              // por isso lemos a seleção aqui, não num
+                              // GestureDetector externo (que veria a seleção ANTIGA,
+                              // antes do TextField processar o tap).
+                              onTap: _definitionModeActive
+                                  ? _onDefinitionTap
+                                  : null,
+                              // TextField sempre define seu PRÓPRIO cursor (I-beam)
+                              // por padrão — sobrescreve o `MouseRegion` externo, que
+                              // nunca vencia a resolução de cursor (o descendente mais
+                              // específico ganha). Precisa ser setado aqui pra virar
+                              // clicável de fato durante o hover de definition.
+                              mouseCursor: _defCursor,
+                              decoration: const InputDecoration(
+                                isCollapsed: true,
+                                border: InputBorder.none,
+                                contentPadding: EdgeInsets.zero,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    );
-                  },
+                      );
+                    },
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/cockpit/linux/CMakeLists.txt
+++ b/cockpit/linux/CMakeLists.txt
@@ -166,6 +166,16 @@ install(PROGRAMS "${COCKPIT_HOOK_EXE}" DESTINATION "${CMAKE_INSTALL_PREFIX}"
 # papel. Rust porque o `dart compile exe` sai de UMA arquitetura, não
 # cross-compila e não sobrevive ao `lipo` — ver macos/build_cli.sh.
 set(COCKPIT_CLI_CRATE "${CMAKE_SOURCE_DIR}/../cli")
+# O PATH do processo que roda o CMake nem sempre traz o `cargo` (IDE/launcher
+# não herda o shell de login), então a instalação padrão do rustup entra como
+# hint — mesma resolução do `resolve_cargo` do macos/build_cli.sh. Falhar aqui,
+# no configure, troca o "no such file or directory" do ninja por uma causa.
+find_program(CARGO_EXECUTABLE cargo HINTS "$ENV{HOME}/.cargo/bin")
+if(NOT CARGO_EXECUTABLE)
+  message(FATAL_ERROR
+    "'cargo' não encontrado: a CLI interna (cli/) é um crate Rust e faz parte "
+    "do build. Instale o Rust (https://rustup.rs) e rode o build de novo.")
+endif()
 file(GLOB_RECURSE COCKPIT_CLI_SOURCES CONFIGURE_DEPENDS
   "${COCKPIT_CLI_CRATE}/src/*.rs" "${COCKPIT_CLI_CRATE}/text/*")
 set(COCKPIT_CLI_BUILT "${COCKPIT_CLI_CRATE}/target/release/cockpit")
@@ -180,7 +190,8 @@ endif()
 add_custom_command(
   OUTPUT "${COCKPIT_CLI_EXE}"
   COMMAND "${CMAKE_COMMAND}" -E env "COCKPIT_FLAVOR=${COCKPIT_CLI_FLAVOR}"
-          cargo build --release --manifest-path "${COCKPIT_CLI_CRATE}/Cargo.toml"
+          "${CARGO_EXECUTABLE}" build --release
+          --manifest-path "${COCKPIT_CLI_CRATE}/Cargo.toml"
   COMMAND "${CMAKE_COMMAND}" -E copy "${COCKPIT_CLI_BUILT}" "${COCKPIT_CLI_EXE}"
   DEPENDS ${COCKPIT_CLI_SOURCES} "${COCKPIT_CLI_CRATE}/Cargo.toml"
   COMMENT "Compilando cockpit-cli (Rust)"

--- a/cockpit/test/ui/code_editor_selection_scroll_test.dart
+++ b/cockpit/test/ui/code_editor_selection_scroll_test.dart
@@ -4,7 +4,9 @@ import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
-import 'package:flutter/material.dart' as m show TextField;
+import 'package:flutter/material.dart'
+    as m
+    show Scrollbar, ScrollbarOrientation, TextField;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
@@ -27,6 +29,36 @@ void main() {
       ),
     );
   }
+
+  testWidgets('exibe só a barra vertical do painel', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    final ctrl = CodeEditingController(text: text, language: 'txt');
+
+    await tester.pumpWidget(harness(ctrl));
+    await tester.pumpAndSettle();
+
+    // O comportamento desktop do shadcn não deve criar barras próprias para o
+    // gutter e o TextField. Restam apenas as barras Material explícitas do
+    // painel: uma vertical e uma horizontal.
+    final automaticBars = find.descendant(
+      of: find.byType(CodeEditor),
+      matching: find.byType(Scrollbar),
+    );
+    expect(automaticBars, findsNothing);
+    final panelBars = tester
+        .widgetList<m.Scrollbar>(find.byType(m.Scrollbar))
+        .toList();
+    expect(panelBars, hasLength(2));
+    expect(
+      panelBars
+          .where(
+            (bar) => bar.scrollbarOrientation != m.ScrollbarOrientation.bottom,
+          )
+          .length,
+      1,
+    );
+    debugDefaultTargetPlatformOverride = null;
+  });
 
   testWidgets(
     'drag-select com auto-scroll não faz a âncora inicial escorregar',

--- a/cockpit/windows/CMakeLists.txt
+++ b/cockpit/windows/CMakeLists.txt
@@ -117,6 +117,16 @@ install(PROGRAMS "${COCKPIT_HOOK_EXE}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
 # papel. Rust porque o `dart compile exe` sai de UMA arquitetura, não
 # cross-compila e não sobrevive ao `lipo` — ver macos/build_cli.sh.
 set(COCKPIT_CLI_CRATE "${CMAKE_SOURCE_DIR}/../cli")
+# O PATH do processo que roda o CMake nem sempre traz o `cargo` (IDE/launcher
+# não herda o shell de login), então a instalação padrão do rustup entra como
+# hint — mesma resolução do `resolve_cargo` do macos/build_cli.sh. Falhar aqui,
+# no configure, troca o "no such file or directory" do ninja por uma causa.
+find_program(CARGO_EXECUTABLE cargo HINTS "$ENV{USERPROFILE}/.cargo/bin")
+if(NOT CARGO_EXECUTABLE)
+  message(FATAL_ERROR
+    "'cargo' não encontrado: a CLI interna (cli/) é um crate Rust e faz parte "
+    "do build. Instale o Rust (https://rustup.rs) e rode o build de novo.")
+endif()
 file(GLOB_RECURSE COCKPIT_CLI_SOURCES CONFIGURE_DEPENDS
   "${COCKPIT_CLI_CRATE}/src/*.rs" "${COCKPIT_CLI_CRATE}/text/*")
 set(COCKPIT_CLI_BUILT "${COCKPIT_CLI_CRATE}/target/release/cockpit.exe")
@@ -131,7 +141,8 @@ endif()
 add_custom_command(
   OUTPUT "${COCKPIT_CLI_EXE}"
   COMMAND "${CMAKE_COMMAND}" -E env "COCKPIT_FLAVOR=${COCKPIT_CLI_FLAVOR}"
-          cargo build --release --manifest-path "${COCKPIT_CLI_CRATE}/Cargo.toml"
+          "${CARGO_EXECUTABLE}" build --release
+          --manifest-path "${COCKPIT_CLI_CRATE}/Cargo.toml"
   COMMAND "${CMAKE_COMMAND}" -E copy "${COCKPIT_CLI_BUILT}" "${COCKPIT_CLI_EXE}"
   DEPENDS ${COCKPIT_CLI_SOURCES} "${COCKPIT_CLI_CRATE}/Cargo.toml"
   COMMENT "Compilando cockpit-cli.exe (Rust)"


### PR DESCRIPTION
## Summary
- Remove barras de scroll duplicadas no editor de código: o shadcn injetava scrollbar automática no gutter e no `TextField`, além das duas barras explícitas do painel. Um `ScrollBehavior` dedicado (`_CodeEditorScrollBehavior`) suprime as barras internas sem alterar a física clamp.
- Resolve `cargo` no CMake de Linux/Windows via hint do rustup (`~/.cargo/bin` / `%USERPROFILE%\.cargo\bin`), alinhado ao macOS — cobre IDE/launcher sem PATH de login — e falha no configure com mensagem clara se o Rust não estiver instalado.
- Documenta os pré-requisitos de build nativos (Rust + Zig) no `CLAUDE.md` e cobre o caso das barras com teste de widget.
