### PR TITLE
feat(cockpit): progresso ao vivo do post-checkout ao criar worktrees

### DIFF
--- a/cockpit/lib/app/cockpit/data/filesystem/worktree_manager_impl.dart
+++ b/cockpit/lib/app/cockpit/data/filesystem/worktree_manager_impl.dart
@@ -1,13 +1,21 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:cockpit/app/cockpit/data/filesystem/git_binary.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/worktree_manager.dart';
 import 'package:cockpit/app/cockpit/domain/entities/worktree.dart';
+import 'package:cockpit/app/core/data/setup/remote_pi_resolver.dart';
 import 'package:cockpit/app/core/domain/result.dart';
 import 'package:cockpit/app/core/utils/path_utils.dart';
+import 'package:path/path.dart' as p;
 
 /// Roda o binário `git` pra listar/criar/remover worktrees. O caminho do `git`
 /// vem do [GitBinary] compartilhado (o app macOS **não herda o PATH do shell**).
+///
+/// `add` usa [Process.start] com streaming (stdout∥stderr) e
+/// [envWithNodeOnPath] pra hooks (ex.: post-checkout com `npx`/`node`) acharem
+/// o binário — mesmo tratamento do [GitCommandRunnerImpl].
 class WorktreeManagerImpl implements WorktreeManager {
   WorktreeManagerImpl(this._gitBinary);
 
@@ -68,54 +76,110 @@ class WorktreeManagerImpl implements WorktreeManager {
   }
 
   @override
-  Future<Result<Worktree, WorktreeOpError>> add(
-    String repoPath,
-    String name, {
-    String? baseRef,
-  }) async {
+  Future<bool> hasPostCheckoutHook(String repoPath) async {
     try {
       final git = await _resolveGit();
-      // Regra cross-plataforma: só cria worktree quando a branch NÃO existe.
-      // Sem isso, `worktree add -b` falha ("branch already exists") e/ou deixa
-      // o repo num estado meio-criado.
-      if (await _branchExists(git, repoPath, name)) {
-        return const Failure(
-          WorktreeOpError('A branch with that name already exists.'),
-        );
-      }
-      // Guard rail: garante `.cockpit/worktrees/` no `.gitignore` do repo ANTES
-      // de materializar a worktree. Sob `.pi/` a pasta era ignorada de graça
-      // (repos pi já ignoram `.pi`); sob `.cockpit/` isso não vale, e sem o
-      // ignore o checkout apareceria como `untracked` no status do usuário.
-      await _ensureIgnored(repoPath);
-      final target = '$repoPath/$worktreesSubdir/$name';
-      // Branch nova a partir do HEAD do repo, ou de [baseRef] (fork de fork).
       final res = await Process.run(git, [
         '-C',
         repoPath,
-        'worktree',
-        'add',
-        target,
-        '-b',
-        name,
-        ?baseRef,
+        'rev-parse',
+        '--git-path',
+        'hooks',
       ]);
-      if (res.exitCode != 0) {
-        return Failure(WorktreeOpError(_errText(res)));
-      }
-      // Devolve o path **como o git lista** (separadores nativos do SO), não o
-      // `target` que montamos com `/`. No Windows o git lista com `\`, então o
-      // `target` com `/` não casaria com `list()` → o chamador não encontraria
-      // o fork recém-criado ("não apareceu na lista") e o dialog não fecharia.
-      final created = (await list(repoPath)).where((w) => w.branch == name);
-      return Success(
-        created.isNotEmpty
-            ? created.first
-            : Worktree(path: target, branch: name, isDetached: false),
-      );
-    } catch (e) {
-      return Failure(WorktreeOpError('Failed to create worktree: $e'));
+      if (res.exitCode != 0) return false;
+      final hooksDir = (res.stdout as String).trim();
+      if (hooksDir.isEmpty) return false;
+      // --git-path pode ser relativo ao repo.
+      final resolved = p.isAbsolute(hooksDir)
+          ? hooksDir
+          : p.normalize(p.join(repoPath, hooksDir));
+      return File(p.join(resolved, 'post-checkout')).existsSync();
+    } catch (_) {
+      return false;
     }
+  }
+
+  @override
+  WorktreeAddRun<Worktree> add(
+    String repoPath,
+    String name, {
+    String? baseRef,
+  }) {
+    final controller = StreamController<String>();
+    final resultCompleter = Completer<Result<Worktree, WorktreeOpError>>();
+
+    () async {
+      try {
+        final git = await _resolveGit();
+        // Regra cross-plataforma: só cria worktree quando a branch NÃO existe.
+        // Sem isso, `worktree add -b` falha ("branch already exists") e/ou deixa
+        // o repo num estado meio-criado.
+        if (await _branchExists(git, repoPath, name)) {
+          await _emit(
+            controller,
+            'A branch with that name already exists.',
+          );
+          resultCompleter.complete(
+            const Failure(
+              WorktreeOpError('A branch with that name already exists.'),
+            ),
+          );
+          return;
+        }
+        // Guard rail: garante `.cockpit/worktrees/` no `.gitignore` do repo ANTES
+        // de materializar a worktree. Sob `.pi/` a pasta era ignorada de graça
+        // (repos pi já ignoram `.pi`); sob `.cockpit/` isso não vale, e sem o
+        // ignore o checkout apareceria como `untracked` no status do usuário.
+        await _ensureIgnored(repoPath);
+        final target = '$repoPath/$worktreesSubdir/$name';
+        final args = <String>[
+          'worktree',
+          'add',
+          target,
+          '-b',
+          name,
+          ?baseRef,
+        ];
+        await _emit(controller, '\$ git ${args.join(' ')}');
+        final code = await _spawn(git, repoPath, args, controller);
+        if (code != 0) {
+          resultCompleter.complete(
+            Failure(
+              WorktreeOpError(
+                'git worktree add exited with code $code',
+              ),
+            ),
+          );
+          return;
+        }
+        // Devolve o path **como o git lista** (separadores nativos do SO), não o
+        // `target` que montamos com `/`. No Windows o git lista com `\`, então o
+        // `target` com `/` não casaria com `list()` → o chamador não encontraria
+        // o fork recém-criado ("não apareceu na lista") e o dialog não fecharia.
+        final created = (await list(repoPath)).where((w) => w.branch == name);
+        resultCompleter.complete(
+          Success(
+            created.isNotEmpty
+                ? created.first
+                : Worktree(path: target, branch: name, isDetached: false),
+          ),
+        );
+      } catch (e) {
+        await _emit(controller, 'Failed to create worktree: $e');
+        if (!resultCompleter.isCompleted) {
+          resultCompleter.complete(
+            Failure(WorktreeOpError('Failed to create worktree: $e')),
+          );
+        }
+      } finally {
+        if (!controller.isClosed) await controller.close();
+      }
+    }();
+
+    return WorktreeAddRun<Worktree>(
+      output: controller.stream,
+      result: resultCompleter.future,
+    );
   }
 
   /// Guard rail: garante que `.cockpit/worktrees/` está no `.gitignore` da
@@ -160,6 +224,43 @@ class WorktreeManagerImpl implements WorktreeManager {
       'refs/heads/$name',
     ]);
     return res.exitCode == 0;
+  }
+
+  /// Spawna `git -C <repoPath> <args>`, encaminha stdout+stderr (por linha) e
+  /// devolve o exit code.
+  Future<int> _spawn(
+    String git,
+    String repoPath,
+    List<String> args,
+    StreamController<String> controller,
+  ) async {
+    try {
+      final proc = await Process.start(
+        git,
+        ['-C', repoPath, ...args],
+        environment: await envWithNodeOnPath(),
+      );
+      final done = <Future<void>>[];
+      for (final stream in [proc.stdout, proc.stderr]) {
+        done.add(
+          stream
+              .transform(utf8.decoder)
+              .transform(const LineSplitter())
+              .forEach((line) {
+                if (!controller.isClosed) controller.add(line);
+              }),
+        );
+      }
+      await Future.wait(done);
+      return await proc.exitCode;
+    } catch (e) {
+      await _emit(controller, 'Failed to run git: $e');
+      return -1;
+    }
+  }
+
+  Future<void> _emit(StreamController<String> controller, String line) async {
+    if (!controller.isClosed) controller.add(line);
   }
 
   @override

--- a/cockpit/lib/app/cockpit/domain/contracts/worktree_manager.dart
+++ b/cockpit/lib/app/cockpit/domain/contracts/worktree_manager.dart
@@ -10,6 +10,21 @@ class WorktreeOpError {
   final String message;
 }
 
+/// Handle ao vivo de um `git worktree add`: stream de stdout/stderr + resultado
+/// final. A UI escuta [output] enquanto o comando (e o post-checkout, se houver)
+/// roda, e reage a [result] pra fechar ou mostrar erro.
+///
+/// [T] é [Worktree] no manager e [Project] no ViewModel (após refresh/select).
+class WorktreeAddRun<T> {
+  const WorktreeAddRun({required this.output, required this.result});
+
+  /// Linhas de stdout/stderr na ordem que chegam.
+  final Stream<String> output;
+
+  /// Completa quando o `worktree add` (e o pós-processamento do VM) termina.
+  final Future<Result<T, WorktreeOpError>> result;
+}
+
 /// Branches locais + nomes de worktree já em uso num repo — insumo da validação
 /// de unicidade (decisão 11), coletado uma vez quando o dialog de criar abre.
 class WorktreeNamespace {
@@ -42,6 +57,10 @@ abstract class WorktreeManager {
   /// validação de unicidade. Vazio se não-git/erro.
   Future<WorktreeNamespace> namespace(String repoPath);
 
+  /// `true` se o repo tem um hook `post-checkout` resolvido via
+  /// `git rev-parse --git-path hooks` (respeita `core.hooksPath` / husky).
+  Future<bool> hasPostCheckoutHook(String repoPath);
+
   /// Cria uma worktree em `<repoPath>/.cockpit/worktrees/<name>` numa branch
   /// **nova** [name] (decisões 2, 3, 15), garantindo antes que
   /// `.cockpit/worktrees/` está no `.gitignore` do repo. A base é o HEAD atual
@@ -49,7 +68,11 @@ abstract class WorktreeManager {
   /// branch de outro fork, mas a pasta nasce sempre sob o repo de origem —
   /// nunca aninhada dentro de outra worktree). [name] já deve ter passado pela
   /// validação de nome.
-  Future<Result<Worktree, WorktreeOpError>> add(
+  ///
+  /// Devolve o handle imediatamente (stream ao vivo); o [WorktreeAddRun.result]
+  /// resolve no fim. O post-checkout do repo, se existir, roda dentro do git e
+  /// aparece no stream.
+  WorktreeAddRun<Worktree> add(
     String repoPath,
     String name, {
     String? baseRef,

--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -490,16 +490,15 @@ class _CockpitPageState extends State<CockpitPage> {
   Future<void> _forkWorktree(Project base) async {
     final vm = _vm;
     final namespace = await vm.forkWorktreeNamespace(base.id);
+    final hasHook = await vm.hasPostCheckoutHookForFork(base.id);
     if (!mounted) return;
     await showWorktreeCreateDialog(
       context,
       rootName: base.name,
       namespace: namespace,
       fork: true,
-      onCreate: (name) async {
-        final res = await vm.forkWorktree(base.id, name);
-        return res.fold((_) => null, (e) => e.message);
-      },
+      hasPostCheckout: hasHook,
+      onCreate: (name) => vm.forkWorktree(base.id, name),
     );
   }
 
@@ -539,15 +538,15 @@ class _CockpitPageState extends State<CockpitPage> {
     // Multi-root: a worktree é de UMA root — a escolha já veio do submenu do
     // kebab (o fork nasce como filho single-root apontando pro checkout dela).
     final namespace = await vm.worktreeNamespace(root.id, rootPath: rootPath);
+    final hasHook = await vm.hasPostCheckoutHook(rootPath);
     if (!mounted) return;
     await showWorktreeCreateDialog(
       context,
       rootName: _gitOpLabel(root, rootPath),
       namespace: namespace,
-      onCreate: (name) async {
-        final res = await vm.createWorktree(root.id, name, rootPath: rootPath);
-        return res.fold((_) => null, (e) => e.message);
-      },
+      hasPostCheckout: hasHook,
+      onCreate: (name) =>
+          vm.createWorktree(root.id, name, rootPath: rootPath),
     );
   }
 

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -1980,79 +1980,93 @@ class CockpitViewModel extends ChangeNotifier {
     _saveTimers.remove(id)?.cancel();
   }
 
-  /// Cria uma worktree [name] no workspace [rootId] (decisões 2, 3, 14, 15). Em
-  /// sucesso, reconcilia, **auto-seleciona** o fork (pane vazia) e o devolve; em
-  /// falha, devolve o erro do git pra mostrar inline no dialog (decisão 21).
-  Future<Result<Project, WorktreeOpError>> createWorktree(
+  /// Cria uma worktree [name] no workspace [rootId] (decisoes 2, 3, 14, 15).
+  /// Devolve o handle ao vivo imediatamente; em sucesso (quando
+  /// [WorktreeAddRun.result] completa), reconcilia, **auto-seleciona** o fork
+  /// e o devolve; em falha, o erro do git vai pro dialog (decisao 21).
+  WorktreeAddRun<Project> createWorktree(
     String rootId,
     String name, {
     String? rootPath,
     String? baseRef,
     String? layoutSourceId,
-  }) async {
+  }) {
     final root = _projectById(rootId);
     if (root == null) {
-      return const Failure(WorktreeOpError('Workspace not found.'));
+      return WorktreeAddRun<Project>(
+        output: Stream.value('Workspace not found.'),
+        result: Future.value(
+          const Failure(WorktreeOpError('Workspace not found.')),
+        ),
+      );
     }
-    // Multi-root: o `git worktree add` parte da root escolhida, não da mãe.
+    // Multi-root: o `git worktree add` parte da root escolhida, nao da mae.
     // [baseRef] ("Fork Worktree"): ramifica da branch de outro fork, mas a
     // pasta nasce sempre no repo de origem.
-    final res = await _worktreeMgr.add(
+    final run = _worktreeMgr.add(
       rootPath ?? root.path,
       name,
       baseRef: baseRef,
     );
-    switch (res) {
-      case Failure(:final error):
-        return Failure<Project, WorktreeOpError>(error);
-      case Success(:final value):
-        // Clona a estrutura (panes/abas/posições) pro fork: do pai por padrão,
-        // ou do fork de origem no "Fork Worktree" (mesma organização, pasta
-        // nova, sessões do zero — ver _cloneLayoutForWorktree).
-        final clonedLayout = _cloneLayoutForWorktree(layoutSourceId ?? rootId);
-        await _refreshWorktrees(rootId); // insere o fork em _projectList
-        // Id de fork é namespaced pela raiz (ver _refreshWorktrees) — o path
-        // cru deixou de ser o id na migração dos Realms.
-        final fork = _projectById('$rootId::${value.path}');
-        if (fork == null) {
-          return const Failure(
-            WorktreeOpError(
-              'Worktree created, but did not appear in the list.',
-            ),
-          );
-        }
-        if (clonedLayout != null) {
-          // Vira o layout salvo do fork → _activateProject reconstrói a estrutura
-          // apontando pra fork.path. Persiste pra sobreviver a reload.
-          _savedLayouts[fork.id] = clonedLayout;
-          unawaited(_layoutStore.save(fork.id, clonedLayout));
-        }
-        selectProject(
-          fork.id,
-        ); // auto-select → activate → reconstrói a estrutura
-        // Orquestração: `*.ckp` com `autorun: worktree` na raiz do fork
-        // aplica o layout sozinho (worktree nasce vazia → determinístico).
-        unawaited(_autorunWorktreeLayout(fork.path));
-        return Success<Project, WorktreeOpError>(fork);
-    }
+    final result = run.result.then<Result<Project, WorktreeOpError>>((res) async {
+      switch (res) {
+        case Failure(:final error):
+          return Failure<Project, WorktreeOpError>(error);
+        case Success(:final value):
+          // Clona a estrutura (panes/abas/posicoes) pro fork: do pai por padrao,
+          // ou do fork de origem no "Fork Worktree" (mesma organizacao, pasta
+          // nova, sessoes do zero — ver _cloneLayoutForWorktree).
+          final clonedLayout = _cloneLayoutForWorktree(layoutSourceId ?? rootId);
+          await _refreshWorktrees(rootId); // insere o fork em _projectList
+          // Id de fork e namespaced pela raiz (ver _refreshWorktrees) — o path
+          // cru deixou de ser o id na migracao dos Realms.
+          final fork = _projectById('$rootId::${value.path}');
+          if (fork == null) {
+            return const Failure(
+              WorktreeOpError(
+                'Worktree created, but did not appear in the list.',
+              ),
+            );
+          }
+          if (clonedLayout != null) {
+            // Vira o layout salvo do fork → _activateProject reconstrucao.
+            // Persiste pra sobreviver a reload.
+            _savedLayouts[fork.id] = clonedLayout;
+            unawaited(_layoutStore.save(fork.id, clonedLayout));
+          }
+          selectProject(
+            fork.id,
+          ); // auto-select → activate → reconstrucao
+          // Orquestracao: `*.ckp` com `autorun: worktree` na raiz do fork
+          // aplica o layout sozinho (worktree nasce vazia → deterministico).
+          unawaited(_autorunWorktreeLayout(fork.path));
+          return Success<Project, WorktreeOpError>(fork);
+      }
+    });
+    return WorktreeAddRun<Project>(output: run.output, result: result);
   }
 
-  /// Branches locais + worktrees de [rootId], pra validação ao vivo do dialog
-  /// de criar (decisão 11).
   /// "Fork Worktree": cria uma worktree nova ramificada da **branch do fork**
   /// [forkId], materializada no repo de origem (nunca aninhada). O fork novo
-  /// entra como irmão na lista (mesmo pai), herdando o layout do fork base.
-  Future<Result<Project, WorktreeOpError>> forkWorktree(
-    String forkId,
-    String name,
-  ) async {
+  /// entra como irmao na lista (mesmo pai), herdando o layout do fork base.
+  WorktreeAddRun<Project> forkWorktree(String forkId, String name) {
     final fork = _projectById(forkId);
     if (fork == null || fork.parentId == null) {
-      return const Failure(WorktreeOpError('Worktree not found.'));
+      return WorktreeAddRun<Project>(
+        output: Stream.value('Worktree not found.'),
+        result: Future.value(
+          const Failure(WorktreeOpError('Worktree not found.')),
+        ),
+      );
     }
     final origin = _forkOriginPath(fork);
     if (origin == null) {
-      return const Failure(WorktreeOpError('Origin root not found.'));
+      return WorktreeAddRun<Project>(
+        output: Stream.value('Origin root not found.'),
+        result: Future.value(
+          const Failure(WorktreeOpError('Origin root not found.')),
+        ),
+      );
     }
     return createWorktree(
       fork.parentId!,
@@ -2063,7 +2077,19 @@ class CockpitViewModel extends ChangeNotifier {
     );
   }
 
-  /// Namespace pra validação do "Fork Worktree" — o do repo de origem do fork.
+  /// `true` se o repo em [repoPath] tem hook `post-checkout`.
+  Future<bool> hasPostCheckoutHook(String repoPath) =>
+      _worktreeMgr.hasPostCheckoutHook(repoPath);
+
+  /// `true` se o repo de origem do fork [forkId] tem hook `post-checkout`.
+  Future<bool> hasPostCheckoutHookForFork(String forkId) async {
+    final fork = _projectById(forkId);
+    final origin = fork == null ? null : _forkOriginPath(fork);
+    if (origin == null) return false;
+    return _worktreeMgr.hasPostCheckoutHook(origin);
+  }
+
+  /// Namespace pra validacao do "Fork Worktree" — o do repo de origem do fork.
   Future<WorktreeNamespace> forkWorktreeNamespace(String forkId) async {
     final fork = _projectById(forkId);
     final origin = fork == null ? null : _forkOriginPath(fork);

--- a/cockpit/lib/app/cockpit/ui/widgets/worktree_create_dialog.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/worktree_create_dialog.dart
@@ -1,22 +1,27 @@
+import 'dart:async';
+
 import 'package:cockpit/app/cockpit/domain/contracts/worktree_manager.dart';
+import 'package:cockpit/app/cockpit/domain/entities/project.dart';
 import 'package:cockpit/app/cockpit/domain/validators/worktree_name_validator.dart';
+import 'package:cockpit/app/core/domain/result.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/i18n/strings.g.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
 /// Dialog de criar worktree. Valida o nome **ao vivo** (decisões 10, 11) contra
 /// o [namespace] (branches locais + worktrees existentes); Criar só acende com
-/// nome válido. Ao confirmar, trava com spinner e chama [onCreate] (que roda o
-/// `git worktree add` real): se devolver uma mensagem de erro, mostra inline e
-/// reabre; `null` = sucesso → fecha (decisão 21).
+/// nome válido. Ao confirmar, mostra o stream do `git worktree add` (incluindo
+/// post-checkout, se houver): sucesso → fecha; falha → mantém logs + erro
+/// (decisão 21).
 Future<void> showWorktreeCreateDialog(
   BuildContext context, {
   required String rootName,
   required WorktreeNamespace namespace,
-  required Future<String?> Function(String name) onCreate,
+  required WorktreeAddRun<Project> Function(String name) onCreate,
   // "Fork Worktree": mesmo dialog, copy própria — a base é a branch do fork
   // ([rootName]), não o HEAD do pai.
   bool fork = false,
+  bool hasPostCheckout = false,
 }) {
   return showDialog<void>(
     context: context,
@@ -26,6 +31,7 @@ Future<void> showWorktreeCreateDialog(
       namespace: namespace,
       onCreate: onCreate,
       fork: fork,
+      hasPostCheckout: hasPostCheckout,
     ),
   );
 }
@@ -36,12 +42,14 @@ class _WorktreeCreateDialog extends StatefulWidget {
     required this.namespace,
     required this.onCreate,
     required this.fork,
+    required this.hasPostCheckout,
   });
 
   final String rootName;
   final bool fork;
+  final bool hasPostCheckout;
   final WorktreeNamespace namespace;
-  final Future<String?> Function(String name) onCreate;
+  final WorktreeAddRun<Project> Function(String name) onCreate;
 
   @override
   State<_WorktreeCreateDialog> createState() => _WorktreeCreateDialogState();
@@ -50,12 +58,17 @@ class _WorktreeCreateDialog extends StatefulWidget {
 class _WorktreeCreateDialogState extends State<_WorktreeCreateDialog> {
   static const _validator = WorktreeNameValidator();
   final TextEditingController _name = TextEditingController();
+  final ScrollController _logScroll = ScrollController();
+  final List<String> _logLines = [];
+  StreamSubscription<String>? _logSub;
   bool _submitting = false;
   String? _gitError; // erro do git no último submit
 
   @override
   void dispose() {
+    _logSub?.cancel();
     _name.dispose();
+    _logScroll.dispose();
     super.dispose();
   }
 
@@ -82,22 +95,48 @@ class _WorktreeCreateDialogState extends State<_WorktreeCreateDialog> {
     };
   }
 
+  void _autoScrollLog() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_logScroll.hasClients) return;
+      _logScroll.jumpTo(_logScroll.position.maxScrollExtent);
+    });
+  }
+
   Future<void> _submit() async {
     if (!_canCreate) return;
+    await _logSub?.cancel();
     setState(() {
       _submitting = true;
       _gitError = null;
+      _logLines.clear();
     });
-    final error = await widget.onCreate(_name.text);
+    final run = widget.onCreate(_name.text);
+    _logSub = run.output.listen(
+      (line) {
+        if (!mounted) return;
+        setState(() => _logLines.add(line));
+        _autoScrollLog();
+      },
+      onError: (Object e) {
+        if (!mounted) return;
+        setState(() => _logLines.add('$e'));
+        _autoScrollLog();
+      },
+    );
+    final res = await run.result;
     if (!mounted) return;
-    if (error == null) {
-      Navigator.of(context).pop();
-      return;
+    await _logSub?.cancel();
+    _logSub = null;
+    switch (res) {
+      case Success():
+        if (!mounted) return;
+        Navigator.of(context).pop();
+      case Failure(:final error):
+        setState(() {
+          _submitting = false;
+          _gitError = error.message;
+        });
     }
-    setState(() {
-      _submitting = false;
-      _gitError = error;
-    });
   }
 
   @override
@@ -105,8 +144,9 @@ class _WorktreeCreateDialogState extends State<_WorktreeCreateDialog> {
     final colors = context.colors;
     final check = _check;
     final reason = _gitError ?? _reason(check);
-    final showError = reason != null;
+    final showError = reason != null && !_submitting;
     final tr = context.t.cockpit.worktreeCreateDialog;
+    final showLog = _submitting || _logLines.isNotEmpty;
 
     return AlertDialog(
       title: Column(
@@ -130,7 +170,10 @@ class _WorktreeCreateDialogState extends State<_WorktreeCreateDialog> {
         ],
       ),
       content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 420),
+        constraints: BoxConstraints(
+          maxWidth: showLog ? 560 : 420,
+          maxHeight: showLog ? 420 : 200,
+        ),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -149,11 +192,60 @@ class _WorktreeCreateDialogState extends State<_WorktreeCreateDialog> {
               borderRadius: BorderRadius.circular(7),
               border: showError ? Border.all(color: colors.error) : null,
             ),
+
+            if (widget.hasPostCheckout) ...[
+              const SizedBox(height: 8),
+              Text(
+                tr.postCheckoutHint,
+                style: context.typo.label.copyWith(color: colors.text3),
+              ),
+            ],
             if (showError) ...[
               const SizedBox(height: 8),
               Text(
                 reason,
                 style: context.typo.label.copyWith(color: colors.error),
+              ),
+            ],
+            if (showLog) ...[
+              const SizedBox(height: 12),
+              if (_submitting)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const CircularProgressIndicator(size: 14),
+                      const SizedBox(width: 8),
+                      Text(
+                        tr.running,
+                        style: context.typo.label.copyWith(
+                          color: colors.text3,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              Container(
+                width: double.infinity,
+                height: 200,
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: colors.panel3,
+                  borderRadius: BorderRadius.circular(7),
+                  border: Border.all(color: colors.border),
+                ),
+                child: SingleChildScrollView(
+                  controller: _logScroll,
+                  child: SelectableText(
+                    _logLines.isEmpty ? ' ' : _logLines.join('\n'),
+                    style: context.typo.mono.copyWith(
+                      fontSize: 12,
+                      color: colors.text2,
+                    ),
+                  ),
+                ),
               ),
             ],
           ],

--- a/cockpit/lib/i18n/en.i18n.json
+++ b/cockpit/lib/i18n/en.i18n.json
@@ -124,7 +124,9 @@
       "errorReserved": "Reserved position (do not start with \"-\"/\".\" or end with \".lock\").",
       "errorDuplicateBranch": "A branch with that name already exists.",
       "errorDuplicateWorktree": "A worktree with that name already exists.",
-      "fork": "Fork"
+      "fork": "Fork",
+      "postCheckoutHint": "This repository has a post-checkout hook.",
+      "running": "Running…"
     },
     "subfolderDialog": {
       "title": "Where to work?",

--- a/cockpit/lib/i18n/es.i18n.json
+++ b/cockpit/lib/i18n/es.i18n.json
@@ -124,7 +124,9 @@
       "errorReserved": "Posición reservada (no empieces con \"-\"/\".\" ni termines con \".lock\").",
       "errorDuplicateBranch": "Ya existe una branch con ese nombre.",
       "errorDuplicateWorktree": "Ya existe un worktree con ese nombre.",
-      "fork": "Fork"
+      "fork": "Fork",
+      "postCheckoutHint": "Este repositorio tiene un hook post-checkout.",
+      "running": "Ejecutando…"
     },
     "subfolderDialog": {
       "title": "¿Dónde trabajar?",

--- a/cockpit/lib/i18n/pt_BR.i18n.json
+++ b/cockpit/lib/i18n/pt_BR.i18n.json
@@ -124,7 +124,9 @@
       "errorReserved": "Posição reservada (não comece com \"-\"/\".\" nem termine com \".lock\").",
       "errorDuplicateBranch": "Já existe um branch com esse nome.",
       "errorDuplicateWorktree": "Já existe uma worktree com esse nome.",
-      "fork": "Fork"
+      "fork": "Fork",
+      "postCheckoutHint": "Este repositório tem um hook post-checkout.",
+      "running": "Executando…"
     },
     "subfolderDialog": {
       "title": "Onde trabalhar?",

--- a/cockpit/lib/i18n/strings.g.dart
+++ b/cockpit/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 2223 (741 per locale)
+/// Strings: 2229 (743 per locale)
 ///
-/// Built on 2026-08-05 at 03:03 UTC
+/// Built on 2026-08-05 at 12:55 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/cockpit/lib/i18n/strings_en.g.dart
+++ b/cockpit/lib/i18n/strings_en.g.dart
@@ -540,6 +540,12 @@ class Translations$cockpit$worktreeCreateDialog$en {
 
 	/// en: 'Fork'
 	String get fork => 'Fork';
+
+	/// en: 'This repository has a post-checkout hook.'
+	String get postCheckoutHint => 'This repository has a post-checkout hook.';
+
+	/// en: 'Running…'
+	String get running => 'Running…';
 }
 
 // Path: cockpit.subfolderDialog
@@ -3026,6 +3032,8 @@ extension on Translations {
 			'cockpit.worktreeCreateDialog.errorDuplicateBranch' => 'A branch with that name already exists.',
 			'cockpit.worktreeCreateDialog.errorDuplicateWorktree' => 'A worktree with that name already exists.',
 			'cockpit.worktreeCreateDialog.fork' => 'Fork',
+			'cockpit.worktreeCreateDialog.postCheckoutHint' => 'This repository has a post-checkout hook.',
+			'cockpit.worktreeCreateDialog.running' => 'Running…',
 			'cockpit.subfolderDialog.title' => 'Where to work?',
 			'cockpit.subfolderDialog.empty' => 'No subfolders here.',
 			'cockpit.subfolderDialog.useRoot' => ({required Object project}) => 'Use the root of ${project}',
@@ -3434,10 +3442,10 @@ extension on Translations {
 			'settings.page.general.checkUpdatesDesc' => 'How often Cockpit should look for new versions.',
 			'settings.page.general.agentsInUseError' => 'Can\'t turn agents off while an agent tab is open. Close all agent tabs first, then disable it.',
 			'settings.page.general.updateFrequency.daily' => 'Daily',
-			'settings.page.general.updateFrequency.weekly' => 'Weekly',
-			'settings.page.general.updateFrequency.monthly' => 'Monthly',
 			_ => null,
 		} ?? switch (path) {
+			'settings.page.general.updateFrequency.weekly' => 'Weekly',
+			'settings.page.general.updateFrequency.monthly' => 'Monthly',
 			'settings.page.general.updateFrequency.never' => 'Never',
 			'settings.page.diagnostics.sectionTitle' => 'Diagnostics',
 			'settings.page.diagnostics.logFileTitle' => 'Log file',

--- a/cockpit/lib/i18n/strings_es.g.dart
+++ b/cockpit/lib/i18n/strings_es.g.dart
@@ -335,6 +335,8 @@ class _Translations$cockpit$worktreeCreateDialog$es extends Translations$cockpit
 	@override String get errorDuplicateBranch => 'Ya existe una branch con ese nombre.';
 	@override String get errorDuplicateWorktree => 'Ya existe un worktree con ese nombre.';
 	@override String get fork => 'Fork';
+	@override String get postCheckoutHint => 'Este repositorio tiene un hook post-checkout.';
+	@override String get running => 'Ejecutando…';
 }
 
 // Path: cockpit.subfolderDialog
@@ -1550,6 +1552,8 @@ extension on TranslationsEs {
 			'cockpit.worktreeCreateDialog.errorDuplicateBranch' => 'Ya existe una branch con ese nombre.',
 			'cockpit.worktreeCreateDialog.errorDuplicateWorktree' => 'Ya existe un worktree con ese nombre.',
 			'cockpit.worktreeCreateDialog.fork' => 'Fork',
+			'cockpit.worktreeCreateDialog.postCheckoutHint' => 'Este repositorio tiene un hook post-checkout.',
+			'cockpit.worktreeCreateDialog.running' => 'Ejecutando…',
 			'cockpit.subfolderDialog.title' => '¿Dónde trabajar?',
 			'cockpit.subfolderDialog.empty' => 'No hay subcarpetas aquí.',
 			'cockpit.subfolderDialog.useRoot' => ({required Object project}) => 'Usar la raíz de ${project}',
@@ -1958,10 +1962,10 @@ extension on TranslationsEs {
 			'settings.page.general.checkUpdatesDesc' => 'Con qué frecuencia Cockpit debe buscar nuevas versiones.',
 			'settings.page.general.agentsInUseError' => 'No se pueden desactivar los agentes mientras haya una pestaña de agente abierta. Cierra todas las pestañas de agente primero y luego desactívalo.',
 			'settings.page.general.updateFrequency.daily' => 'Diariamente',
-			'settings.page.general.updateFrequency.weekly' => 'Semanalmente',
-			'settings.page.general.updateFrequency.monthly' => 'Mensualmente',
 			_ => null,
 		} ?? switch (path) {
+			'settings.page.general.updateFrequency.weekly' => 'Semanalmente',
+			'settings.page.general.updateFrequency.monthly' => 'Mensualmente',
 			'settings.page.general.updateFrequency.never' => 'Nunca',
 			'settings.page.diagnostics.sectionTitle' => 'Diagnóstico',
 			'settings.page.diagnostics.logFileTitle' => 'Archivo de registro',

--- a/cockpit/lib/i18n/strings_pt_BR.g.dart
+++ b/cockpit/lib/i18n/strings_pt_BR.g.dart
@@ -335,6 +335,8 @@ class _Translations$cockpit$worktreeCreateDialog$pt_BR extends Translations$cock
 	@override String get errorDuplicateBranch => 'Já existe um branch com esse nome.';
 	@override String get errorDuplicateWorktree => 'Já existe uma worktree com esse nome.';
 	@override String get fork => 'Fork';
+	@override String get postCheckoutHint => 'Este repositório tem um hook post-checkout.';
+	@override String get running => 'Executando…';
 }
 
 // Path: cockpit.subfolderDialog
@@ -1550,6 +1552,8 @@ extension on TranslationsPtBr {
 			'cockpit.worktreeCreateDialog.errorDuplicateBranch' => 'Já existe um branch com esse nome.',
 			'cockpit.worktreeCreateDialog.errorDuplicateWorktree' => 'Já existe uma worktree com esse nome.',
 			'cockpit.worktreeCreateDialog.fork' => 'Fork',
+			'cockpit.worktreeCreateDialog.postCheckoutHint' => 'Este repositório tem um hook post-checkout.',
+			'cockpit.worktreeCreateDialog.running' => 'Executando…',
 			'cockpit.subfolderDialog.title' => 'Onde trabalhar?',
 			'cockpit.subfolderDialog.empty' => 'Nenhuma subpasta aqui.',
 			'cockpit.subfolderDialog.useRoot' => ({required Object project}) => 'Usar a raiz de ${project}',
@@ -1958,10 +1962,10 @@ extension on TranslationsPtBr {
 			'settings.page.general.checkUpdatesDesc' => 'Com que frequência o Cockpit deve procurar novas versões.',
 			'settings.page.general.agentsInUseError' => 'Não é possível desligar os agentes com uma aba de agente aberta. Feche todas as abas de agente primeiro e depois desative.',
 			'settings.page.general.updateFrequency.daily' => 'Diariamente',
-			'settings.page.general.updateFrequency.weekly' => 'Semanalmente',
-			'settings.page.general.updateFrequency.monthly' => 'Mensalmente',
 			_ => null,
 		} ?? switch (path) {
+			'settings.page.general.updateFrequency.weekly' => 'Semanalmente',
+			'settings.page.general.updateFrequency.monthly' => 'Mensalmente',
 			'settings.page.general.updateFrequency.never' => 'Nunca',
 			'settings.page.diagnostics.sectionTitle' => 'Diagnóstico',
 			'settings.page.diagnostics.logFileTitle' => 'Arquivo de log',

--- a/cockpit/test/data/worktree_manager_impl_test.dart
+++ b/cockpit/test/data/worktree_manager_impl_test.dart
@@ -23,6 +23,17 @@ void main() {
     }
   }
 
+  /// Aguarda o [WorktreeAddRun] e devolve o resultado (descarta o stream).
+  Future<Result<Worktree, WorktreeOpError>> addResult(
+    String name, {
+    String? baseRef,
+  }) {
+    final run = manager.add(repo.path, name, baseRef: baseRef);
+    // Drena o stream pra não vazar o controller.
+    run.output.drain<void>();
+    return run.result;
+  }
+
   setUp(() async {
     repo = await Directory.systemTemp.createTemp('cockpit_wt_test_');
     await git(['init']);
@@ -49,7 +60,7 @@ void main() {
     }
 
     // add: cria worktree aninhada + branch nova a partir do HEAD.
-    final added = await manager.add(repo.path, 'feat/sso');
+    final added = await addResult('feat/sso');
     expect(
       added.isSuccess,
       isTrue,
@@ -102,7 +113,7 @@ void main() {
       markTestSkipped('git não disponível no ambiente');
       return;
     }
-    final dup = await manager.add(repo.path, mainBranch);
+    final dup = await addResult(mainBranch);
     expect(dup.isFailure, isTrue);
     expect(
       (dup as Failure<Worktree, WorktreeOpError>).error.message,
@@ -126,7 +137,7 @@ void main() {
         markTestSkipped('git não disponível no ambiente');
         return;
       }
-      final added = await manager.add(repo.path, 'feat/x');
+      final added = await addResult('feat/x');
       final wt = (added as Success<Worktree, WorktreeOpError>).value;
 
       // Recém-criada do HEAD, sem commits → mergeada (tip alcançável do HEAD).
@@ -143,4 +154,56 @@ void main() {
       expect(await manager.isBranchMerged(repo.path, 'nao/existe'), isFalse);
     },
   );
+
+  test('hasPostCheckoutHook: false sem hook, true com arquivo', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível no ambiente');
+      return;
+    }
+    expect(await manager.hasPostCheckoutHook(repo.path), isFalse);
+
+    final hooksDir = (await git([
+      'rev-parse',
+      '--git-path',
+      'hooks',
+    ])).stdout.toString().trim();
+    final hookPath = hooksDir.startsWith('/')
+        ? '$hooksDir/post-checkout'
+        : '${repo.path}/$hooksDir/post-checkout';
+    await File(hookPath).writeAsString('#!/bin/sh\necho hook-ok\n');
+    // Não precisa ser executável pra detecção — só existência do arquivo.
+    expect(await manager.hasPostCheckoutHook(repo.path), isTrue);
+  });
+
+  test('add com post-checkout: stream contém saída do hook', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível no ambiente');
+      return;
+    }
+    final hooksDir = (await git([
+      'rev-parse',
+      '--git-path',
+      'hooks',
+    ])).stdout.toString().trim();
+    final hookPath = hooksDir.startsWith('/')
+        ? '$hooksDir/post-checkout'
+        : '${repo.path}/$hooksDir/post-checkout';
+    await File(hookPath).writeAsString(
+      '#!/bin/sh\necho post-checkout-marker\n',
+    );
+    await Process.run('chmod', ['+x', hookPath]);
+
+    final run = manager.add(repo.path, 'feat/hooked');
+    final lines = <String>[];
+    final sub = run.output.listen(lines.add);
+    final added = await run.result;
+    await sub.cancel();
+
+    expect(added.isSuccess, isTrue, reason: lines.join('\n'));
+    expect(
+      lines.any((l) => l.contains('post-checkout-marker')),
+      isTrue,
+      reason: 'stream should include hook stdout; got:\n${lines.join('\n')}',
+    );
+  });
 }


### PR DESCRIPTION
## Resumo
- Faz stream ao vivo de stdout/stderr do `git worktree add` no diálogo Criar worktree (incluindo hooks `post-checkout`), para hooks longos não travarem a UI só com spinner.
- Detecta um hook `post-checkout` via `git rev-parse --git-path hooks` e mostra um aviso curto antes de criar.

## Screenshots

<img width="551" height="480" alt="image" src="https://github.com/user-attachments/assets/99af6a97-29c8-47d6-9d8c-3c08467bf4e4" />

<img width="637" height="497" alt="image" src="https://github.com/user-attachments/assets/8ed8945b-8b9c-4588-81b5-2de09c6b06ac" />
