### PR TITLE
fix(cockpit): prevent app crash when closing currently selected workspace

### DIFF
--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -2116,22 +2116,75 @@ class CockpitViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Pra onde a seleção vai quando o workspace [excluding] deixa de existir:
+  /// o primeiro workspace raiz do realm ativo que não seja ele, senão o
+  /// Cockpit (se ligado), senão `null` — rail vazio → `WelcomeView`.
+  String? _selectionAfterClosing(String excluding) {
+    for (final p in rootProjects) {
+      if (p.id != excluding) return p.id;
+    }
+    return cockpitWorkspace != null ? Project.cockpitId : null;
+  }
+
+  /// Fecha o workspace [id] (e as worktrees dele) — remove da lista local,
+  /// encerra os processos e apaga a persistência. **Não** deleta a pasta.
+  ///
+  /// Ordem obrigatória quando o workspace fechado é o que está na tela:
+  /// **primeiro sai dele, só depois destrói**. Fechar o workspace atual
+  /// crashava porque o runtime era encerrado (PTYs/agentes/controllers
+  /// `dispose()`) enquanto os panes dele ainda eram os pintados: o
+  /// `notifyListeners` só vinha depois de três `await` (persistência +
+  /// `_activateProject` do destino), e qualquer frame nesse intervalo — ou
+  /// qualquer rebuild disparado pelo próprio encerramento das sessões —
+  /// pintava terminais já descartados. Workspace não selecionado nunca
+  /// crashou porque o `IndexedStack` monta todos mas pinta só o ativo.
+  ///
+  /// Por isso: (1) troca a seleção e espera o destino subir; (2) bloco
+  /// **síncrono** que tira da lista + encerra o runtime + notifica, sem
+  /// `await` no meio (mesma invariante do [closeTab]); (3) persistência.
   Future<void> removeProject(String id) async {
-    // Encerra as worktrees do workspace junto (não deixa fork órfão).
+    if (_projectById(id) == null) return;
+    final selected = _selectedProjectId;
+    final leaving =
+        selected == id ||
+        (_worktrees[id] ?? const <Project>[]).any((f) => f.id == selected);
+
+    // (1) Sai do workspace antes de destruí-lo. Com o destino já ativo (ou
+    // `null` → WelcomeView, caso do único workspace aberto), a UI para de
+    // pintar os panes do que vai morrer.
+    if (leaving) {
+      final next = _selectionAfterClosing(id);
+      _selectedProjectId = next;
+      _clearFocusedNotification();
+      _requestPaneKeyboard();
+      git.watchProject(next);
+      notifyListeners();
+      if (next != null) {
+        await _activateProject(next); // reconstrói o destino (idempotente)
+        unawaited(git.refresh(next));
+        unawaited(_projects.saveLastSelected(realmCtrl.activeId, next));
+      }
+    }
+
+    // (2) Agora sim fecha — sem `await` até o notifyListeners.
     for (final fork in _worktrees.remove(id) ?? const <Project>[]) {
       _disposeProjectRuntime(fork.id);
       _projectList.removeWhere((p) => p.id == fork.id);
     }
     _disposeProjectRuntime(id);
     _projectList.removeWhere((p) => p.id == id);
-    if (_selectedProjectId == id || _projectById(_selectedProjectId) == null) {
-      _selectedProjectId = rootProjects.isEmpty ? null : rootProjects.first.id;
+    // Rede de segurança: seleção apontando pra algo que sumiu junto (ou que já
+    // não existia) cai no mesmo fallback.
+    if (_selectedProjectId != null &&
+        _projectById(_selectedProjectId) == null) {
+      _selectedProjectId = _selectionAfterClosing(id);
+      git.watchProject(_selectedProjectId);
     }
+    notifyListeners();
+
+    // (3) Persistência por último — não segura a troca de workspace.
     await _projects.remove(id);
     await _layoutStore.remove(id);
-    final next = _selectedProjectId;
-    if (next != null) await _activateProject(next);
-    notifyListeners();
   }
 
   /// Encerra o runtime de um projeto (árvore de panes + sessões + foco + caches),

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -82,6 +82,7 @@ import 'package:cockpit/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart';
 import 'package:cockpit/app/cockpit/ui/viewmodels/git_controller.dart';
 import 'package:cockpit/app/cockpit/ui/viewmodels/realm_controller.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:window_manager/window_manager.dart';
 
 /// Controlador do shell: projetos, árvore de splits **por projeto**, sessões de
@@ -1859,10 +1860,13 @@ class CockpitViewModel extends ChangeNotifier {
       notifyListeners();
       return;
     }
-    // OFF: encerra runtime (mata PTYs/sessões/timers) e remove o sintético.
+    // OFF: remove o sintético e encerra o runtime (mata PTYs/sessões/timers)
+    // — nessa ordem, e o runtime só depois do frame que desmonta os panes:
+    // liberar o terminal nativo com a view montada é SIGSEGV no libghostty
+    // (ver [removeProject]).
     final wasSelected = _selectedProjectId == Project.cockpitId;
-    _disposeProjectRuntime(Project.cockpitId);
     _projectList.removeWhere((p) => p.isSystemTerminal);
+    unawaited(_disposeRuntimeAfterFrame(Project.cockpitId));
     if (wasSelected) {
       final roots = rootProjects;
       _selectedProjectId = roots.isEmpty ? null : roots.first.id;
@@ -2126,32 +2130,56 @@ class CockpitViewModel extends ChangeNotifier {
     return cockpitWorkspace != null ? Project.cockpitId : null;
   }
 
+  /// Espera o fim do frame em que a UI aplica a última notificação — ou seja,
+  /// o frame que **desmonta** os panes de um workspace que saiu da lista.
+  ///
+  /// O timeout evita travar o fechamento se não houver frame agendado (janela
+  /// minimizada, app sem listeners): pior caso é voltar ao comportamento antigo.
+  Future<void> _endOfFrame() async {
+    try {
+      await SchedulerBinding.instance.endOfFrame.timeout(
+        const Duration(milliseconds: 500),
+      );
+    } on TimeoutException {
+      // Sem frame: segue o fechamento mesmo assim.
+    }
+  }
+
+  /// [_disposeProjectRuntime] adiado pro fim do frame — para call-sites
+  /// síncronos que acabaram de tirar o projeto da lista. Ver [removeProject].
+  Future<void> _disposeRuntimeAfterFrame(String id) async {
+    await _endOfFrame();
+    _disposeProjectRuntime(id);
+  }
+
   /// Fecha o workspace [id] (e as worktrees dele) — remove da lista local,
   /// encerra os processos e apaga a persistência. **Não** deleta a pasta.
   ///
-  /// Ordem obrigatória quando o workspace fechado é o que está na tela:
-  /// **primeiro sai dele, só depois destrói**. Fechar o workspace atual
-  /// crashava porque o runtime era encerrado (PTYs/agentes/controllers
-  /// `dispose()`) enquanto os panes dele ainda eram os pintados: o
-  /// `notifyListeners` só vinha depois de três `await` (persistência +
-  /// `_activateProject` do destino), e qualquer frame nesse intervalo — ou
-  /// qualquer rebuild disparado pelo próprio encerramento das sessões —
-  /// pintava terminais já descartados. Workspace não selecionado nunca
-  /// crashou porque o `IndexedStack` monta todos mas pinta só o ativo.
+  /// Ordem obrigatória: **sai → desmonta → destrói**. Fechar o workspace atual
+  /// crashava o app com `SIGSEGV` dentro do `libghostty`
+  /// (`ghostty_terminal_get*` na thread `io.flutter.ui`) — use-after-free do
+  /// handle nativo do terminal. O runtime era encerrado primeiro
+  /// (`_disposeProjectRuntime` → `TerminalSession.dispose` →
+  /// `GhosttyTerminalController.dispose` → libera o terminal nativo) com as
+  /// `TerminalView` do workspace **ainda montadas**: o layout/`detach()` do
+  /// frame seguinte tocava um ponteiro liberado. Não é exceção Dart — é
+  /// segfault, por isso não havia stack trace no console.
   ///
-  /// Por isso: (1) troca a seleção e espera o destino subir; (2) bloco
-  /// **síncrono** que tira da lista + encerra o runtime + notifica, sem
-  /// `await` no meio (mesma invariante do [closeTab]); (3) persistência.
+  /// Por isso:
+  /// 1. troca a seleção e espera o destino subir (o usuário sai do workspace
+  ///    antes de ele deixar de existir; sem destino → `WelcomeView`);
+  /// 2. tira da lista, notifica e **espera o frame**, pra Flutter desmontar as
+  ///    views enquanto os controllers ainda estão vivos (ordem que o `flterm`
+  ///    espera: `view.dispose()` → `detach()` → só depois `controller.dispose()`);
+  /// 3. só então encerra o runtime (mata `pi`/PTY e libera o Ghostty);
+  /// 4. persistência por último.
   Future<void> removeProject(String id) async {
     if (_projectById(id) == null) return;
     final selected = _selectedProjectId;
-    final leaving =
-        selected == id ||
-        (_worktrees[id] ?? const <Project>[]).any((f) => f.id == selected);
+    final forks = List<Project>.of(_worktrees[id] ?? const <Project>[]);
+    final leaving = selected == id || forks.any((f) => f.id == selected);
 
-    // (1) Sai do workspace antes de destruí-lo. Com o destino já ativo (ou
-    // `null` → WelcomeView, caso do único workspace aberto), a UI para de
-    // pintar os panes do que vai morrer.
+    // (1) Sai do workspace antes de destruí-lo.
     if (leaving) {
       final next = _selectionAfterClosing(id);
       _selectedProjectId = next;
@@ -2166,13 +2194,9 @@ class CockpitViewModel extends ChangeNotifier {
       }
     }
 
-    // (2) Agora sim fecha — sem `await` até o notifyListeners.
-    for (final fork in _worktrees.remove(id) ?? const <Project>[]) {
-      _disposeProjectRuntime(fork.id);
-      _projectList.removeWhere((p) => p.id == fork.id);
-    }
-    _disposeProjectRuntime(id);
-    _projectList.removeWhere((p) => p.id == id);
+    // (2) Some da UI — e espera o frame que desmonta os panes.
+    _worktrees.remove(id);
+    _projectList.removeWhere((p) => p.id == id || p.parentId == id);
     // Rede de segurança: seleção apontando pra algo que sumiu junto (ou que já
     // não existia) cai no mesmo fallback.
     if (_selectedProjectId != null &&
@@ -2181,8 +2205,16 @@ class CockpitViewModel extends ChangeNotifier {
       git.watchProject(_selectedProjectId);
     }
     notifyListeners();
+    await _endOfFrame();
 
-    // (3) Persistência por último — não segura a troca de workspace.
+    // (3) Nenhuma view referencia mais estas sessões — agora é seguro liberar
+    // os terminais nativos.
+    for (final fork in forks) {
+      _disposeProjectRuntime(fork.id);
+    }
+    _disposeProjectRuntime(id);
+
+    // (4) Persistência por último — não segura a troca de workspace.
     await _projects.remove(id);
     await _layoutStore.remove(id);
   }
@@ -4473,15 +4505,25 @@ class CockpitViewModel extends ChangeNotifier {
     final newIds = forks.map((f) => f.id).toSet();
     final oldIds = old.map((f) => f.id).toSet();
 
-    // Forks que sumiram → encerra runtime e tira de _projectList.
+    // Forks que sumiram → tira de _projectList, espera o frame que desmonta os
+    // panes e SÓ ENTÃO encerra o runtime. Mesma ordem de [removeProject]:
+    // liberar o terminal nativo com a `TerminalView` ainda montada é SIGSEGV
+    // dentro do libghostty.
     var switched = false;
-    for (final gone in old.where((f) => !newIds.contains(f.id))) {
-      _disposeProjectRuntime(gone.id);
-      _forkOrigin.remove(gone.id);
-      _projectList.removeWhere((p) => p.id == gone.id);
-      if (_selectedProjectId == gone.id) {
-        _selectedProjectId = rootId; // pai assume
-        switched = true;
+    final vanished = old.where((f) => !newIds.contains(f.id)).toList();
+    if (vanished.isNotEmpty) {
+      for (final gone in vanished) {
+        _forkOrigin.remove(gone.id);
+        _projectList.removeWhere((p) => p.id == gone.id);
+        if (_selectedProjectId == gone.id) {
+          _selectedProjectId = rootId; // pai assume
+          switched = true;
+        }
+      }
+      notifyListeners();
+      await _endOfFrame();
+      for (final gone in vanished) {
+        _disposeProjectRuntime(gone.id);
       }
     }
     // Forks novos → entram em _projectList + carregam layout salvo (decisão 18).


### PR DESCRIPTION
## Resumo
- Previne crash (`SIGSEGV` no `libghostty`) ao fechar o workspace selecionado ou quando worktrees ativas são removidas.
- Ajusta a ordem de desalocação em `removeProject`, `_disposeSystemTerminal` e `_syncForksFromProjectList`:
  1. Alterna a seleção para um workspace válido (ou fallback para a tela inicial `WelcomeView`).
  2. Notifica a UI e aguarda a conclusão do frame (`_endOfFrame`) para desmontar as `TerminalView`.
  3. Encerra o runtime (`_disposeProjectRuntime`) e libera os terminais nativos com a UI já desmontada.
  4. Executa a remoção na persistência por último.

## Contexto
Ao fechar o workspace atual, o runtime (`_disposeProjectRuntime` → `GhosttyTerminalController.dispose`) era liberado enquanto as `TerminalView` continuavam montadas na árvore do Flutter. No frame seguinte de layout/detach, o Flutter interagia com o ponteiro nativo liberado do terminal, gerando `SIGSEGV` (`ghostty_terminal_get*` na thread `io.flutter.ui`). Por ser um crash de memória nativa, a aplicação fechava sem stack trace no Dart.

## Validação
- `flutter analyze lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart` — 0 issues.
- `flutter test test/widget_test.dart` — passou.