### PR TITLE
fix(cockpit): stabilize DevTools inspector and workspace teardown

### DIFF
--- a/cockpit/lib/app/app_widget.dart
+++ b/cockpit/lib/app/app_widget.dart
@@ -7,6 +7,7 @@ import 'package:cockpit/app/core/ui/menu/editor_menu_bridge.dart';
 import 'package:cockpit/app/core/ui/menu/menu_model.dart';
 import 'package:cockpit/app/core/ui/menu/workspace_menu_bridge.dart';
 import 'package:cockpit/app/core/ui/clamping_scroll_behavior.dart';
+import 'package:cockpit/app/core/ui/widgets/devtools_inspector.dart';
 import 'package:cockpit/app/core/ui/overlay/app_popover_handler.dart';
 import 'package:cockpit/app/core/ui/settings_controller.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
@@ -78,13 +79,15 @@ class AppRoot extends StatelessWidget {
           // barra de título do shell pelo [WindowMenuBar].
           child: AppMenuBar(
             menus: menus,
-            child: _AppZoom(
-              scale: uiScale,
-              child: CockpitTheme(
-                colors: tokens.colors,
-                typo: tokens.typo,
-                syntax: tokens.syntax,
-                child: child ?? const SizedBox(),
+            child: DevToolsInspector(
+              child: _AppZoom(
+                scale: uiScale,
+                child: CockpitTheme(
+                  colors: tokens.colors,
+                  typo: tokens.typo,
+                  syntax: tokens.syntax,
+                  child: child ?? const SizedBox(),
+                ),
               ),
             ),
           ),

--- a/cockpit/lib/app/bootstrapper.dart
+++ b/cockpit/lib/app/bootstrapper.dart
@@ -22,6 +22,7 @@ import 'package:cockpit/app/core/ui/settings_controller.dart';
 import 'package:cockpit/i18n/strings.g.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/bootstrap_error_view.dart';
+import 'package:cockpit/app/core/ui/widgets/devtools_inspector.dart';
 import 'package:cockpit/app/core/ui/widgets/error_report_dialog.dart';
 import 'package:cockpit/app/core/ui/widgets/loading_screen.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/confirm_dialog.dart';
@@ -310,7 +311,7 @@ class _CockpitBootstrapperState extends State<CockpitBootstrapper> {
           colors: tokens.colors,
           typo: tokens.typo,
           syntax: tokens.syntax,
-          child: child ?? const SizedBox(),
+          child: DevToolsInspector(child: child ?? const SizedBox()),
         );
       },
     );

--- a/cockpit/lib/app/core/ui/menu/workspace_menu_bridge.dart
+++ b/cockpit/lib/app/core/ui/menu/workspace_menu_bridge.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 
 /// Ponte **reativa** entre o shell e o menu **File** (New Agent / New Terminal).
 /// O `CockpitPage` publica se há um workspace ativo + os callbacks que abrem uma
@@ -88,6 +89,16 @@ class WorkspaceMenuBridge extends ChangeNotifier {
     _hasWorkspace = hasWorkspace;
     _agentTabsInUse = agentTabsInUse;
     _agentsAllowed = agentsAllowed;
-    notifyListeners();
+    // CockpitPage clears this bridge from dispose(), which runs while Flutter
+    // finalizes the route subtree. Notifying synchronously there asks AppRoot
+    // (an ancestor) to rebuild while the element tree is locked and produces
+    // the misleading _InactiveElements._unmount cascade. Match the editor
+    // bridge: publish state immediately, but defer the rebuild notification
+    // whenever Flutter is not idle.
+    if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle) {
+      notifyListeners();
+    } else {
+      SchedulerBinding.instance.addPostFrameCallback((_) => notifyListeners());
+    }
   }
 }

--- a/cockpit/lib/app/core/ui/widgets/devtools_inspector.dart
+++ b/cockpit/lib/app/core/ui/widgets/devtools_inspector.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart' as material;
+import 'package:flutter/widgets.dart';
+
+/// Flutter's [WidgetsApp] supports DevTools' widget-selection mode, but its
+/// optional HUD builders are not exposed by shadcn_flutter's [ShadcnApp].
+/// This is the small adapter that keeps the framework inspector while
+/// supplying the same three controls that [MaterialApp] supplies.
+class DevToolsInspector extends StatelessWidget {
+  const DevToolsInspector({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // Keep the inspector graph inside an assert, like WidgetsApp does. Asserts
+    // are disabled in profile/release, so those builds return only [child] and
+    // do not retain the DevTools listenable or WidgetInspector.
+    Widget result = child;
+    assert(() {
+      result = ValueListenableBuilder<bool>(
+        valueListenable:
+            WidgetsBinding.instance.debugShowWidgetInspectorOverrideNotifier,
+        builder: (context, enabled, child) {
+          if (!enabled) return child!;
+          return WidgetInspector(
+            exitWidgetSelectionButtonBuilder: _buildExitButton,
+            moveExitWidgetSelectionButtonBuilder: _buildMoveButton,
+            tapBehaviorButtonBuilder: _buildTapBehaviorButton,
+            child: child!,
+          );
+        },
+        child: result,
+      );
+      return true;
+    }());
+    return result;
+  }
+
+  Widget _buildExitButton(
+    BuildContext context, {
+    required VoidCallback onPressed,
+    required String semanticsLabel,
+    required GlobalKey key,
+  }) {
+    return _InspectorButton(
+      key: key,
+      icon: material.Icons.close,
+      onPressed: onPressed,
+      semanticsLabel: semanticsLabel,
+      variant: _InspectorButtonVariant.filled,
+    );
+  }
+
+  Widget _buildMoveButton(
+    BuildContext context, {
+    required VoidCallback onPressed,
+    required String semanticsLabel,
+    bool usesDefaultAlignment = true,
+  }) {
+    return _InspectorButton(
+      icon: usesDefaultAlignment
+          ? material.Icons.arrow_right
+          : material.Icons.arrow_left,
+      onPressed: onPressed,
+      semanticsLabel: semanticsLabel,
+      variant: _InspectorButtonVariant.iconOnly,
+    );
+  }
+
+  Widget _buildTapBehaviorButton(
+    BuildContext context, {
+    required VoidCallback onPressed,
+    required String semanticsLabel,
+    required bool selectionOnTapEnabled,
+  }) {
+    return _InspectorButton(
+      icon: const IconData(0x1F74A),
+      onPressed: onPressed,
+      semanticsLabel: semanticsLabel,
+      selectionOnTapEnabled: selectionOnTapEnabled,
+      variant: _InspectorButtonVariant.toggle,
+    );
+  }
+}
+
+enum _InspectorButtonVariant { filled, toggle, iconOnly }
+
+class _InspectorButton extends StatelessWidget {
+  const _InspectorButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    required this.semanticsLabel,
+    required this.variant,
+    this.selectionOnTapEnabled,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+  final String semanticsLabel;
+  final _InspectorButtonVariant variant;
+  final bool? selectionOnTapEnabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = material.Theme.of(context);
+    final dark = theme.brightness == Brightness.dark;
+    final primary = dark
+        ? theme.colorScheme.onPrimaryContainer
+        : theme.colorScheme.primaryContainer;
+    final secondary = dark
+        ? theme.colorScheme.primaryContainer
+        : theme.colorScheme.onPrimaryContainer;
+    final foreground = switch (variant) {
+      _InspectorButtonVariant.filled => primary,
+      _InspectorButtonVariant.iconOnly => secondary,
+      _InspectorButtonVariant.toggle =>
+        selectionOnTapEnabled! ? primary : secondary,
+    };
+    final background = switch (variant) {
+      _InspectorButtonVariant.filled => secondary,
+      _InspectorButtonVariant.iconOnly => material.Colors.transparent,
+      _InspectorButtonVariant.toggle =>
+        selectionOnTapEnabled! ? secondary : material.Colors.transparent,
+    };
+    final border =
+        variant == _InspectorButtonVariant.toggle && !selectionOnTapEnabled!
+        ? material.BorderSide(color: foreground)
+        : null;
+
+    // WidgetInspector already renders its own tooltip in the HUD. Supplying
+    // IconButton.tooltip here would create a second Tooltip that looks for an
+    // Overlay above this subtree; the inspector intentionally lives inside the
+    // ShadcnApp builder, below that app's Navigator/Overlay.
+    return material.IconButton(
+      onPressed: onPressed,
+      iconSize: 18,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints.tightFor(width: 32, height: 32),
+      style: material.IconButton.styleFrom(
+        foregroundColor: foreground,
+        backgroundColor: background,
+        side: border,
+        tapTargetSize: material.MaterialTapTargetSize.padded,
+      ),
+      icon: Icon(icon, semanticLabel: semanticsLabel),
+    );
+  }
+}

--- a/cockpit/lib/main.dart
+++ b/cockpit/lib/main.dart
@@ -18,6 +18,14 @@ import 'package:shadcn_flutter/shadcn_flutter.dart';
 Future<void> main() async {
   await runGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
+    // ShadcnApp delegates to WidgetsApp but does not expose the inspector HUD
+    // builders. Disable WidgetsApp's automatic inspector insertion so AppRoot
+    // can provide one manually with the same DevTools selection semantics and
+    // shadcn-compatible controls.
+    assert(() {
+      WidgetsBinding.instance.debugExcludeRootWidgetInspector = true;
+      return true;
+    }());
 
     // Versão primeiro: alimenta o log e os relatórios de issue.
     final version = await _resolveVersion();

--- a/cockpit/test/ui/devtools_inspector_test.dart
+++ b/cockpit/test/ui/devtools_inspector_test.dart
@@ -1,0 +1,74 @@
+import 'dart:ui' as ui;
+
+import 'package:cockpit/app/core/ui/widgets/devtools_inspector.dart';
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+void main() {
+  testWidgets('Select Widget mode toggles without Tooltip overlay errors', (
+    tester,
+  ) async {
+    final previousErrorHandler = FlutterError.onError;
+    final previousInspectorOverride =
+        WidgetsBinding.instance.debugShowWidgetInspectorOverride;
+    final previousExcludeRootInspector =
+        WidgetsBinding.instance.debugExcludeRootWidgetInspector;
+    final previousSelectionOnTap =
+        WidgetsBinding.instance.debugWidgetInspectorSelectionOnTapEnabled.value;
+    final errors = <FlutterErrorDetails>[];
+    FlutterError.onError = errors.add;
+    addTearDown(() {
+      WidgetsBinding.instance.debugShowWidgetInspectorOverride =
+          previousInspectorOverride;
+      WidgetsBinding.instance.debugExcludeRootWidgetInspector =
+          previousExcludeRootInspector;
+      WidgetsBinding.instance.debugWidgetInspectorSelectionOnTapEnabled.value =
+          previousSelectionOnTap;
+      FlutterError.onError = previousErrorHandler;
+    });
+
+    WidgetsBinding.instance.debugExcludeRootWidgetInspector = true;
+    WidgetsBinding.instance.debugShowWidgetInspectorOverride = false;
+    await tester.pumpWidget(
+      ShadcnApp(
+        theme: const ThemeData(),
+        home: const DevToolsInspector(
+          child: ColoredBox(color: Color(0xFF000000)),
+        ),
+      ),
+    );
+    expect(find.bySemanticsLabel('Exit Select Widget mode'), findsNothing);
+
+    WidgetsBinding.instance.debugShowWidgetInspectorOverride = true;
+    await tester.pump();
+
+    final exitButton = find.bySemanticsLabel('Exit Select Widget mode');
+    final tapModeButton = find.bySemanticsLabel(
+      'Change widget selection mode for taps',
+    );
+    expect(exitButton, findsOneWidget);
+    expect(tapModeButton, findsOneWidget);
+    expect(find.bySemanticsLabel('Move to the right'), findsOneWidget);
+    expect(find.byType(material.Tooltip), findsNothing);
+
+    final mouse = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    await mouse.addPointer(location: tester.getCenter(exitButton));
+    await tester.pump(const Duration(milliseconds: 200));
+    await mouse.removePointer();
+    await tester.pump();
+
+    final selectionOnTap =
+        WidgetsBinding.instance.debugWidgetInspectorSelectionOnTapEnabled;
+    final selectionOnTapBefore = selectionOnTap.value;
+    await tester.tap(tapModeButton);
+    await tester.pump();
+    expect(selectionOnTap.value, isNot(selectionOnTapBefore));
+
+    await tester.tap(exitButton);
+    await tester.pump();
+    expect(WidgetsBinding.instance.debugShowWidgetInspectorOverride, isFalse);
+    expect(find.bySemanticsLabel('Exit Select Widget mode'), findsNothing);
+    expect(errors, isEmpty);
+  });
+}

--- a/cockpit/test/ui/devtools_inspector_test.dart
+++ b/cockpit/test/ui/devtools_inspector_test.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui;
 
+import 'package:cockpit/app/core/ui/menu/workspace_menu_bridge.dart';
 import 'package:cockpit/app/core/ui/widgets/devtools_inspector.dart';
 import 'package:flutter/material.dart' as material;
 import 'package:flutter_test/flutter_test.dart';
@@ -52,6 +53,8 @@ void main() {
     expect(find.bySemanticsLabel('Move to the right'), findsOneWidget);
     expect(find.byType(material.Tooltip), findsNothing);
 
+    // Exercise the inspector's own HUD tooltip path. The buttons must not ask
+    // Material Tooltip for an Overlay because the inspector is below ShadcnApp.
     final mouse = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
     await mouse.addPointer(location: tester.getCenter(exitButton));
     await tester.pump(const Duration(milliseconds: 200));
@@ -71,4 +74,51 @@ void main() {
     expect(find.bySemanticsLabel('Exit Select Widget mode'), findsNothing);
     expect(errors, isEmpty);
   });
+
+  testWidgets('clearing the workspace menu during disposal is deferred', (
+    tester,
+  ) async {
+    final previous = FlutterError.onError;
+    final errors = <FlutterErrorDetails>[];
+    FlutterError.onError = errors.add;
+    addTearDown(() => FlutterError.onError = previous);
+
+    final bridge = WorkspaceMenuBridge();
+    bridge.setWorkspace(hasWorkspace: true);
+    await tester.pumpWidget(
+      ListenableBuilder(
+        listenable: bridge,
+        builder: (context, child) =>
+            _ClearBridgeOnDispose(bridge: bridge, child: child!),
+        child: const SizedBox(),
+      ),
+    );
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
+
+    expect(bridge.hasWorkspace, isFalse);
+    expect(errors, isEmpty);
+  });
+}
+
+class _ClearBridgeOnDispose extends StatefulWidget {
+  const _ClearBridgeOnDispose({required this.bridge, required this.child});
+
+  final WorkspaceMenuBridge bridge;
+  final Widget child;
+
+  @override
+  State<_ClearBridgeOnDispose> createState() => _ClearBridgeOnDisposeState();
+}
+
+class _ClearBridgeOnDisposeState extends State<_ClearBridgeOnDispose> {
+  @override
+  Widget build(BuildContext context) => widget.child;
+
+  @override
+  void dispose() {
+    widget.bridge.setWorkspace(hasWorkspace: false);
+    super.dispose();
+  }
 }


### PR DESCRIPTION
## Summary
- add a Shadcn-compatible DevTools widget inspector, guarded out of profile/release
- defer workspace-menu notifications during route teardown to avoid Flutter tree-lock errors

## Validation
- `flutter analyze`
- focused widget tests

> Local macOS Xcode signing changes are intentionally excluded.