### PR TITLE
fix(cockpit): permite scroll horizontal na barra de tabs com a roda do mouse

### DIFF
--- a/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
@@ -32,7 +32,8 @@ import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/hover_tap.dart';
 import 'package:cockpit/app/core/ui/settings_controller.dart';
 import 'package:desktop_drop/desktop_drop.dart';
-import 'package:flutter/gestures.dart' show HitTestResult;
+import 'package:flutter/gestures.dart'
+    show HitTestResult, PointerScrollEvent, PointerDeviceKind;
 import 'package:flutter/services.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:cockpit/app/core/ui/widgets/app_tooltip.dart';
@@ -323,20 +324,43 @@ class _TabStripState extends State<_TabStrip> {
               child: MouseRegion(
                 onEnter: (_) => _setHover(true),
                 onExit: (_) => _setHover(false),
-                child: Scrollbar(
-                  controller: _scroll,
-                  // Só aparece com o mouse em cima (e quando há overflow).
-                  thumbVisibility: _hovering && _overflowing,
-                  thickness: 3,
-                  radius: const Radius.circular(3),
-                  child: ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(
-                      context,
-                    ).copyWith(scrollbars: false),
-                    child: SingleChildScrollView(
-                      controller: _scroll,
-                      scrollDirection: Axis.horizontal,
-                      child: Row(
+                child: Listener(
+                  onPointerSignal: (pointerSignal) {
+                    if (pointerSignal is PointerScrollEvent && _scroll.hasClients) {
+                      final dy = pointerSignal.scrollDelta.dy;
+                      final dx = pointerSignal.scrollDelta.dx;
+                      final delta = (dx != 0) ? dx : dy;
+                      if (delta != 0) {
+                        final newOffset = (_scroll.offset + delta).clamp(
+                          0.0,
+                          _scroll.position.maxScrollExtent,
+                        );
+                        _scroll.jumpTo(newOffset);
+                      }
+                    }
+                  },
+                  child: Scrollbar(
+                    controller: _scroll,
+                    // Só aparece com o mouse em cima (e quando há overflow).
+                    thumbVisibility: _hovering && _overflowing,
+                    thickness: 3,
+                    radius: const Radius.circular(3),
+                    child: ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(
+                        context,
+                      ).copyWith(
+                        scrollbars: false,
+                        dragDevices: {
+                          PointerDeviceKind.touch,
+                          PointerDeviceKind.mouse,
+                          PointerDeviceKind.trackpad,
+                          PointerDeviceKind.stylus,
+                        },
+                      ),
+                      child: SingleChildScrollView(
+                        controller: _scroll,
+                        scrollDirection: Axis.horizontal,
+                        child: Row(
                         children: [
                           for (var i = 0; i < pane.tabs.length; i++)
                             _TabDropSlot(
@@ -386,6 +410,7 @@ class _TabStripState extends State<_TabStrip> {
                 ),
               ),
             ),
+          ),
             // Overflow: lista todas as abas pra pular direto (só quando estoura).
             if (_overflowing)
               Builder(

--- a/cockpit/test/ui/tab_strip_scrolling_test.dart
+++ b/cockpit/test/ui/tab_strip_scrolling_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Tab strip horizontal scrolling', () {
+    testWidgets('PointerScrollEvent dy translates to horizontal scroll offset', (
+      tester,
+    ) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              height: 40,
+              child: Listener(
+                onPointerSignal: (pointerSignal) {
+                  if (pointerSignal is PointerScrollEvent &&
+                      controller.hasClients) {
+                    final dy = pointerSignal.scrollDelta.dy;
+                    final dx = pointerSignal.scrollDelta.dx;
+                    final delta = (dx != 0) ? dx : dy;
+                    if (delta != 0) {
+                      final newOffset = (controller.offset + delta).clamp(
+                        0.0,
+                        controller.position.maxScrollExtent,
+                      );
+                      controller.jumpTo(newOffset);
+                    }
+                  }
+                },
+                child: SingleChildScrollView(
+                  controller: controller,
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: List.generate(
+                      10,
+                      (index) =>
+                          SizedBox(width: 100, child: Text('Tab $index')),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(controller.offset, 0.0);
+
+      final location = tester.getCenter(find.text('Tab 0'));
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: location,
+          scrollDelta: const Offset(0, 150),
+        ),
+      );
+      await tester.pump();
+
+      expect(controller.offset, 150.0);
+    });
+  });
+}


### PR DESCRIPTION
## Descrição

Corrige a navegação na linha de abas (tabs) no Cockpit quando há muitas tabs abertas (terminais ou agentes), permitindo rolar horizontalmente usando a roda do mouse (scroll vertical/horizontal) e gestos de trackpad/mouse drag.

### Mudanças efetuadas
- **`cockpit/lib/app/cockpit/ui/widgets/pane_view.dart`**:
  - Envolto o `_TabStrip` num `Listener` para capturar eventos `PointerScrollEvent`.
  - Converte o delta vertical (`dy`) da roda do mouse em incremento no offset horizontal do `ScrollController`.
  - Atualizado `ScrollConfiguration` para habilitar drag devices (`mouse`, `touch`, `trackpad`, `stylus`).
- **`cockpit/test/ui/tab_strip_scrolling_test.dart`**:
  - Adicionado teste de widget automatizado validando a conversão do sinal de scroll em offset horizontal.