### PR TITLE
feat: sync Pi session name to mobile titles

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -280,6 +280,47 @@ Detalhes em `plan/28-pi-commands.md`.
 
 ---
 
+## Nome de exibição da sessão Pi
+
+A identidade da sala e o título apresentado no app são campos distintos:
+
+- `room_meta.name`: nome estável do agente na mesh; participa da derivação de
+  `room_id = roomIdFor(cwd, name)` e nunca muda por causa de `/name`.
+- `room_meta.display_name`: nome mutável da conversa Pi (`/name`), usado apenas
+  para apresentação. String vazia significa “sem nome; usar os fallbacks”.
+
+A Pi-extension semeia ambos no `hello`:
+
+```jsonc
+{
+  "type": "hello",
+  "room_id": "<stable-id>",
+  "room_meta": {
+    "name": "backend",
+    "display_name": "Review payment retries",
+    "cwd": "/repo"
+  }
+}
+```
+
+Quando Pi emite `session_info_changed`, a extension envia somente metadata:
+
+```jsonc
+{
+  "type": "room_meta_update",
+  "room_id": "<same-stable-id>",
+  "meta": { "display_name": "Review refunds" }
+}
+```
+
+O relay preserva `name`, `cwd` e `room_id`, atualiza `display_name` e distribui
+`room_meta_updated` aos subscribers. Limpar `/name` envia
+`{"display_name":""}` para que o app reverta sem ambiguidade. A precedência no
+app é: **alias local > Pi `/name` > mesh agent name > cwd**. Apps/relays antigos
+ignoram o campo; rollout seguro: relay → app → pi-extension.
+
+---
+
 ## Imagens (plan/30)
 
 `user_message` aceita um anexo de imagem inline (uma por mensagem hoje),

--- a/app/lib/data/transport/connection_manager.dart
+++ b/app/lib/data/transport/connection_manager.dart
@@ -595,6 +595,7 @@ class ConnectionManager extends Service {
         :final peer,
         :final roomId,
         :final name,
+        :final sessionDisplayName,
         :final cwd,
         :final startedAt,
         :final model,
@@ -603,10 +604,11 @@ class ConnectionManager extends Service {
       ):
         final key = toStandardB64(peer);
         final list = _roomsByPeer[key] ?? <RoomInfo>[];
-        // Preserve any localName the user already set for this room
-        // (long-press rename) — only the live metadata comes from the
-        // wire, the rename is local-only.
-        String? preservedName;
+        // Preserve the mobile-only long-press alias. Live mesh/session names
+        // continue to refresh independently from wire metadata.
+        String? preservedLocalName;
+        String? preservedSessionDisplayName;
+        String? preservedAgentName;
         // Plan/28 Wave D — also preserve a previously-learned thinking
         // level when the announce frame omits it. Relays that don't
         // flatten `meta.thinking` will keep `thinking == null` here;
@@ -619,13 +621,18 @@ class ConnectionManager extends Service {
         var preservedWorking = false;
         final existingIdx = list.indexWhere((r) => r.roomId == roomId);
         if (existingIdx >= 0) {
-          preservedName = list[existingIdx].name;
+          preservedLocalName = list[existingIdx].localName;
+          preservedSessionDisplayName = list[existingIdx].sessionDisplayName;
+          preservedAgentName = list[existingIdx].name;
           preservedThinking = list[existingIdx].thinking;
           preservedWorking = list[existingIdx].working;
         }
         final next = RoomInfo(
           roomId: roomId,
-          name: preservedName ?? name,
+          name: name ?? preservedAgentName,
+          sessionDisplayName:
+              sessionDisplayName ?? preservedSessionDisplayName,
+          localName: preservedLocalName,
           cwd: cwd,
           startedAt: startedAt,
           model: model,
@@ -666,6 +673,8 @@ class ConnectionManager extends Service {
       case RoomMetaUpdated(
         :final peer,
         :final roomId,
+        :final sessionDisplayName,
+        :final hasSessionDisplayName,
         :final model,
         :final thinking,
         :final working,
@@ -684,6 +693,9 @@ class ConnectionManager extends Service {
         // (preserve previous value) from "field was explicitly null"
         // (overwrite with null). Without this, a thinking-only update
         // would clobber the previously cached model with null.
+        final nextSessionDisplayName = hasSessionDisplayName
+            ? sessionDisplayName
+            : current.sessionDisplayName;
         final nextModel = hasModel ? model : current.model;
         final nextThinking = hasThinking ? thinking : current.thinking;
         // Plan/32 — `working` is nullable-as-absent: null preserves the
@@ -691,12 +703,14 @@ class ConnectionManager extends Service {
         // non-null sets it. This is what carries the relay's
         // turn_start/turn_end broadcast to the Home dot for EVERY room.
         final nextWorking = working ?? current.working;
-        if (current.model == nextModel &&
+        if (current.sessionDisplayName == nextSessionDisplayName &&
+            current.model == nextModel &&
             current.thinking == nextThinking &&
             current.working == nextWorking) {
           break; // dedup: nothing actually changed
         }
         list[idx] = current.copyWith(
+          sessionDisplayName: nextSessionDisplayName,
           model: nextModel,
           thinking: nextThinking,
           working: nextWorking,
@@ -706,20 +720,25 @@ class ConnectionManager extends Service {
         _persistRoomsForPeer(key);
       case RoomsSnapshot(:final peer, :final rooms):
         final key = toStandardB64(peer);
-        // Merge snapshot into cache: add unknown rooms, refresh
-        // metadata (preserving local rename + previous model when
-        // the snapshot omits it), update live set.
+        // Merge snapshot into cache: add unknown rooms, refresh live metadata,
+        // preserve the mobile-only alias, and retain optional fields when a
+        // legacy relay omits them.
         final existing = _roomsByPeer[key] ?? <RoomInfo>[];
         final byId = {for (final r in existing) r.roomId: r};
         for (final r in rooms) {
-          final preservedName = byId[r.roomId]?.name ?? r.name;
-          final preservedModel = r.model ?? byId[r.roomId]?.model;
+          final previous = byId[r.roomId];
+          final preservedAgentName = r.name ?? previous?.name;
+          final preservedSessionDisplayName =
+              r.sessionDisplayName ?? previous?.sessionDisplayName;
+          final preservedModel = r.model ?? previous?.model;
           // Plan/28 Wave D — same convention as model: keep the
           // previously-known thinking when the snapshot omits it.
           final preservedThinking = r.thinking ?? byId[r.roomId]?.thinking;
           byId[r.roomId] = RoomInfo(
             roomId: r.roomId,
-            name: preservedName,
+            name: preservedAgentName,
+            sessionDisplayName: preservedSessionDisplayName,
+            localName: previous?.localName,
             cwd: r.cwd,
             startedAt: r.startedAt,
             model: preservedModel,
@@ -895,7 +914,9 @@ class ConnectionManager extends Service {
           .map(
             (c) => RoomInfo(
               roomId: c.roomId,
-              name: c.localName ?? c.name,
+              name: c.name,
+              sessionDisplayName: c.sessionDisplayName,
+              localName: c.localName,
               cwd: c.cwd,
               startedAt: c.startedAt,
               model: c.model,
@@ -921,23 +942,15 @@ class ConnectionManager extends Service {
     }
     if (match == null) return;
     final list = _roomsByPeer[peerKey] ?? const <RoomInfo>[];
-    // Read the current on-disk localNames so we don't drop the user's
-    // long-press rename when we re-persist in response to a wire
-    // metadata refresh.
-    final existing = await _storage.loadRooms(match.remoteEpk);
-    final localById = {
-      for (final p in existing)
-        if (p.localName != null && p.localName!.isNotEmpty)
-          p.roomId: p.localName!,
-    };
     final persisted = list
         .map(
           (r) => PersistedRoom(
             roomId: r.roomId,
             name: r.name,
+            sessionDisplayName: r.sessionDisplayName,
             cwd: r.cwd,
             startedAt: r.startedAt,
-            localName: localById[r.roomId],
+            localName: r.localName,
             model: r.model,
           ),
         )
@@ -954,18 +967,15 @@ class ConnectionManager extends Service {
     if (list == null) return;
     final idx = list.indexWhere((r) => r.roomId == roomId);
     if (idx < 0) return;
-    final old = list[idx];
-    // Use copyWith so EVERY field (model, cwd, startedAt, …) is
-    // preserved. The previous explicit constructor call dropped
-    // `model`, which made the tile subtitle fall back to
-    // "Last Paired: …" right after a rename — bug.
-    list[idx] = old.copyWith(
-      name: (name != null && name.isNotEmpty) ? name : old.name,
-    );
+    final normalizedName = name?.trim();
+    final localName = normalizedName == null || normalizedName.isEmpty
+        ? null
+        : normalizedName;
+    list[idx] = list[idx].copyWith(localName: localName);
     // Persist with localName so it survives cold start.
     final cached = await _storage.loadRooms(epk);
     final updated = cached
-        .map((c) => c.roomId == roomId ? c.copyWith(localName: name) : c)
+        .map((c) => c.roomId == roomId ? c.copyWith(localName: localName) : c)
         .toList();
     await _storage.saveRooms(epk, updated);
     if (!_roomsController.isClosed) {

--- a/app/lib/pairing/storage.dart
+++ b/app/lib/pairing/storage.dart
@@ -15,6 +15,9 @@ const _kRoomsService = 'dev.remotepi.rooms';
 class PersistedRoom {
   final String roomId;
   final String? name;
+  /// Last Pi `/name` received for this room. Presentation-only; it never
+  /// changes the room id or mesh agent identity.
+  final String? sessionDisplayName;
   final String? cwd;
   final int startedAt;
   /// Local-only override for [name]. When non-null, takes precedence
@@ -28,6 +31,7 @@ class PersistedRoom {
     required this.roomId,
     required this.startedAt,
     this.name,
+    this.sessionDisplayName,
     this.cwd,
     this.localName,
     this.model,
@@ -36,6 +40,7 @@ class PersistedRoom {
   Map<String, dynamic> toJson() => {
     'room_id': roomId,
     'name': name,
+    'display_name': sessionDisplayName,
     'cwd': cwd,
     'started_at': startedAt,
     'local_name': localName,
@@ -45,6 +50,7 @@ class PersistedRoom {
   factory PersistedRoom.fromJson(Map<String, dynamic> j) => PersistedRoom(
     roomId: j['room_id'] as String,
     name: j['name'] as String?,
+    sessionDisplayName: j['display_name'] as String?,
     cwd: j['cwd'] as String?,
     startedAt: (j['started_at'] as num).toInt(),
     localName: j['local_name'] as String?,
@@ -53,6 +59,7 @@ class PersistedRoom {
 
   PersistedRoom copyWith({
     String? name,
+    Object? sessionDisplayName = _unset,
     String? cwd,
     int? startedAt,
     Object? localName = _unset,
@@ -60,6 +67,9 @@ class PersistedRoom {
   }) => PersistedRoom(
     roomId: roomId,
     name: name ?? this.name,
+    sessionDisplayName: identical(sessionDisplayName, _unset)
+        ? this.sessionDisplayName
+        : sessionDisplayName as String?,
     cwd: cwd ?? this.cwd,
     startedAt: startedAt ?? this.startedAt,
     localName: identical(localName, _unset)

--- a/app/lib/protocol/protocol.dart
+++ b/app/lib/protocol/protocol.dart
@@ -33,6 +33,9 @@ sealed class ControlInbound {
         final metaJson = j['meta'] as Map<String, dynamic>?;
         final rawThinking =
             (j['thinking'] as String?) ?? (metaJson?['thinking'] as String?);
+        final sessionDisplayName =
+            (j['display_name'] as String?) ??
+            (metaJson?['display_name'] as String?);
         // Plan/32 — `working` arrives top-level (RoomMeta serializes flat)
         // or nested under `meta.working`; read both for forward-compat.
         final rawWorking =
@@ -41,6 +44,7 @@ sealed class ControlInbound {
           peer: j['peer'] as String,
           roomId: j['room_id'] as String,
           name: j['name'] as String?,
+          sessionDisplayName: sessionDisplayName,
           cwd: j['cwd'] as String?,
           startedAt: (j['started_at'] as num).toInt(),
           model: j['model'] as String?,
@@ -63,12 +67,15 @@ sealed class ControlInbound {
       ),
       'room_meta_updated' => () {
         final meta = j['meta'] as Map<String, dynamic>?;
+        final hasSessionDisplayName =
+            meta?.containsKey('display_name') ?? false;
         final hasModel = meta?.containsKey('model') ?? false;
         final hasThinking = meta?.containsKey('thinking') ?? false;
         final rawThinking = meta?['thinking'] as String?;
         return RoomMetaUpdated(
           peer: j['peer'] as String,
           roomId: j['room_id'] as String,
+          sessionDisplayName: meta?['display_name'] as String?,
           model: meta?['model'] as String?,
           thinking: rawThinking != null
               ? ThinkingLevel.fromWire(rawThinking)
@@ -77,6 +84,7 @@ sealed class ControlInbound {
           // cleared state), so a plain nullable bool models the patch:
           // null = absent (preserve current), true/false = set.
           working: meta?['working'] as bool?,
+          hasSessionDisplayName: hasSessionDisplayName,
           hasModel: hasModel,
           hasThinking: hasThinking,
         );
@@ -171,7 +179,19 @@ const Object _kRoomInfoUnset = Object();
 /// Snapshot of a single Pi room (one cwd / session).
 class RoomInfo {
   final String roomId;
+
+  /// Stable mesh agent name. This identifies the room but is not necessarily
+  /// the title the user assigned to the current Pi conversation.
   final String? name;
+
+  /// Pi's mutable `/name`, synchronized as presentation-only room metadata.
+  /// Empty/null means fall back to [name].
+  final String? sessionDisplayName;
+
+  /// Mobile-only override set by long-press rename. It has highest display
+  /// precedence and is never sent back to Pi or the relay.
+  final String? localName;
+
   final String? cwd;
   final int startedAt;
 
@@ -198,17 +218,31 @@ class RoomInfo {
     required this.roomId,
     required this.startedAt,
     this.name,
+    this.sessionDisplayName,
+    this.localName,
     this.cwd,
     this.model,
     this.thinking,
     this.working = false,
   });
 
+  /// Display precedence shared by Home and Chat. A mobile-local alias wins;
+  /// otherwise Pi's `/name` wins over the stable mesh agent name.
+  String? get preferredDisplayName {
+    for (final candidate in [localName, sessionDisplayName, name]) {
+      if (candidate != null && candidate.trim().isNotEmpty) {
+        return candidate.trim();
+      }
+    }
+    return null;
+  }
+
   factory RoomInfo.fromJson(Map<String, dynamic> j) {
     final rawThinking = j['thinking'] as String?;
     return RoomInfo(
       roomId: j['room_id'] as String,
       name: j['name'] as String?,
+      sessionDisplayName: j['display_name'] as String?,
       cwd: j['cwd'] as String?,
       startedAt: (j['started_at'] as num).toInt(),
       model: j['model'] as String?,
@@ -222,6 +256,7 @@ class RoomInfo {
   Map<String, dynamic> toJson() => {
     'room_id': roomId,
     'name': name,
+    'display_name': sessionDisplayName,
     'cwd': cwd,
     'started_at': startedAt,
     'model': model,
@@ -231,6 +266,8 @@ class RoomInfo {
 
   RoomInfo copyWith({
     String? name,
+    Object? sessionDisplayName = _kRoomInfoUnset,
+    Object? localName = _kRoomInfoUnset,
     String? cwd,
     int? startedAt,
     Object? model = _kRoomInfoUnset,
@@ -239,6 +276,12 @@ class RoomInfo {
   }) => RoomInfo(
     roomId: roomId,
     name: name ?? this.name,
+    sessionDisplayName: identical(sessionDisplayName, _kRoomInfoUnset)
+        ? this.sessionDisplayName
+        : sessionDisplayName as String?,
+    localName: identical(localName, _kRoomInfoUnset)
+        ? this.localName
+        : localName as String?,
     cwd: cwd ?? this.cwd,
     startedAt: startedAt ?? this.startedAt,
     model: identical(model, _kRoomInfoUnset) ? this.model : model as String?,
@@ -253,6 +296,8 @@ class RoomInfo {
       other is RoomInfo &&
       other.roomId == roomId &&
       other.name == name &&
+      other.sessionDisplayName == sessionDisplayName &&
+      other.localName == localName &&
       other.cwd == cwd &&
       other.startedAt == startedAt &&
       other.model == model &&
@@ -260,14 +305,24 @@ class RoomInfo {
       other.working == working;
 
   @override
-  int get hashCode =>
-      Object.hash(roomId, name, cwd, startedAt, model, thinking, working);
+  int get hashCode => Object.hash(
+    roomId,
+    name,
+    sessionDisplayName,
+    localName,
+    cwd,
+    startedAt,
+    model,
+    thinking,
+    working,
+  );
 }
 
 class RoomAnnounced extends ControlInbound {
   final String peer;
   final String roomId;
   final String? name;
+  final String? sessionDisplayName;
   final String? cwd;
   final int startedAt;
 
@@ -288,6 +343,7 @@ class RoomAnnounced extends ControlInbound {
     required this.roomId,
     required this.startedAt,
     this.name,
+    this.sessionDisplayName,
     this.cwd,
     this.model,
     this.thinking,
@@ -319,6 +375,13 @@ class RoomsSnapshot extends ControlInbound {
 class RoomMetaUpdated extends ControlInbound {
   final String peer;
   final String roomId;
+
+  /// Pi's mutable `/name`. Empty string explicitly clears it; absence is
+  /// represented by [hasSessionDisplayName] so unrelated metadata updates do
+  /// not clobber the cached title.
+  final String? sessionDisplayName;
+  final bool hasSessionDisplayName;
+
   final String? model;
 
   /// Plan/28 Wave D — current thinking level, parsed from
@@ -350,6 +413,8 @@ class RoomMetaUpdated extends ControlInbound {
   const RoomMetaUpdated({
     required this.peer,
     required this.roomId,
+    this.sessionDisplayName,
+    this.hasSessionDisplayName = false,
     this.model,
     this.thinking,
     this.working,

--- a/app/lib/ui/chat/chat_page.dart
+++ b/app/lib/ui/chat/chat_page.dart
@@ -329,7 +329,8 @@ class ChatPage extends StatelessWidget {
     String? initialTitle,
   ) {
     if (room != null) {
-      if (room.name != null && room.name!.isNotEmpty) return room.name!;
+      final preferred = room.preferredDisplayName;
+      if (preferred != null) return preferred;
       final cwd = room.cwd;
       if (cwd != null && cwd.isNotEmpty) {
         final segs = cwd.split('/').where((s) => s.isNotEmpty).toList();
@@ -342,7 +343,7 @@ class ChatPage extends StatelessWidget {
     // Plan/24-fix-title: Home knows the peer label before /chat
     // mounts; use it instead of the generic 'Remote Pi' placeholder
     // while we wait for the first room_meta_updated to populate
-    // `room.name`.
+    // room metadata.
     if (initialTitle != null && initialTitle.isNotEmpty) return initialTitle;
     return 'Remote Pi';
   }

--- a/app/lib/ui/home/home_page.dart
+++ b/app/lib/ui/home/home_page.dart
@@ -435,7 +435,7 @@ class HomePage extends StatelessWidget {
     HomeViewModel vm,
     HomeItem it,
   ) async {
-    final controller = TextEditingController(text: it.room.name ?? '');
+    final controller = TextEditingController(text: it.room.localName ?? '');
     final result = await showDialog<String?>(
       context: context,
       builder: (dCtx) {
@@ -561,21 +561,21 @@ class HomePage extends StatelessWidget {
   /// Plan/24-fix-title: the peer/room label we already know here, so the
   /// Chat AppBar doesn't show '—' / 'Remote Pi' until the ChatViewModel
   /// loads the PeerRecord + the first room_meta_updated arrives. Prefers
-  /// room.name (per-cwd title) → cwd tail → nickname → sessionName.
+  /// mobile alias → Pi `/name` → mesh agent name → cwd tail → pairing fallbacks.
   static String _titleFor(PeerRecord peer, RoomInfo room) {
     final roomCwdTail = room.cwd
         ?.split('/')
         .where((s) => s.isNotEmpty)
         .lastOrNull;
-    return (room.name?.isNotEmpty ?? false)
-        ? room.name!
-        : (roomCwdTail != null && roomCwdTail.isNotEmpty)
+    final preferred = room.preferredDisplayName;
+    return preferred ??
+        ((roomCwdTail != null && roomCwdTail.isNotEmpty)
         ? roomCwdTail
         : (peer.nickname?.isNotEmpty ?? false)
         ? peer.nickname!
         : peer.sessionName.isNotEmpty
         ? peer.sessionName
-        : peer.remoteEpk.substring(0, 8);
+        : peer.remoteEpk.substring(0, 8));
   }
 }
 

--- a/app/lib/ui/home/states/home_state.dart
+++ b/app/lib/ui/home/states/home_state.dart
@@ -33,10 +33,11 @@ class HomeItem {
 
   const HomeItem({required this.peer, required this.room});
 
-  /// Display name preference: explicit room.name → cwd basename →
-  /// `<peer-nickname>` → fallback session_name.
+  /// Display name preference: mobile alias → Pi `/name` → mesh agent name →
+  /// cwd basename → peer nickname → pairing fallback.
   String get displayName {
-    if (room.name != null && room.name!.isNotEmpty) return room.name!;
+    final preferred = room.preferredDisplayName;
+    if (preferred != null) return preferred;
     final cwd = room.cwd;
     if (cwd != null && cwd.isNotEmpty) {
       final last = cwd.split('/').where((s) => s.isNotEmpty).toList();
@@ -137,7 +138,8 @@ class HomeList extends HomeState {
   }
 
   static String _roomLabel(RoomInfo r) {
-    if (r.name != null && r.name!.isNotEmpty) return r.name!;
+    final preferred = r.preferredDisplayName;
+    if (preferred != null) return preferred;
     final cwd = r.cwd;
     if (cwd != null && cwd.isNotEmpty) {
       final segs = cwd.split('/').where((s) => s.isNotEmpty).toList();

--- a/app/lib/ui/home/widgets/session_tile.dart
+++ b/app/lib/ui/home/widgets/session_tile.dart
@@ -89,7 +89,8 @@ class SessionTile extends StatelessWidget {
   String _avatarName() {
     final r = room;
     if (r != null) {
-      if (r.name != null && r.name!.isNotEmpty) return r.name!;
+      final preferred = r.preferredDisplayName;
+      if (preferred != null) return preferred;
       final cwd = r.cwd;
       if (cwd != null && cwd.isNotEmpty) {
         final segs = cwd.split('/').where((s) => s.isNotEmpty).toList();
@@ -143,13 +144,14 @@ class _TitleBlock extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final r = room;
-    // Title preference: explicit room.name → cwd basename → peer
-    // nickname → session name. The cwd path line was dropped on purpose
+    // Title preference: mobile alias → Pi `/name` → mesh agent name → cwd
+    // basename → peer nickname → pairing fallback.
     // — the tile now shows just title + subtitle (model / paired date).
     final String title;
     if (r != null) {
-      if (r.name != null && r.name!.isNotEmpty) {
-        title = r.name!;
+      final preferred = r.preferredDisplayName;
+      if (preferred != null) {
+        title = preferred;
       } else if (r.cwd != null && r.cwd!.isNotEmpty) {
         final segs = r.cwd!.split('/').where((s) => s.isNotEmpty).toList();
         title = segs.isNotEmpty ? segs.last : r.cwd!;

--- a/app/test/pairing/storage_test.dart
+++ b/app/test/pairing/storage_test.dart
@@ -192,6 +192,20 @@ void main() {
       expect(preserved.harness!.version, '0.4.0');
     });
 
+    test('PersistedRoom keeps Pi session display name and mobile alias separate', () {
+      const room = PersistedRoom(
+        roomId: 'r1',
+        startedAt: 1,
+        name: 'mesh-agent',
+        sessionDisplayName: 'Review payments',
+        localName: 'Pinned alias',
+      );
+      final restored = PersistedRoom.fromJson(room.toJson());
+      expect(restored.name, 'mesh-agent');
+      expect(restored.sessionDisplayName, 'Review payments');
+      expect(restored.localName, 'Pinned alias');
+    });
+
     test('list/save/load round-trips through fake storage', () async {
       final storage = PairingStorage(_FakeSecureStorage());
       const r = PeerRecord(

--- a/app/test/protocol/rooms_protocol_test.dart
+++ b/app/test/protocol/rooms_protocol_test.dart
@@ -11,6 +11,7 @@ void main() {
         'peer': 'epk_A',
         'room_id': 'room-uuid-1',
         'name': 'work',
+        'display_name': 'Review authentication',
         'cwd': '/Users/jacob/projects/app',
         'started_at': 1700000000000,
       });
@@ -19,6 +20,7 @@ void main() {
       expect(r.peer, 'epk_A');
       expect(r.roomId, 'room-uuid-1');
       expect(r.name, 'work');
+      expect(r.sessionDisplayName, 'Review authentication');
       expect(r.cwd, '/Users/jacob/projects/app');
       expect(r.startedAt, 1700000000000);
     });
@@ -57,6 +59,7 @@ void main() {
           {
             'room_id': 'r1',
             'name': 'one',
+            'display_name': 'Implement payments',
             'cwd': '/one',
             'started_at': 1000,
           },
@@ -71,6 +74,7 @@ void main() {
       expect(r.peer, 'epk_A');
       expect(r.rooms, hasLength(2));
       expect(r.rooms[0].roomId, 'r1');
+      expect(r.rooms[0].sessionDisplayName, 'Implement payments');
       expect(r.rooms[0].cwd, '/one');
       expect(r.rooms[1].name, isNull);
       expect(r.rooms[1].cwd, isNull);
@@ -108,6 +112,20 @@ void main() {
       },
     );
 
+    test('room_meta_updated parses Pi session display name updates', () {
+      final c = ControlInbound.tryFromJson({
+        'type': 'room_meta_updated',
+        'peer': 'epk_A',
+        'room_id': 'r1',
+        'meta': {'display_name': 'Review payments'},
+      });
+      expect(c, isA<RoomMetaUpdated>());
+      final r = c! as RoomMetaUpdated;
+      expect(r.sessionDisplayName, 'Review payments');
+      expect(r.hasSessionDisplayName, isTrue);
+      expect(r.hasModel, isFalse);
+    });
+
     test(
       'room_meta_updated tolerates missing meta / model (clears value)',
       () {
@@ -126,11 +144,13 @@ void main() {
         roomId: 'r1',
         startedAt: 100,
         name: 'work',
+        sessionDisplayName: 'Review auth',
         cwd: '/x',
         model: 'claude-sonnet-4.5',
       );
       final back = RoomInfo.fromJson(r.toJson());
       expect(back, r);
+      expect(back.sessionDisplayName, 'Review auth');
       expect(back.model, 'claude-sonnet-4.5');
     });
 

--- a/app/test/transport/connection_manager_test.dart
+++ b/app/test/transport/connection_manager_test.dart
@@ -1367,6 +1367,119 @@ void _registerRoomsTests() {
     );
 
     test(
+      'Pi session display name updates without replacing a mobile-local alias',
+      () async {
+        final ch = _ControllableChannel();
+        final cm = ConnectionManager(
+          factory: (_, _) async => ch,
+          storage: _FakeStorage([_fakePeer()]),
+          emitDebounce: Duration.zero,
+        );
+        await cm.connectTo(_fakePeer());
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        ch.pushControl(const RoomAnnounced(
+          peer: 'epk_test',
+          roomId: 'r1',
+          name: 'mesh-agent',
+          sessionDisplayName: 'Initial task',
+          startedAt: 1,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        expect(
+          cm.roomsFor('epk_test').single.preferredDisplayName,
+          'Initial task',
+        );
+
+        await cm.setRoomLocalName('epk_test', 'r1', 'Pinned mobile alias');
+        ch.pushControl(const RoomMetaUpdated(
+          peer: 'epk_test',
+          roomId: 'r1',
+          sessionDisplayName: 'Review payments',
+          hasSessionDisplayName: true,
+          hasModel: false,
+          hasThinking: false,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+
+        final withAlias = cm.roomsFor('epk_test').single;
+        expect(withAlias.sessionDisplayName, 'Review payments');
+        expect(withAlias.localName, 'Pinned mobile alias');
+        expect(withAlias.preferredDisplayName, 'Pinned mobile alias');
+
+        await cm.setRoomLocalName('epk_test', 'r1', '');
+        final withoutAlias = cm.roomsFor('epk_test').single;
+        expect(withoutAlias.localName, isNull);
+        expect(withoutAlias.preferredDisplayName, 'Review payments');
+
+        ch.pushControl(const RoomMetaUpdated(
+          peer: 'epk_test',
+          roomId: 'r1',
+          sessionDisplayName: '',
+          hasSessionDisplayName: true,
+          hasModel: false,
+          hasThinking: false,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        final cleared = cm.roomsFor('epk_test').single;
+        expect(cleared.sessionDisplayName, '');
+        expect(cleared.name, 'mesh-agent');
+        expect(cleared.preferredDisplayName, 'mesh-agent');
+
+        cm.dispose();
+      },
+    );
+
+    test(
+      'room snapshots restore cached Pi names, tolerate legacy omission, and persist clear markers',
+      () async {
+        final ch = _ControllableChannel();
+        final storage = _FakeStorage([_fakePeer()]);
+        await storage.saveRooms('epk_test', const [
+          PersistedRoom(
+            roomId: 'r1',
+            startedAt: 1,
+            name: 'mesh-agent',
+            sessionDisplayName: 'Cached Pi name',
+          ),
+        ]);
+        final cm = ConnectionManager(
+          factory: (_, _) async => ch,
+          storage: storage,
+          emitDebounce: Duration.zero,
+        );
+        await cm.boot();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(cm.roomsFor('epk_test').single.preferredDisplayName, 'Cached Pi name');
+
+        // An old relay does not know display_name; absence must not destroy a
+        // cached value during a mixed-version rollout.
+        ch.pushControl(const RoomsSnapshot(peer: 'epk_test', rooms: [
+          RoomInfo(roomId: 'r1', startedAt: 1, name: 'mesh-agent'),
+        ]));
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        expect(cm.roomsFor('epk_test').single.sessionDisplayName, 'Cached Pi name');
+
+        // A new relay includes the empty string to reconcile an offline clear.
+        ch.pushControl(const RoomsSnapshot(peer: 'epk_test', rooms: [
+          RoomInfo(
+            roomId: 'r1',
+            startedAt: 1,
+            name: 'mesh-agent',
+            sessionDisplayName: '',
+          ),
+        ]));
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        final cleared = cm.roomsFor('epk_test').single;
+        expect(cleared.sessionDisplayName, '');
+        expect(cleared.preferredDisplayName, 'mesh-agent');
+        expect((await storage.loadRooms('epk_test')).single.sessionDisplayName, '');
+
+        cm.dispose();
+      },
+    );
+
+    test(
       'RoomMetaUpdated for unknown room is a no-op (no crash, no insert)',
       () async {
         final ch = _ControllableChannel();
@@ -1421,8 +1534,10 @@ void _registerRoomsTests() {
         await Future<void>.delayed(const Duration(milliseconds: 10));
 
         final after = cm.roomsFor('epk_test').single;
-        expect(after.name, 'meu-projeto',
-            reason: 'local name override applied');
+        expect(after.name, 'work', reason: 'mesh name remains stable');
+        expect(after.localName, 'meu-projeto',
+            reason: 'local name override applied separately');
+        expect(after.preferredDisplayName, 'meu-projeto');
         expect(after.model, 'claude-sonnet-4.5',
             reason: 'model must survive rename');
         expect(after.cwd, '/Users/jacob/projects/app',

--- a/app/test/ui/home/home_items_test.dart
+++ b/app/test/ui/home/home_items_test.dart
@@ -61,7 +61,7 @@ void main() {
       },
     );
 
-    test('HomeItem.displayName prefers room.name → cwd basename', () {
+    test('HomeItem.displayName prefers local alias → Pi `/name` → mesh name → cwd', () {
       final namedRoom = HomeItem(
         peer: _peer('A'),
         room: const RoomInfo(
@@ -72,6 +72,29 @@ void main() {
         ),
       );
       expect(namedRoom.displayName, 'project-alpha');
+
+      final sessionNamedRoom = HomeItem(
+        peer: _peer('A'),
+        room: const RoomInfo(
+          roomId: 'r1',
+          startedAt: 1,
+          name: 'mesh-agent',
+          sessionDisplayName: 'Review payments',
+        ),
+      );
+      expect(sessionNamedRoom.displayName, 'Review payments');
+
+      final locallyNamedRoom = HomeItem(
+        peer: _peer('A'),
+        room: const RoomInfo(
+          roomId: 'r1',
+          startedAt: 1,
+          name: 'mesh-agent',
+          sessionDisplayName: 'Review payments',
+          localName: 'Pinned alias',
+        ),
+      );
+      expect(locallyNamedRoom.displayName, 'Pinned alias');
 
       final cwdRoom = HomeItem(
         peer: _peer('A'),

--- a/pi-extension/README.md
+++ b/pi-extension/README.md
@@ -171,7 +171,7 @@ messages are unaffected.
 
 ## Install
 
-Requirements: Node 20+, Pi (the host coding agent).
+Requirements: Node 20+, Pi 0.80.3+ (the host coding agent).
 
 ```bash
 pi install npm:remote-pi
@@ -403,6 +403,12 @@ Useful commands:
 Name collisions inside a session get a numeric suffix automatically
 (`backend`, `backend#2`, `backend#3`). The broker assigns it and returns the
 real name to the peer.
+
+The mobile session title follows Pi's `/name` automatically. This is
+presentation-only: changing or clearing `/name` does not rename the mesh agent,
+change its address, or derive a new relay room. A mobile-local long-press alias
+still takes precedence over the synchronized Pi title. Use
+`/remote-pi rename` only when you actually intend to change mesh identity.
 
 ---
 

--- a/pi-extension/package.json
+++ b/pi-extension/package.json
@@ -76,8 +76,8 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.10",
-    "@earendil-works/pi-tui": "^0.79.10",
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
     "@noble/ed25519": "^3.1.0",

--- a/pi-extension/pnpm-lock.yaml
+++ b/pi-extension/pnpm-lock.yaml
@@ -16,11 +16,11 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.79.10
-        version: 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.3
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.79.10
-        version: 0.79.10
+        specifier: ^0.80.3
+        version: 0.80.10
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -181,22 +181,22 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@earendil-works/pi-agent-core@0.79.10':
-    resolution: {integrity: sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q==}
+  '@earendil-works/pi-agent-core@0.80.10':
+    resolution: {integrity: sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.79.10':
-    resolution: {integrity: sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.79.10':
-    resolution: {integrity: sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA==}
+  '@earendil-works/pi-ai@0.80.10':
+    resolution: {integrity: sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.79.10':
-    resolution: {integrity: sha512-FUVOjDn1DVwM1uHD5MNYboXQrXjIDbSt+BQ3py7nQWCY62tKfxgiM1OBMxTcwRWLfSdZHUPpV0hm1loIdUJnPw==}
+  '@earendil-works/pi-coding-agent@0.80.10':
+    resolution: {integrity: sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.80.10':
+    resolution: {integrity: sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.10.0':
@@ -1712,7 +1712,7 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.26.0
       '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -1891,9 +1891,9 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@earendil-works/pi-agent-core@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -1905,7 +1905,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -1926,11 +1926,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.10
+      '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.10
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -1956,7 +1956,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.79.10':
+  '@earendil-works/pi-tui@0.80.10':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -218,6 +218,7 @@ const {
   _hasPendingReconnect,
   _getMessageBufferForTest,
   _setCurrentModelForTest,
+  _setSessionDisplayNameForTest,
   _setPiForTest,
   _getCurrentTurnIdForTest,
   _getPendingSteerIdsForTest,
@@ -5679,7 +5680,7 @@ describe("cumulative buffer", () => {
 
 // ── model meta in room_meta + model_select hook ──────────────────────────────
 
-describe("model meta", () => {
+describe("room meta", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     _knownPeers.length = 0;
@@ -5694,6 +5695,7 @@ describe("model meta", () => {
     _defaultConnectImpl = async () => undefined;
     delete process.env["REMOTE_PI_RELAY"];
     _setCurrentModelForTest(undefined);
+    _setSessionDisplayNameForTest(undefined);
     const qr = await import("./pairing/qr.js");
     (qr.qrSession.consumeToken as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       (token: string) => {
@@ -5724,6 +5726,101 @@ describe("model meta", () => {
     expect(capturedOpts[0]!.roomMeta?.model).toBe("claude-sonnet-4.5");
     expect(capturedOpts[0]!.roomMeta?.name).toBeTruthy();
     expect(capturedOpts[0]!.roomMeta?.cwd).toBe("/tmp/remote-pi-model-test");
+  });
+
+  test("session_start seeds Pi `/name` into room_meta without changing the mesh name", async () => {
+    const cwd = "/tmp/remote-pi-session-display-name";
+    const capturedOpts: Array<{
+      roomId?: string;
+      roomMeta?: { name?: string; display_name?: string };
+    }> = [];
+    _defaultConnectImpl = async (opts?: unknown) => {
+      capturedOpts.push(opts as typeof capturedOpts[number]);
+    };
+
+    const onSessionStart = captureEventHandler("session_start");
+    onSessionStart(
+      { type: "session_start" },
+      {
+        ...makeMockCtx(cwd),
+        sessionManager: { getSessionName: () => "Implement auth flow" },
+      },
+    );
+
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx(cwd));
+
+    expect(capturedOpts).toHaveLength(1);
+    expect(capturedOpts[0]!.roomMeta?.display_name).toBe("Implement auth flow");
+    expect(capturedOpts[0]!.roomMeta?.name).not.toBe("Implement auth flow");
+    expect(capturedOpts[0]!.roomId).toMatch(/^[A-Za-z0-9_-]{12}$/);
+  });
+
+  test("session_info_changed publishes display_name updates and an empty clear", async () => {
+    captureHandler("remote-pi");
+    await _connectForTest(makeMockCtx("/tmp/remote-pi-session-display-update"));
+
+    const onSessionInfoChanged = captureEventHandler("session_info_changed");
+    onSessionInfoChanged({ type: "session_info_changed", name: "Review payments" });
+    onSessionInfoChanged({ type: "session_info_changed", name: undefined });
+
+    const updates = relayRef.current!.sendControl.mock.calls
+      .map((c) => c[0] as {
+        type: string;
+        room_id?: string;
+        meta?: { display_name?: string };
+      })
+      .filter((f) => f.type === "room_meta_update");
+    expect(updates).toHaveLength(2);
+    expect(updates.map((u) => u.meta?.display_name)).toEqual([
+      "Review payments",
+      "",
+    ]);
+    expect(updates.every((u) => /^[A-Za-z0-9_-]{12}$/.test(u.room_id ?? ""))).toBe(true);
+    expect(new Set(updates.map((u) => u.room_id)).size).toBe(1);
+    expect(relayRef.current!.connect).toHaveBeenCalledTimes(1);
+    expect(relayRef.current!.close).not.toHaveBeenCalled();
+  });
+
+  test("session_info_changed during the initial handshake is reconciled after connect", async () => {
+    let releaseConnect!: () => void;
+    const connectGate = new Promise<void>((resolve) => {
+      releaseConnect = resolve;
+    });
+    const capturedOpts: Array<{
+      roomId?: string;
+      roomMeta?: { display_name?: string };
+    }> = [];
+    _defaultConnectImpl = async (opts?: unknown) => {
+      capturedOpts.push(opts as typeof capturedOpts[number]);
+      await connectGate;
+    };
+
+    captureHandler("remote-pi");
+    const pendingConnect = _connectForTest(
+      makeMockCtx("/tmp/remote-pi-session-display-handshake"),
+    );
+    await vi.waitFor(() => expect(capturedOpts).toHaveLength(1));
+
+    const onSessionInfoChanged = captureEventHandler("session_info_changed");
+    onSessionInfoChanged({ type: "session_info_changed", name: "Handshake title" });
+    expect(capturedOpts[0]!.roomMeta?.display_name).toBe("");
+
+    releaseConnect();
+    await pendingConnect;
+
+    const updates = relayRef.current!.sendControl.mock.calls
+      .map((c) => c[0] as {
+        type: string;
+        room_id?: string;
+        meta?: { display_name?: string };
+      })
+      .filter((f) => f.type === "room_meta_update");
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.room_id).toBe(capturedOpts[0]!.roomId);
+    expect(updates[0]!.meta?.display_name).toBe("Handshake title");
+    expect(relayRef.current!.connect).toHaveBeenCalledTimes(1);
+    expect(relayRef.current!.close).not.toHaveBeenCalled();
   });
 
   test("hello carries `model` from getModel() when ctx.model is absent (daemon path)", async () => {
@@ -5897,7 +5994,15 @@ describe("model meta", () => {
   test("reconnect replays the same room_id + room_meta from _cmdStart (no phantom 'legacy session')", async () => {
     vi.useFakeTimers();
     try {
-      const capturedOpts: Array<{ roomId?: string; roomMeta?: { name?: string; cwd?: string; model?: string } }> = [];
+      const capturedOpts: Array<{
+        roomId?: string;
+        roomMeta?: {
+          name?: string;
+          cwd?: string;
+          display_name?: string;
+          model?: string;
+        };
+      }> = [];
       _defaultConnectImpl = async (opts?: unknown) => {
         capturedOpts.push(opts as typeof capturedOpts[number]);
       };
@@ -5915,8 +6020,15 @@ describe("model meta", () => {
       const initialRoomId = capturedOpts[0]!.roomId!;
       expect(capturedOpts[0]!.roomMeta?.model).toBe("claude-sonnet-4.5");
 
-      // Drop relay → reconnect path fires
+      // Drop relay, then rename while reconnect is only scheduled. The next
+      // hello carries the value, and a forced post-auth patch ensures existing
+      // subscribers see it even if the relay still has a half-open old socket.
       relayInstances[0]!.emit("close");
+      const onSessionInfoChanged = captureEventHandler("session_info_changed");
+      onSessionInfoChanged({
+        type: "session_info_changed",
+        name: "Changed while disconnected",
+      });
       await vi.advanceTimersByTimeAsync(1_000);
 
       // Second connect call must carry the same roomId + roomMeta (CRITICAL:
@@ -5925,7 +6037,59 @@ describe("model meta", () => {
       expect(capturedOpts).toHaveLength(2);
       expect(capturedOpts[1]!.roomId).toBe(initialRoomId);
       expect(capturedOpts[1]!.roomMeta?.cwd).toBe("/tmp/remote-pi-reconnect-room");
+      expect(capturedOpts[1]!.roomMeta?.display_name).toBe(
+        "Changed while disconnected",
+      );
       expect(capturedOpts[1]!.roomMeta?.model).toBe("claude-sonnet-4.5");
+      const reconnectUpdate = relayInstances[1]!.sendControl.mock.calls[0]![0] as {
+        meta?: { display_name?: string };
+      };
+      expect(reconnectUpdate.meta?.display_name).toBe(
+        "Changed while disconnected",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("session_info_changed during reconnect is reconciled without another reconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseReconnect!: () => void;
+      const reconnectGate = new Promise<void>((resolve) => {
+        releaseReconnect = resolve;
+      });
+      const capturedOpts: Array<{
+        roomId?: string;
+        roomMeta?: { display_name?: string };
+      }> = [];
+      _defaultConnectImpl = async (opts?: unknown) => {
+        capturedOpts.push(opts as typeof capturedOpts[number]);
+        if (capturedOpts.length === 2) await reconnectGate;
+      };
+
+      captureHandler("remote-pi");
+      await _connectForTest(makeMockCtx("/tmp/remote-pi-display-reconnect-race"));
+      relayInstances[0]!.emit("close");
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(capturedOpts).toHaveLength(2);
+
+      const onSessionInfoChanged = captureEventHandler("session_info_changed");
+      onSessionInfoChanged({ type: "session_info_changed", name: "Reconnect title" });
+      expect(capturedOpts[1]!.roomMeta?.display_name).toBe("");
+
+      releaseReconnect();
+      await vi.waitFor(() => {
+        expect(relayInstances[1]!.sendControl).toHaveBeenCalledTimes(1);
+      });
+      const update = relayInstances[1]!.sendControl.mock.calls[0]![0] as {
+        room_id?: string;
+        meta?: { display_name?: string };
+      };
+      expect(update.room_id).toBe(capturedOpts[0]!.roomId);
+      expect(update.meta?.display_name).toBe("Reconnect title");
+      expect(relayInstances).toHaveLength(2);
+      expect(relayInstances[1]!.close).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -68,7 +68,11 @@ import type {
   WireImage,
   QueuedMessageItem,
 } from "./protocol/types.js";
-import { RelayClient, RoomAlreadyOpenError } from "./transport/relay_client.js";
+import {
+  RelayClient,
+  RoomAlreadyOpenError,
+  type RoomMeta,
+} from "./transport/relay_client.js";
 import { PlainPeerChannel } from "./transport/peer_channel.js";
 import {
   createExtensionUiBridge,
@@ -225,7 +229,9 @@ let _myRoomId: string | null = null;   // this Pi's room id (derived from cwd)
 // open instead of starting null. The SDK fires `thinking_level_select`
 // on every change (initial load + user toggle), mirrored to room_meta
 // the same way model is — apps subscribe to one channel for both.
-let _myRoomMeta: { name: string; cwd: string; model?: string; thinking?: ThinkingLevel; working?: boolean } | null = null;
+let _myRoomMeta: RoomMeta | null = null;
+let _currentSessionDisplayName: string | undefined = undefined;
+let _sessionDisplayNameRevision = 0;
 let _currentModel: string | undefined = undefined;  // last-known model name
 let _currentThinking: ThinkingLevel | undefined = undefined;  // last-known thinking level
 
@@ -307,6 +313,47 @@ function _setCurrentModel(name: string): void {
   if (_relay && _myRoomId) {
     _relay.sendControl({ type: "room_meta_update", room_id: _myRoomId, meta: { model: name } });
   }
+}
+
+/**
+ * Publish Pi's mutable `/name` as presentation-only room metadata. The stable
+ * mesh `name` continues to key `roomIdFor(cwd, name)` and agent addresses; an
+ * empty display_name tells the app to fall back without re-keying the room.
+ */
+function _setSessionDisplayName(name: string | undefined): void {
+  const normalized = name?.trim() || undefined;
+  const changed = normalized !== _currentSessionDisplayName;
+  _currentSessionDisplayName = normalized;
+  if (_myRoomMeta) {
+    _myRoomMeta = { ..._myRoomMeta, display_name: normalized ?? "" };
+  }
+  if (!changed) return;
+
+  _sessionDisplayNameRevision += 1;
+  if (_relay && _myRoomId) {
+    _relay.sendControl({
+      type: "room_meta_update",
+      room_id: _myRoomId,
+      meta: { display_name: normalized ?? "" },
+    });
+  }
+}
+
+/** Publish the latest `/name` after connect when the hello may be stale.
+ * Reconnects can force the patch so subscribers are updated even if the relay
+ * still considers an overlapping old socket the room's announced instance. */
+function _reconcileSessionDisplayNameAfterConnect(
+  relay: RelayClient,
+  roomId: string,
+  revisionAtConnect: number,
+  force = false,
+): void {
+  if (!force && _sessionDisplayNameRevision === revisionAtConnect) return;
+  relay.sendControl({
+    type: "room_meta_update",
+    room_id: roomId,
+    meta: { display_name: _currentSessionDisplayName ?? "" },
+  });
 }
 
 /**
@@ -1049,6 +1096,12 @@ export function _setCurrentModelForTest(name: string | undefined): void {
   _currentModel = name;
 }
 
+/** Test-only: reset the cached Pi session display name (between tests). */
+export function _setSessionDisplayNameForTest(name: string | undefined): void {
+  _currentSessionDisplayName = name?.trim() || undefined;
+  _sessionDisplayNameRevision = 0;
+}
+
 /** Test-only: read the active turn id used for plain `cancel` routing. */
 export function _getCurrentTurnIdForTest(): string | null {
   return _currentTurnId;
@@ -1544,6 +1597,7 @@ async function _attemptReconnect(
   // _relayUrl is stored in canonical http(s):// form — convert at the
   // WS boundary, same as _cmdStart.
   const relay = new RelayClient(toWebSocketUrl(url), edKp);
+  const sessionDisplayNameRevisionAtConnect = _sessionDisplayNameRevision;
 
   try {
     // Replay the same room identity from _cmdStart. Without this the relay
@@ -1569,6 +1623,17 @@ async function _attemptReconnect(
 
   _relay = relay;
   _reconnectAttempt = 0;
+  if (_myRoomId) {
+    _reconcileSessionDisplayNameAfterConnect(
+      relay,
+      _myRoomId,
+      sessionDisplayNameRevisionAtConnect,
+      // A relay may still retain an overlapping half-open socket for this
+      // room. Force a post-auth patch so subscribers see the current title
+      // even when the reconnect hello is not announced as a new room.
+      true,
+    );
+  }
 
   relay.on("close", () => _onRelayClose(relay));
   _stopAutoListener = _installAutoListener(relay);
@@ -2137,6 +2202,12 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
     return undefined;
   });
 
+  // Pi `/name` is presentation metadata only. Keep mesh identity and room id
+  // stable while updating subscribed mobile clients in real time.
+  pi.on("session_info_changed", (event) => {
+    _setSessionDisplayName(event.name);
+  });
+
   // Track active model so the app can show it in the SessionTile (plano 18).
   // SDK fires model_select on settings load + every user switch. We cache the
   // friendly name and broadcast a room_meta_update so the relay can fan it
@@ -2340,6 +2411,8 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // bound to the current session.
   pi.on("session_start", (_event, ctx) => {
     _lastEventCtx = ctx;
+    const sessionManager = (ctx as Partial<ExtensionContext>).sessionManager;
+    _setSessionDisplayName(sessionManager?.getSessionName());
     // session_shutdown disposes per-session pi-ask subscriptions. A host that
     // reuses this module instance does NOT re-run the factory, so rebind the
     // bridge here; fresh-module hosts already created theirs in the factory.
@@ -2954,7 +3027,11 @@ async function _cmdStart(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<voi
     _currentThinking = _pi?.getThinkingLevel() as ThinkingLevel | undefined;
   } catch { /* defensive — never block /remote-pi start on this */ }
 
-  const roomMeta: { name: string; cwd: string; model?: string; thinking?: ThinkingLevel } = { name: sessionName, cwd };
+  const roomMeta: RoomMeta = {
+    name: sessionName,
+    cwd,
+    display_name: _currentSessionDisplayName ?? "",
+  };
   const modelName = _currentModelName();
   if (modelName) roomMeta.model = modelName;
   if (_currentThinking) roomMeta.thinking = _currentThinking;
@@ -2962,6 +3039,7 @@ async function _cmdStart(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<voi
   // this, reconnect issues a bare hello and the relay creates a "default room"
   // entry that surfaces in the app as a phantom legacy session.
   _myRoomMeta = roomMeta;
+  const sessionDisplayNameRevisionAtConnect = _sessionDisplayNameRevision;
 
   ctx.ui.notify(`[remote-pi] Connecting to relay ${relayUrl} (source: ${source}, room: ${roomId})…`, "info");
 
@@ -3003,6 +3081,11 @@ async function _cmdStart(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<voi
   _peerShort = myShort;
   _myRoomId = roomId;
   _state = "started";
+  _reconcileSessionDisplayNameAfterConnect(
+    relay,
+    roomId,
+    sessionDisplayNameRevisionAtConnect,
+  );
   // Set _sessionStartedAt ONLY on first /remote-pi start since process boot.
   // Subsequent start cycles (after stop) preserve the original epoch so the
   // app keeps treating it as the same session (and merges new events from

--- a/pi-extension/src/session/mesh_node.ts
+++ b/pi-extension/src/session/mesh_node.ts
@@ -391,7 +391,11 @@ export class MeshNode {
       try {
         await candidateRelay.connect({
           roomId,
-          roomMeta: { name: roomName, cwd: paramsAtStart.cwd! },
+          roomMeta: {
+            name: roomName,
+            cwd: paramsAtStart.cwd!,
+            display_name: "",
+          },
         });
       } catch (error) {
         this._closeOwnedRelay(candidateRelay);

--- a/pi-extension/src/transport/relay_client.ts
+++ b/pi-extension/src/transport/relay_client.ts
@@ -28,18 +28,29 @@ interface ChallengeMsg { type: "challenge"; nonce: string }
 interface AuthMsg { type: "auth"; sig: string }
 
 export interface RoomMeta {
+  /** Stable mesh identity. This still keys `roomIdFor(cwd, name)`. */
   name: string;
   cwd: string;
+  /** Pi's mutable `/name` value for display in the mobile app. Empty means
+   *  "fall back to the stable mesh name"; it never changes room identity. */
+  display_name: string;
   /** Friendly model name (e.g. "claude-sonnet-4.5"). Optional — pi-ext sends
    *  when `ExtensionContext.model` is available; relay/app tolerate absence. */
   model?: string;
+  thinking?: string;
+  working?: boolean;
 }
 
 /** Control frame sent to relay (not routed to app peer). */
 export interface RoomMetaUpdateFrame {
   type: "room_meta_update";
   room_id: string;
-  meta: { model?: string };
+  meta: {
+    display_name?: string;
+    model?: string;
+    thinking?: string;
+    working?: boolean;
+  };
 }
 
 export interface ConnectOptions {

--- a/plan/00-decisions.md
+++ b/plan/00-decisions.md
@@ -66,6 +66,7 @@ Numeração `00-` é proposital: este arquivo carrega antes dos planos numerados
 | ~~**Mobile pode ativar sessão histórica**~~ | ~~Não precisa o dev resumir no terminal. App envia `switch_session` e Pi process faz `AgentSessionRuntime.resume()`~~ (revertida 2026-05-18: sem switch_session no MVP) |
 | ~~**Rename em 3 níveis**~~ | ~~Peer no Keychain (local), Projeto em `~/.pi/remote/projects.json` (sincroniza p/ outros celulares pareados), Sessão no metadata JSONL (sincroniza bidirecionalmente com a CLI)~~ (revertida 2026-05-18) |
 | **Rename apenas do pareamento** | Local no Keychain/Keystore do mobile. Nome default = cwd onde o Pi rodou (ex: `remote_pi · feature/protocol`). Sem 3 níveis. |
+| **Pi Session `/name` como título automático** | O nome da conversa do Pi sincroniza como `room_meta.display_name`, separado do `agent_name` estável. Precedência no app: alias local > Pi `/name` > agent name > cwd. Renomear/limpar `/name` não muda mesh address nem `room_id`. Fechado 2026-08-11. |
 | **Trabalho paralelo** | Emerge da arquitetura: N Pi processes pareados = N sessões no app. App mostra todas com swipe entre elas |
 | **Switcher por gesto** | Recomendação UX: swipe da borda esquerda alterna entre últimos N pareamentos |
 

--- a/relay/src/handlers/peer.rs
+++ b/relay/src/handlers/peer.rs
@@ -98,6 +98,10 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
             .and_then(|m| m.get("cwd"))
             .and_then(|v| v.as_str())
             .map(String::from);
+        let display_name = room_meta_val
+            .and_then(|m| m.get("display_name"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
         let model = room_meta_val
             .and_then(|m| m.get("model"))
             .and_then(|v| v.as_str())
@@ -118,6 +122,7 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
             room_id,
             name,
             cwd,
+            display_name,
             model,
             thinking,
             working,
@@ -256,12 +261,13 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
                                 }
 
                                 // ── room meta update (plano 18 + 28 + 32) ──
-                                // `meta.model`, `meta.thinking` and
-                                // `meta.working` are patched independently: a
+                                // `meta.display_name`, `meta.model`,
+                                // `meta.thinking` and `meta.working` are patched independently: a
                                 // field absent from `meta` is *left alone* on
-                                // the room (not cleared). For the nullable
-                                // string fields, an explicit `null` clears
-                                // them. `working` is a plain bool, so it only
+                                // the room (not cleared). Empty `display_name`
+                                // clears the Pi title; explicit `null` clears
+                                // the nullable model/thinking fields.
+                                // `working` is a plain bool, so it only
                                 // ever toggles — a non-bool/absent value leaves
                                 // it untouched. Mirrors the JSON Merge Patch
                                 // shape clients already produce.
@@ -274,6 +280,10 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
                                     let meta_obj = frame
                                         .get("meta")
                                         .and_then(|v| v.as_object());
+                                    let display_name_patch = meta_obj
+                                        .and_then(|m| m.get("display_name"))
+                                        .and_then(|v| v.as_str())
+                                        .map(String::from);
                                     let model_patch = meta_obj
                                         .and_then(|m| m.get("model"))
                                         .map(|v| v.as_str().map(String::from));
@@ -284,6 +294,7 @@ async fn handle_peer(socket: WebSocket, peer_addr: SocketAddr, state: AppState) 
                                         .and_then(|m| m.get("working"))
                                         .and_then(|v| v.as_bool());
                                     let patch = RoomMetaPatch {
+                                        display_name: display_name_patch,
                                         model: model_patch,
                                         thinking: thinking_patch,
                                         working: working_patch,

--- a/relay/src/peers/registry.rs
+++ b/relay/src/peers/registry.rs
@@ -287,12 +287,15 @@ impl PeerRegistry {
         room_id: &str,
         patch: RoomMetaPatch,
     ) -> bool {
-        let (current_model, current_thinking, current_working) = {
+        let (current_display_name, current_model, current_thinking, current_working) = {
             let mut lock = self.senders.lock().unwrap();
             let key = (peer_id.to_string(), room_id.to_string());
             match lock.get_mut(&key) {
                 Some(v) if !v.is_empty() => {
                     for (_, meta, _) in v.iter_mut() {
+                        if let Some(ref display_name) = patch.display_name {
+                            meta.display_name = Some(display_name.clone());
+                        }
                         if let Some(ref m) = patch.model {
                             meta.model = m.clone();
                         }
@@ -307,6 +310,7 @@ impl PeerRegistry {
                     // now; read the first as the canonical snapshot.
                     let head = v.first().expect("v is non-empty");
                     (
+                        head.1.display_name.clone(),
                         head.1.model.clone(),
                         head.1.thinking.clone(),
                         head.1.working,
@@ -324,6 +328,12 @@ impl PeerRegistry {
         let room_subs = self.rooms.subscribers_of(peer_id).await;
         if !room_subs.is_empty() {
             let mut meta_obj = serde_json::Map::new();
+            if let Some(display_name) = current_display_name {
+                meta_obj.insert(
+                    "display_name".to_string(),
+                    serde_json::Value::String(display_name),
+                );
+            }
             if let Some(m) = &current_model {
                 meta_obj.insert("model".to_string(), serde_json::Value::String(m.clone()));
             }
@@ -397,6 +407,7 @@ mod tests {
             room_id: room_id.into(),
             name: None,
             cwd: None,
+            display_name: None,
             model: None,
             thinking: None,
             working: false,

--- a/relay/src/rooms.rs
+++ b/relay/src/rooms.rs
@@ -11,6 +11,10 @@ pub struct RoomMeta {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+    /// Pi's mutable session `/name`, used only as a mobile display label.
+    /// The stable `name` above remains the mesh identity and room-id input.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     /// Active Claude model for this room (plano 18). None = not reported yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -28,16 +32,15 @@ pub struct RoomMeta {
     pub started_at: i64,
 }
 
-/// Patch over the mutable `RoomMeta` fields. Each entry distinguishes
-/// "field absent in the update" (outer `None`, meaning "leave current") from
-/// "field present in the update" (outer `Some(_)`, whose inner `None` means
-/// "clear to null" and whose inner `Some(s)` means "set to s").
-///
-/// Built by the `room_meta_update` handler from the `meta` JSON object; the
-/// relay never inspects the inner values beyond JSON-shape (they're forwarded
-/// opaquely to subscribers).
+/// Patch over the mutable `RoomMeta` fields. `model` and `thinking` use nested
+/// options: outer `None` leaves the field unchanged, while inner `None` clears
+/// it to null. `display_name` uses an empty string as its explicit clear marker
+/// because the Pi Session name API represents an unset `/name` that way.
 #[derive(Debug, Default, Clone)]
 pub struct RoomMetaPatch {
+    /// Empty string explicitly clears the presentation label while keeping the
+    /// field present for subscribers; absence leaves the current value alone.
+    pub display_name: Option<String>,
     pub model: Option<Option<String>>,
     pub thinking: Option<Option<String>>,
     /// `working` is a non-nullable bool, so the patch is a single `Option`:
@@ -51,7 +54,10 @@ impl RoomMetaPatch {
     /// otherwise). Used by the registry to skip work when callers send empty
     /// `meta: {}`.
     pub fn is_empty(&self) -> bool {
-        self.model.is_none() && self.thinking.is_none() && self.working.is_none()
+        self.display_name.is_none()
+            && self.model.is_none()
+            && self.thinking.is_none()
+            && self.working.is_none()
     }
 }
 

--- a/relay/tests/pi_forward_test.rs
+++ b/relay/tests/pi_forward_test.rs
@@ -67,6 +67,7 @@ fn test_room_meta() -> RoomMeta {
         room_id: "main".to_string(),
         name: None,
         cwd: None,
+        display_name: None,
         model: None,
         thinking: None,
         working: false,

--- a/relay/tests/rooms_test.rs
+++ b/relay/tests/rooms_test.rs
@@ -270,7 +270,11 @@ async fn room_announced_includes_model_from_hello() {
                 "type": "hello",
                 "pubkey": B64.encode(vk.to_bytes()),
                 "room_id": "work",
-                "room_meta": {"name": "my-proj", "model": "claude-opus-4-7"},
+                "room_meta": {
+                    "name": "my-proj",
+                    "display_name": "Review authentication",
+                    "model": "claude-opus-4-7"
+                },
             })
             .to_string(),
         ))
@@ -305,6 +309,116 @@ async fn room_announced_includes_model_from_hello() {
         "model must be present in room_announced"
     );
     assert_eq!(v["name"], "my-proj");
+    assert_eq!(v["display_name"], "Review authentication");
+}
+
+/// A Pi `/name` change updates presentation metadata without changing the
+/// stable mesh name or room id.
+#[tokio::test]
+async fn room_meta_update_propagates_session_display_name() {
+    let port = start_relay().await;
+    let sk_pi = random_key();
+    use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+    let peer_pi = B64.encode(sk_pi.verifying_key().to_bytes());
+
+    let (mut ws_pi, _) = connect_and_auth_with_key(port, &sk_pi).await;
+    let (mut ws_app, _) = connect_and_auth(port).await;
+    ws_app
+        .send(Message::text(
+            json!({"type": "subscribe_rooms", "peers": [&peer_pi]}).to_string(),
+        ))
+        .await
+        .unwrap();
+    tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+
+    ws_pi
+        .send(Message::text(
+            json!({
+                "type": "room_meta_update",
+                "room_id": "main",
+                "meta": {"display_name": "Review payments"},
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+
+    let msg = tokio::time::timeout(tokio::time::Duration::from_secs(1), ws_app.next())
+        .await
+        .expect("timed out waiting for room_meta_updated")
+        .unwrap()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
+    assert_eq!(v["type"], "room_meta_updated");
+    assert_eq!(v["peer"], peer_pi);
+    assert_eq!(v["room_id"], "main");
+    assert_eq!(v["meta"]["display_name"], "Review payments");
+
+    ws_app
+        .send(Message::text(
+            json!({"type": "rooms_check", "peers": [&peer_pi]}).to_string(),
+        ))
+        .await
+        .unwrap();
+    let snapshot = tokio::time::timeout(tokio::time::Duration::from_secs(1), ws_app.next())
+        .await
+        .expect("timed out waiting for rooms snapshot")
+        .unwrap()
+        .unwrap();
+    let snapshot: serde_json::Value = serde_json::from_str(snapshot.to_text().unwrap()).unwrap();
+    assert_eq!(snapshot["rooms"][0]["room_id"], "main");
+    assert_eq!(snapshot["rooms"][0]["display_name"], "Review payments");
+
+    // Clearing `/name` is an explicit empty string, not an absent field. A
+    // newly connected phone must receive that marker in its initial snapshot
+    // rather than retaining an old cached title.
+    ws_pi
+        .send(Message::text(
+            json!({
+                "type": "room_meta_update",
+                "room_id": "main",
+                "meta": {"display_name": ""},
+            })
+            .to_string(),
+        ))
+        .await
+        .unwrap();
+    let cleared = tokio::time::timeout(tokio::time::Duration::from_secs(1), ws_app.next())
+        .await
+        .expect("timed out waiting for cleared room_meta_updated")
+        .unwrap()
+        .unwrap();
+    let cleared: serde_json::Value = serde_json::from_str(cleared.to_text().unwrap()).unwrap();
+    assert_eq!(cleared["room_id"], "main");
+    assert_eq!(cleared["meta"]["display_name"], "");
+
+    ws_app.close(None).await.unwrap();
+    let (mut ws_reconnected_app, _) = connect_and_auth(port).await;
+    ws_reconnected_app
+        .send(Message::text(
+            json!({"type": "subscribe_rooms", "peers": [&peer_pi]}).to_string(),
+        ))
+        .await
+        .unwrap();
+    ws_reconnected_app
+        .send(Message::text(
+            json!({"type": "rooms_check", "peers": [&peer_pi]}).to_string(),
+        ))
+        .await
+        .unwrap();
+    let reconnected_snapshot = tokio::time::timeout(
+        tokio::time::Duration::from_secs(1),
+        ws_reconnected_app.next(),
+    )
+    .await
+    .expect("timed out waiting for reconnect snapshot")
+    .unwrap()
+    .unwrap();
+    let reconnected_snapshot: serde_json::Value =
+        serde_json::from_str(reconnected_snapshot.to_text().unwrap()).unwrap();
+    assert_eq!(reconnected_snapshot["type"], "rooms");
+    assert_eq!(reconnected_snapshot["rooms"][0]["room_id"], "main");
+    assert_eq!(reconnected_snapshot["rooms"][0]["display_name"], "");
 }
 
 /// Pi sends room_meta_update → subscribers receive room_meta_updated with new model.


### PR DESCRIPTION
## Summary

- synchronize Pi Session `/name` to the mobile session title through a presentation-only `display_name` room metadata field
- keep mesh `agent_name`, mesh address, and `room_id` stable; title changes never invoke the rename/reconnect path
- persist and reconcile the title across relay snapshots, mobile cold starts, reconnects, and mixed-version rollouts
- keep mobile-local aliases highest priority: local alias > Pi `/name` > stable mesh name > cwd/pairing fallbacks

## Protocol and compatibility

The extension seeds `room_meta.display_name` in `hello` and publishes later changes with `room_meta_update`. An empty string is an explicit clear marker, allowing reconnecting clients to discard stale cached titles and fall back to the existing name.

Unknown fields are ignored by older components. The intended rollout order is relay → app → extension. The minimum Pi SDK dependency moves from `^0.79.10` to `^0.80.3`, where `session_info_changed` is available.

A post-auth metadata patch reconciles name changes that occur during initial/reconnect handshakes. Reconnects force this patch so existing subscribers are updated even if the relay temporarily retains an overlapping half-open room socket.

## Verification

- Pi extension: 802 passed, 3 skipped; typecheck and build passed
- Relay: full `cargo test`, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` passed
- Flutter app: 546 tests passed; `flutter analyze` reported no issues
- Added coverage for initialization, live rename, clear/fallback, stable room/no reconnect, local alias precedence, storage/cold cache, legacy field omission, reconnect snapshots, and initial/reconnect handshake races
