### PR TITLE
fix(pi-extension): clean up failed registration and release the broker path

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -4855,6 +4855,42 @@ describe("relay reconnect", () => {
     }
   });
 
+  test("a failed mesh join closes the candidate that may already own the broker", async () => {
+    // A candidate that loses the ack handshake can still have won the election
+    // and bound the broker socket. If _cmdJoin only notifies, that idle session
+    // keeps brokering the machine's mesh, so close must run on this path too.
+    const meshNodeModule = await import("./session/mesh_node.js");
+    const connectSpy = vi.spyOn(meshNodeModule.MeshNode.prototype, "connect")
+      .mockRejectedValue(new Error("register_ack timeout: broker never answered"));
+    const closeSpy = vi.spyOn(meshNodeModule.MeshNode.prototype, "close")
+      .mockResolvedValue(undefined);
+    const cwd = `/tmp/remote-pi-join-fail-${process.pid}-${Date.now()}`;
+    const ctx = makeMockCtx(cwd);
+
+    try {
+      process.env["REMOTE_PI_DIRECT_CONFIG"] = JSON.stringify({
+        agent_name: "join-fail",
+        auto_start_relay: false,
+      });
+      const root = captureHandler("remote-pi");
+      await root("", ctx);
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(_hasMeshNodeForTest()).toBe(false);
+      // The user is still told, so cleanup must not swallow the failure.
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("join failed"),
+        "error",
+      );
+    } finally {
+      delete process.env["REMOTE_PI_DIRECT_CONFIG"];
+      connectSpy.mockRestore();
+      closeSpy.mockRestore();
+      _resetCwdLockForTest();
+    }
+  });
+
   test("/remote-pi stop cancels delayed keypair resolve before any Relay side effect", async () => {
     const storage = await import("./pairing/storage.js");
     const getKeypair = vi.mocked(storage.getOrCreateEd25519Keypair);

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -4326,12 +4326,14 @@ async function _cmdJoin(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<void
     // again from `_cmdStart`).
     _attachBridgeIfReady();
   } catch (err) {
+    // Close on every failure path, not just the superseded one. A failed leader
+    // election leaves this MeshNode owning the broker socket, so skipping close
+    // would keep an idle session brokering the machine's mesh while it reports
+    // "join failed" to the user.
+    try { await peer.close(); } catch { /* best-effort */ }
     // A replacement/stop/newer join can invalidate this candidate before its
-    // failure arrives. Clean it up and never notify the outgoing session ctx.
-    if (!isCurrentCandidate()) {
-      try { await peer.close(); } catch { /* best-effort */ }
-      return;
-    }
+    // failure arrives; never notify the outgoing session ctx in that case.
+    if (!isCurrentCandidate()) return;
     ctx.ui.notify(`[remote-pi] join failed: ${String(err)}`, "error");
   }
 }

--- a/pi-extension/src/session/peer.leader.test.ts
+++ b/pi-extension/src/session/peer.leader.test.ts
@@ -1,0 +1,76 @@
+import { once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { ipcAddress } from "./ipc.js";
+// `vi.mock` is hoisted above these imports, so `peer.js` resolves the mocked
+// broker even though this import is static.
+import { SessionPeer } from "./peer.js";
+
+// A broker that answers every registration with a well-formed line that is not
+// a register_ack. The real Broker always acks correctly, so this is the only
+// way to drive the leader's self-registration into its failure branch.
+//
+// `close` mirrors the real Broker.close contract: destroy accepted peer sockets
+// first, then close the server. Without the destroy, the server stays open
+// waiting on the live loopback connection and never releases the path.
+vi.mock("./broker.js", () => ({
+  Broker: class {
+    private readonly server: Server;
+    private readonly accepted = new Set<Socket>();
+
+    constructor(opts: { server: Server }) {
+      this.server = opts.server;
+      this.server.on("connection", (sock: Socket) => {
+        this.accepted.add(sock);
+        sock.write(`${JSON.stringify({ type: "not_an_ack" })}\n`);
+      });
+    }
+
+    async close(): Promise<void> {
+      for (const sock of this.accepted) sock.destroy();
+      this.accepted.clear();
+      await new Promise<void>((resolve) => this.server.close(() => resolve()));
+    }
+  },
+}));
+
+describe("SessionPeer leader self-registration", () => {
+  test("a malformed ack releases the broker path instead of stranding it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-peer-leader-"));
+    const sockPath = ipcAddress(`peer-${basename(dir)}`, join(dir, "broker.sock"));
+
+    try {
+      // Nothing is listening, so election makes this peer the leader: it binds
+      // the path, constructs the broker, then registers back over a loopback
+      // connection. The mocked broker refuses that handshake.
+      const peer = new SessionPeer({ sockPath, name: "leader-with-broken-broker" });
+      const error = await peer.start().then(
+        () => null,
+        (reason: unknown) => reason,
+      );
+
+      expect.soft(error).toBeInstanceOf(Error);
+
+      // The contract under test: a leader that cannot register itself must not
+      // keep owning the path. If it does, every later session connects to a
+      // broker whose owner reports "join failed" and the mesh is stranded.
+      const replacement = createServer();
+      const rebound = await new Promise<boolean>((resolve) => {
+        replacement.once("error", () => resolve(false));
+        replacement.listen(sockPath, () => resolve(true));
+      });
+      if (replacement.listening) {
+        const closed = once(replacement, "close");
+        replacement.close();
+        await closed;
+      }
+
+      expect(rebound).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/pi-extension/src/session/peer.test.ts
+++ b/pi-extension/src/session/peer.test.ts
@@ -38,6 +38,11 @@ describe("SessionPeer registration", () => {
       const message = error instanceof Error ? error.message : String(error);
       expect.soft(message).toContain(sockPath);
       expect.soft(message).toContain("resume or terminate it, then rejoin");
+      // This process owns the unanswered listener, so the diagnosis must name
+      // it rather than leave the operator to search /proc for the blocker.
+      if (process.platform === "linux") {
+        expect.soft(message).toContain(`pid ${process.pid}`);
+      }
       expect.soft(sawClose).toBe(true);
     } finally {
       acceptedSocket?.destroy();

--- a/pi-extension/src/session/peer.test.ts
+++ b/pi-extension/src/session/peer.test.ts
@@ -37,7 +37,7 @@ describe("SessionPeer registration", () => {
       expect.soft(error).toBeInstanceOf(Error);
       const message = error instanceof Error ? error.message : String(error);
       expect.soft(message).toContain(sockPath);
-      expect.soft(message).toContain("may be suspended or its event loop may be blocked");
+      expect.soft(message).toContain("resume or terminate it, then rejoin");
       expect.soft(sawClose).toBe(true);
     } finally {
       acceptedSocket?.destroy();

--- a/pi-extension/src/session/peer.test.ts
+++ b/pi-extension/src/session/peer.test.ts
@@ -1,0 +1,52 @@
+import { once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, test } from "vitest";
+import { ipcAddress } from "./ipc.js";
+import { SessionPeer } from "./peer.js";
+
+describe("SessionPeer registration", () => {
+  test("destroys an unanswered registration socket after the timeout", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-peer-"));
+    const sockPath = ipcAddress(`peer-${basename(dir)}`, join(dir, "broker.sock"));
+    const server = createServer();
+    let acceptedSocket: Socket | null = null;
+    const connection = once(server, "connection");
+    const listening = once(server, "listening");
+    server.listen(sockPath);
+    await listening;
+
+    try {
+      const peer = new SessionPeer({ sockPath, name: "blocked-broker-client" });
+      const start = peer.start();
+      [acceptedSocket] = await connection as [Socket];
+      acceptedSocket.resume();
+      const socketClosed = once(acceptedSocket, "close");
+      const error = await start.then(
+        () => null,
+        (reason: unknown) => reason,
+      );
+      const sawClose = await Promise.race([
+        socketClosed.then(() => true),
+        delay(500).then(() => false),
+      ]);
+
+      expect.soft(error).toBeInstanceOf(Error);
+      const message = error instanceof Error ? error.message : String(error);
+      expect.soft(message).toContain(sockPath);
+      expect.soft(message).toContain("may be suspended or its event loop may be blocked");
+      expect.soft(sawClose).toBe(true);
+    } finally {
+      acceptedSocket?.destroy();
+      if (server.listening) {
+        const closed = once(server, "close");
+        server.close();
+        await closed;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/pi-extension/src/session/peer.test.ts
+++ b/pi-extension/src/session/peer.test.ts
@@ -37,7 +37,9 @@ describe("SessionPeer registration", () => {
       expect.soft(error).toBeInstanceOf(Error);
       const message = error instanceof Error ? error.message : String(error);
       expect.soft(message).toContain(sockPath);
-      expect.soft(message).toContain("resume or terminate it, then rejoin");
+      // Every branch closes with the same instruction; which advice precedes it
+      // depends on what the diagnosis could establish about the owner.
+      expect.soft(message).toContain("then rejoin.");
       // This process owns the unanswered listener, so the diagnosis must name
       // it rather than leave the operator to search /proc for the blocker.
       if (process.platform === "linux") {

--- a/pi-extension/src/session/peer.ts
+++ b/pi-extension/src/session/peer.ts
@@ -345,10 +345,27 @@ export class SessionPeer {
 
   private _registerOver(sock: Socket): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      // The first inbound line MUST be the register_ack. Buffer-aware.
-      const wait = setTimeout(() => reject(new Error("register_ack timeout")), 5_000);
-      const onceListener = (raw: unknown) => {
+      let settled = false;
+      const fail = (err: Error): void => {
+        if (settled) return;
+        settled = true;
         clearTimeout(wait);
+        this._preAckListener = null;
+        // Leader self-registration uses a separate client socket. Destroying it does not close the broker server.
+        // Clear the active socket first. This prevents the close handler from starting a new election after registration failed.
+        if (this.socket === sock) this.socket = null;
+        sock.destroy();
+        reject(err);
+      };
+      // The first inbound line MUST be the register_ack. Buffer-aware.
+      const wait = setTimeout(() => {
+        fail(new Error(
+          `register_ack timeout after ${ACK_TIMEOUT_MS}ms: a listener is bound to ${this.opts.sockPath} but did not answer the register handshake. `
+          + "The broker process may be suspended or its event loop may be blocked. "
+          + "AF_UNIX connect() succeeds as soon as the kernel queues the connection, so leader election cannot detect this by connectivity alone.",
+        ));
+      }, ACK_TIMEOUT_MS);
+      const onceListener = (raw: unknown) => {
         // plan/38: a new broker returns `address_assigned` (canonical key) +
         // `name_assigned` (clean leaf). Read both with cross-fallback so we work
         // against either a new broker OR a legacy one (only `name_assigned`,
@@ -357,12 +374,15 @@ export class SessionPeer {
         const name = typeof ack?.name_assigned === "string" ? ack.name_assigned : ack?.address_assigned;
         const address = typeof ack?.address_assigned === "string" ? ack.address_assigned : ack?.name_assigned;
         if (ack && ack.type === "register_ack" && typeof name === "string" && typeof address === "string") {
+          if (settled) return;
+          settled = true;
+          clearTimeout(wait);
           this.assignedName = name;
           this.assignedAddress = address;
           this._preAckListener = null;
           resolve(name);
         } else {
-          reject(new Error(`expected register_ack, got: ${JSON.stringify(raw)}`));
+          fail(new Error(`expected register_ack, got: ${JSON.stringify(raw)}`));
         }
       };
       this._preAckListener = onceListener;
@@ -378,8 +398,7 @@ export class SessionPeer {
       try {
         sock.write(req);
       } catch (e) {
-        clearTimeout(wait);
-        reject(e as Error);
+        fail(e as Error);
       }
     });
   }

--- a/pi-extension/src/session/peer.ts
+++ b/pi-extension/src/session/peer.ts
@@ -12,6 +12,7 @@ import {
 } from "./envelope.js";
 import { joinOrLead, type ElectionResult } from "./leader_election.js";
 import { Broker } from "./broker.js";
+import { describeRegistrationBlocker, describeSocketOwner } from "./socket_owner.js";
 
 /**
  * Symmetric peer-in-session API. Hides whether you are leader or follower;
@@ -366,19 +367,6 @@ export class SessionPeer {
   private _registerOver(sock: Socket): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       let settled = false;
-      const fail = (err: Error): void => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(wait);
-        this._preAckListener = null;
-        // Clear the active socket before destroying it, so the close handler does
-        // not read this as a live-connection drop and start a fresh election.
-        // On the leader path this is only the self-loopback client; the broker
-        // server belongs to _joinOrLead and is closed there when we throw.
-        if (this.socket === sock) this.socket = null;
-        sock.destroy();
-        reject(err);
-      };
       // The first inbound line MUST be the register_ack. Buffer-aware.
       //
       // Reaching this timer means election chose the follower path against a
@@ -387,15 +375,46 @@ export class SessionPeer {
       // AF_UNIX connect() completes as soon as the kernel queues the connection
       // in the listener backlog, so the owning process need not run at all; a
       // suspended or event-loop-blocked leader still looks healthy to election.
-      // Only the handshake separates the two, and nothing here can recover on
-      // its own, so the message must name the endpoint and the way to clear it.
+      //
+      // Nothing here can recover on its own, because the queued connection and
+      // the mesh both belong to that other process. Naming it saves the operator
+      // a manual walk of /proc, but diagnosis must never widen the leak this
+      // path exists to close: the deadline decides the outcome and frees the
+      // descriptor, and only the wording of the rejection is still pending. An
+      // ack arriving after that point is too late to be honoured.
+      //
+      // The deadline is installed before the helpers it calls. JavaScript runs
+      // this executor to completion before any timer callback, so `release` is
+      // always defined by the time the deadline can fire.
       const wait = setTimeout(() => {
-        fail(new Error(
-          `register_ack timeout after ${ACK_TIMEOUT_MS}ms: ${this.opts.sockPath} has a listener `
-          + "that never answered the register handshake. Its owning process is probably suspended "
-          + "or blocked; resume or terminate it, then rejoin.",
-        ));
+        if (settled) return;
+        settled = true;
+        release();
+        void describeSocketOwner(this.opts.sockPath).then((owner) => {
+          reject(new Error(
+            `register_ack timeout after ${ACK_TIMEOUT_MS}ms: `
+            + describeRegistrationBlocker(this.opts.sockPath, owner),
+          ));
+        });
       }, ACK_TIMEOUT_MS);
+      // Releasing is separate from rejecting because the timeout path needs the
+      // descriptor closed at the deadline while it still has a message to build.
+      const release = (): void => {
+        clearTimeout(wait);
+        this._preAckListener = null;
+        // Clear the active socket before destroying it, so the close handler does
+        // not read this as a live-connection drop and start a fresh election.
+        // On the leader path this is only the self-loopback client; the broker
+        // server belongs to _joinOrLead and is closed there when we throw.
+        if (this.socket === sock) this.socket = null;
+        sock.destroy();
+      };
+      const fail = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        release();
+        reject(err);
+      };
       const onceListener = (raw: unknown) => {
         // plan/38: a new broker returns `address_assigned` (canonical key) +
         // `name_assigned` (clean leaf). Read both with cross-fallback so we work

--- a/pi-extension/src/session/peer.ts
+++ b/pi-extension/src/session/peer.ts
@@ -307,15 +307,33 @@ export class SessionPeer {
     const result: ElectionResult = await joinOrLead(this.opts.sockPath);
     if (result.role === "leader") {
       this.role = "leader";
-      this.broker = new Broker({
+      const broker = new Broker({
         server: result.server,
         auditPath: this.opts.auditPath,
       });
+      this.broker = broker;
       // Leader also registers itself as a peer so other followers see it +
       // can address it. We create a self-loopback socket via the broker's
       // internal API: easiest is to open a real client connection back to
       // our own server.
-      return this._registerAsClient();
+      try {
+        return await this._registerAsClient();
+      } catch (err) {
+        // Self-registration failed, so this process cannot act as a peer even
+        // though it now owns the broker path. Release the path rather than hold
+        // it: leaving it bound strands every later joiner behind a broker whose
+        // owner simultaneously reports "join failed".
+        //
+        // The server accepts from the moment Broker is constructed, so a fast
+        // follower may already be attached. close() destroys those sockets, and
+        // a follower that is still joined reads the drop as a leader loss and
+        // re-runs election via _onSocketClose; one already leaving stays put.
+        // Either way it recovers, whereas a stranded path never does.
+        try { await broker.close(); } catch { /* best-effort */ }
+        this.broker = null;
+        this.role = "follower";
+        throw err;
+      }
     } else {
       this.role = "follower";
       this._wireSocket(result.socket);
@@ -328,7 +346,9 @@ export class SessionPeer {
     const sock = createConnection(this.opts.sockPath);
     await new Promise<void>((resolve, reject) => {
       sock.once("connect", () => resolve());
-      sock.once("error", reject);
+      // Destroy before rejecting: a failed connect still leaves a socket object
+      // holding an fd, and nothing downstream ever sees this one.
+      sock.once("error", (err) => { sock.destroy(); reject(err); });
     });
     this._wireSocket(sock);
     return this._registerOver(sock);
@@ -351,18 +371,29 @@ export class SessionPeer {
         settled = true;
         clearTimeout(wait);
         this._preAckListener = null;
-        // Leader self-registration uses a separate client socket. Destroying it does not close the broker server.
-        // Clear the active socket first. This prevents the close handler from starting a new election after registration failed.
+        // Clear the active socket before destroying it, so the close handler does
+        // not read this as a live-connection drop and start a fresh election.
+        // On the leader path this is only the self-loopback client; the broker
+        // server belongs to _joinOrLead and is closed there when we throw.
         if (this.socket === sock) this.socket = null;
         sock.destroy();
         reject(err);
       };
       // The first inbound line MUST be the register_ack. Buffer-aware.
+      //
+      // Reaching this timer means election chose the follower path against a
+      // broker that cannot answer. `tryConnect` only proves the endpoint is
+      // connectable, never that its owner is servicing anything. On POSIX an
+      // AF_UNIX connect() completes as soon as the kernel queues the connection
+      // in the listener backlog, so the owning process need not run at all; a
+      // suspended or event-loop-blocked leader still looks healthy to election.
+      // Only the handshake separates the two, and nothing here can recover on
+      // its own, so the message must name the endpoint and the way to clear it.
       const wait = setTimeout(() => {
         fail(new Error(
-          `register_ack timeout after ${ACK_TIMEOUT_MS}ms: a listener is bound to ${this.opts.sockPath} but did not answer the register handshake. `
-          + "The broker process may be suspended or its event loop may be blocked. "
-          + "AF_UNIX connect() succeeds as soon as the kernel queues the connection, so leader election cannot detect this by connectivity alone.",
+          `register_ack timeout after ${ACK_TIMEOUT_MS}ms: ${this.opts.sockPath} has a listener `
+          + "that never answered the register handshake. Its owning process is probably suspended "
+          + "or blocked; resume or terminate it, then rejoin.",
         ));
       }, ACK_TIMEOUT_MS);
       const onceListener = (raw: unknown) => {

--- a/pi-extension/src/session/socket_owner.test.ts
+++ b/pi-extension/src/session/socket_owner.test.ts
@@ -25,6 +25,8 @@ describe("describeState", () => {
     // resumable nor merely busy.
     expect(describeState("Z")).toEqual({ state: "a zombie", liveness: "exited" });
     expect(describeState("X")).toEqual({ state: "dead", liveness: "exited" });
+    // Linux spells dead two ways, and the lower-case one is easy to miss.
+    expect(describeState("x")).toEqual({ state: "dead", liveness: "exited" });
   });
 
   test("names the state instead of flattening everything to running", () => {

--- a/pi-extension/src/session/socket_owner.test.ts
+++ b/pi-extension/src/session/socket_owner.test.ts
@@ -1,0 +1,136 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, test } from "vitest";
+import {
+  describeRegistrationBlocker,
+  describeSocketOwner,
+  type SocketOwner,
+} from "./socket_owner.js";
+
+const onLinux = process.platform === "linux";
+
+describe("describeSocketOwner", () => {
+  test.runIf(onLinux)("names the process listening on the path", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "owner-"));
+    const sockPath = join(dir, "broker.sock");
+    let server: Server | undefined;
+    try {
+      server = createServer(() => {});
+      server.listen(sockPath);
+      await once(server, "listening");
+
+      const owner = await describeSocketOwner(sockPath);
+
+      expect(owner?.pid).toBe(process.pid);
+      expect(owner?.halted).toBe(false);
+      // `comm` would read "MainThread" for a Node process, which identifies
+      // nothing in `ps`; the executable name is what an operator can act on.
+      expect(owner?.command).toBe(basename(process.execPath));
+    } finally {
+      server?.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.runIf(onLinux)("reports a suspended owner as unable to answer", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "owner-stopped-"));
+    const sockPath = join(dir, "broker.sock");
+    const script = join(dir, "listener.cjs");
+    writeFileSync(script, `
+      const { createServer } = require("node:net");
+      createServer(() => {}).listen(process.argv[2], () => {
+        process.kill(process.pid, "SIGSTOP");
+      });
+    `);
+    const child = spawn(process.execPath, [script, sockPath], { stdio: "ignore" });
+    try {
+      for (let i = 0; i < 200 && !existsSync(sockPath); i++) await delay(25);
+      // The listener only counts as suspended once the kernel says so.
+      let state = "";
+      for (let i = 0; i < 200; i++) {
+        const stat = readFileSync(`/proc/${child.pid}/stat`, "utf8");
+        state = stat.slice(stat.lastIndexOf(")") + 2).trim().charAt(0);
+        if (state === "T") break;
+        await delay(25);
+      }
+      expect(state).toBe("T");
+
+      const owner = await describeSocketOwner(sockPath);
+
+      expect(owner?.pid).toBe(child.pid);
+      expect(owner?.halted).toBe(true);
+      expect(owner?.state).toBe("suspended");
+      expect(owner?.command).toBe(basename(process.execPath));
+    } finally {
+      child.kill("SIGKILL");
+      // Reap it before removing the directory it still has open.
+      await once(child, "exit");
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("returns null when nothing is listening on the path", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "owner-absent-"));
+    try {
+      expect(await describeSocketOwner(join(dir, "broker.sock"))).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.runIf(onLinux)("gives up rather than scanning past its budget", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "owner-budget-"));
+    const sockPath = join(dir, "broker.sock");
+    let server: Server | undefined;
+    try {
+      server = createServer(() => {});
+      server.listen(sockPath);
+      await once(server, "listening");
+
+      // The socket is resolvable; only the exhausted budget stops the walk.
+      expect(await describeSocketOwner(sockPath, 0)).toBeNull();
+      expect((await describeSocketOwner(sockPath))?.pid).toBe(process.pid);
+    } finally {
+      server?.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("describeRegistrationBlocker", () => {
+  const halted: SocketOwner = { pid: 4242, command: "omp", state: "suspended", halted: true };
+  const running: SocketOwner = { pid: 4243, command: "omp", state: "running", halted: false };
+
+  test("tells the operator how to resume a halted owner", () => {
+    const message = describeRegistrationBlocker("/run/broker.sock", halted);
+
+    expect(message).toContain("/run/broker.sock");
+    expect(message).toContain("pid 4242 (omp)");
+    expect(message).toContain("kill -CONT 4242");
+    expect(message).toContain("then rejoin.");
+  });
+
+  test("never advises killing an owner that is merely late", () => {
+    const message = describeRegistrationBlocker("/run/broker.sock", running);
+
+    expect(message).toContain("pid 4243 (omp)");
+    // Missing a fixed deadline does not prove a fault, so the message must not
+    // read as an instruction to destroy a possibly healthy broker.
+    expect(message).not.toContain("kill");
+    expect(message).toContain("may be busy");
+    expect(message).toContain("resume or terminate it, then rejoin.");
+  });
+
+  test("keeps one recovery instruction when the owner is unknown", () => {
+    const message = describeRegistrationBlocker("/run/broker.sock", null);
+
+    expect(message).toContain("/run/broker.sock");
+    expect(message).not.toContain("pid ");
+    expect(message).toContain("resume or terminate it, then rejoin.");
+  });
+});

--- a/pi-extension/src/session/socket_owner.test.ts
+++ b/pi-extension/src/session/socket_owner.test.ts
@@ -9,8 +9,35 @@ import { describe, expect, test } from "vitest";
 import {
   describeRegistrationBlocker,
   describeSocketOwner,
+  describeState,
   type SocketOwner,
 } from "./socket_owner.js";
+
+describe("describeState", () => {
+  test("offers resumption only for states a process can be resumed from", () => {
+    expect(describeState("T")).toEqual({ state: "suspended", liveness: "halted" });
+    expect(describeState("t")).toEqual({ state: "stopped by a debugger", liveness: "halted" });
+  });
+
+  test("separates an exited owner from a working one", () => {
+    // Reachable rather than theoretical: the owner can exit between the socket
+    // table read and the state read, and an exited process is neither
+    // resumable nor merely busy.
+    expect(describeState("Z")).toEqual({ state: "a zombie", liveness: "exited" });
+    expect(describeState("X")).toEqual({ state: "dead", liveness: "exited" });
+  });
+
+  test("names the state instead of flattening everything to running", () => {
+    expect(describeState("R").state).toBe("running");
+    expect(describeState("S").state).toBe("sleeping");
+    expect(describeState("D").state).toBe("in uninterruptible sleep");
+    expect(describeState("D").liveness).toBe("active");
+  });
+
+  test("passes through a state the kernel adds later", () => {
+    expect(describeState("Q")).toEqual({ state: "in state Q", liveness: "active" });
+  });
+});
 
 const onLinux = process.platform === "linux";
 
@@ -27,7 +54,7 @@ describe("describeSocketOwner", () => {
       const owner = await describeSocketOwner(sockPath);
 
       expect(owner?.pid).toBe(process.pid);
-      expect(owner?.halted).toBe(false);
+      expect(owner?.liveness).toBe("active");
       // `comm` would read "MainThread" for a Node process, which identifies
       // nothing in `ps`; the executable name is what an operator can act on.
       expect(owner?.command).toBe(basename(process.execPath));
@@ -63,7 +90,7 @@ describe("describeSocketOwner", () => {
       const owner = await describeSocketOwner(sockPath);
 
       expect(owner?.pid).toBe(child.pid);
-      expect(owner?.halted).toBe(true);
+      expect(owner?.liveness).toBe("halted");
       expect(owner?.state).toBe("suspended");
       expect(owner?.command).toBe(basename(process.execPath));
     } finally {
@@ -103,8 +130,9 @@ describe("describeSocketOwner", () => {
 });
 
 describe("describeRegistrationBlocker", () => {
-  const halted: SocketOwner = { pid: 4242, command: "omp", state: "suspended", halted: true };
-  const running: SocketOwner = { pid: 4243, command: "omp", state: "running", halted: false };
+  const halted: SocketOwner = { pid: 4242, command: "omp", state: "suspended", liveness: "halted" };
+  const running: SocketOwner = { pid: 4243, command: "omp", state: "running", liveness: "active" };
+  const gone: SocketOwner = { pid: 4244, command: "omp", state: "a zombie", liveness: "exited" };
 
   test("tells the operator how to resume a halted owner", () => {
     const message = describeRegistrationBlocker("/run/broker.sock", halted);
@@ -115,22 +143,43 @@ describe("describeRegistrationBlocker", () => {
     expect(message).toContain("then rejoin.");
   });
 
-  test("never advises killing an owner that is merely late", () => {
+  test("does not call an exited owner busy or resumable", () => {
+    const message = describeRegistrationBlocker("/run/broker.sock", gone);
+
+    expect(message).toContain("pid 4244 (omp)");
+    expect(message).toContain("a zombie");
+    // A process that has exited is neither working nor waiting to be resumed,
+    // so both the busy hedge and the resume instruction would misdescribe it.
+    expect(message).not.toContain("may be busy");
+    expect(message).not.toContain("kill");
+    expect(message).not.toContain("Resume it");
+    expect(message).toContain("already released the socket");
+    expect(message).toContain("then rejoin.");
+  });
+
+  test("never prescribes an action for an owner that is merely late", () => {
     const message = describeRegistrationBlocker("/run/broker.sock", running);
 
     expect(message).toContain("pid 4243 (omp)");
     // Missing a fixed deadline does not prove a fault, so the message must not
-    // read as an instruction to destroy a possibly healthy broker.
+    // read as an instruction to destroy a possibly healthy broker. "Resume" is
+    // also incoherent for a process that is already running.
     expect(message).not.toContain("kill");
+    expect(message).not.toContain("resume or terminate");
     expect(message).toContain("may be busy");
-    expect(message).toContain("resume or terminate it, then rejoin.");
+    expect(message).toContain("inspect pid 4243 before acting");
+    expect(message).toContain("then rejoin.");
   });
 
-  test("keeps one recovery instruction when the owner is unknown", () => {
+  test("admits it cannot identify an unknown owner", () => {
     const message = describeRegistrationBlocker("/run/broker.sock", null);
 
     expect(message).toContain("/run/broker.sock");
     expect(message).not.toContain("pid ");
-    expect(message).toContain("resume or terminate it, then rejoin.");
+    // Without an owner there is nothing to resume, and guessing that one is
+    // suspended would send the operator after a process that may not exist.
+    expect(message).not.toContain("resume or terminate");
+    expect(message).toContain("could not be identified");
+    expect(message).toContain("then rejoin.");
   });
 });

--- a/pi-extension/src/session/socket_owner.ts
+++ b/pi-extension/src/session/socket_owner.ts
@@ -1,0 +1,173 @@
+// Identifies the process holding a listening AF_UNIX socket.
+//
+// A queued connection belongs to the listener, not to the client that made it,
+// so a peer whose registration times out cannot release anything or repair the
+// mesh on its own. Only the owning process can, by accepting, resuming, or
+// exiting. The one useful thing the peer can do is say which process that is,
+// which otherwise costs the operator a manual walk of /proc/net/unix and every
+// /proc/<pid>/fd on the machine.
+//
+// Linux only: this reads /proc. Everywhere else the caller keeps its generic
+// message rather than guessing.
+import { readFile, readdir, readlink } from "node:fs/promises";
+import { basename } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+/**
+ * Kernel process states in which a process cannot run its event loop, so no
+ * amount of waiting produces a register_ack. Any other state is reported as
+ * observed and nothing is inferred from it: a healthy broker under load can
+ * miss a fixed deadline, and that is not evidence of a fault.
+ */
+const HALTED_STATES: Record<string, string> = {
+  T: "suspended",
+  t: "stopped by a debugger",
+  Z: "a zombie",
+  X: "dead",
+};
+
+export type SocketOwner = {
+  pid: number;
+  command: string;
+  /** Kernel state as observed, e.g. "suspended" or "running". */
+  state: string;
+  /** True only when the state itself proves the process cannot answer. */
+  halted: boolean;
+};
+
+/** Listening sockets report `01`; queued and connected ones do not. */
+const ST_LISTENING = "01";
+
+/**
+ * Ceiling on how long a caller waits for this diagnosis. It runs on a path
+ * where a descriptor has already been released and someone is waiting to
+ * report an error, so the wait must be bounded by wall clock rather than by
+ * how many processes and descriptors happen to exist.
+ */
+export const OWNER_LOOKUP_BUDGET_MS = 250;
+
+async function listeningInode(sockPath: string): Promise<string | null> {
+  const table = await readFile("/proc/net/unix", "utf8");
+  for (const line of table.split("\n")) {
+    // Num RefCount Protocol Flags Type St Inode Path
+    const cols = line.trim().split(/\s+/);
+    if (cols.length < 8) continue;
+    if (cols[5] !== ST_LISTENING) continue;
+    if (cols[cols.length - 1] !== sockPath) continue;
+    return cols[6];
+  }
+  return null;
+}
+
+/**
+ * Walks /proc until the descriptor turns up or `deadline` passes. Abandoning
+ * the walk is a real stop, not a race against work that keeps running.
+ */
+async function pidHoldingInode(inode: string, deadline: number): Promise<number | null> {
+  const target = `socket:[${inode}]`;
+  for (const entry of await readdir("/proc")) {
+    if (Date.now() >= deadline) return null;
+    const pid = Number(entry);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    let fds: string[];
+    try {
+      fds = await readdir(`/proc/${pid}/fd`);
+    } catch {
+      // Exited between listing and opening, or owned by another user.
+      continue;
+    }
+    for (const fd of fds) {
+      try {
+        if ((await readlink(`/proc/${pid}/fd/${fd}`)) === target) return pid;
+      } catch {
+        // Descriptor closed mid-scan; keep looking.
+      }
+    }
+  }
+  return null;
+}
+
+async function readState(pid: number): Promise<{ state: string; halted: boolean }> {
+  const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+  // The command field is parenthesized and may itself contain spaces or
+  // parentheses, so the state character is read after the final ')'.
+  const code = stat.slice(stat.lastIndexOf(")") + 2).trim().charAt(0);
+  const halted = Object.prototype.hasOwnProperty.call(HALTED_STATES, code);
+  return { state: halted ? HALTED_STATES[code] : "running", halted };
+}
+
+/**
+ * A name the operator can match against `ps` output. `comm` is capped at 15
+ * characters and runtimes overwrite it with a thread name, so Node processes
+ * report "MainThread" there and identify nothing; the command line carries the
+ * executable that was actually run.
+ */
+async function readCommand(pid: number): Promise<string> {
+  try {
+    const argv0 = (await readFile(`/proc/${pid}/cmdline`, "utf8")).split("\0")[0];
+    if (argv0 !== "") return basename(argv0);
+  } catch {
+    // Kernel threads expose an empty cmdline; fall back to comm.
+  }
+  return (await readFile(`/proc/${pid}/comm`, "utf8")).trim();
+}
+
+async function lookup(sockPath: string, deadline: number): Promise<SocketOwner | null> {
+  const inode = await listeningInode(sockPath);
+  if (inode === null) return null;
+  const pid = await pidHoldingInode(inode, deadline);
+  if (pid === null) return null;
+  const { state, halted } = await readState(pid);
+  return { pid, command: await readCommand(pid), state, halted };
+}
+
+/**
+ * Resolves the process listening on `sockPath`, or null when it cannot be
+ * determined within `budgetMs`. Never throws.
+ *
+ * The budget is enforced twice, because one mechanism alone is not enough. The
+ * race caps what the caller waits for even if a single /proc read stalls; the
+ * deadline passed into the walk stops the abandoned scan shortly afterwards
+ * instead of letting it run to completion unobserved.
+ */
+export async function describeSocketOwner(
+  sockPath: string,
+  budgetMs: number = OWNER_LOOKUP_BUDGET_MS,
+): Promise<SocketOwner | null> {
+  if (process.platform !== "linux") return null;
+  const deadline = Date.now() + budgetMs;
+  // `ref: false` so a pending diagnosis never holds the process open, and the
+  // walk absorbs its own failure so losing the race cannot surface later as an
+  // unhandled rejection.
+  const expired = delay(budgetMs, null, { ref: false });
+  const walk = lookup(sockPath, deadline).catch(() => null);
+  return await Promise.race([walk, expired]);
+}
+
+/**
+ * The operator-facing half of a registration timeout. Names the blocker when it
+ * is known, and always ends with the same instruction so callers can rely on
+ * one recovery contract regardless of what was discoverable.
+ *
+ * Only a halted owner earns a specific command. Missing a fixed deadline does
+ * not prove a process is broken, and advising an operator to kill a busy broker
+ * would turn a slow mesh into a destroyed one.
+ */
+export function describeRegistrationBlocker(sockPath: string, owner: SocketOwner | null): string {
+  const preamble = `${sockPath} has a listener `;
+  const tail = "resume or terminate it, then rejoin.";
+  if (owner === null) {
+    return preamble
+      + "that never answered the register handshake. Its owning process is probably suspended "
+      + `or blocked; ${tail}`;
+  }
+  const who = `owned by pid ${owner.pid} (${owner.command}), which is ${owner.state} `;
+  if (owner.halted) {
+    return preamble + who
+      + `and cannot answer the register handshake. Resume it with \`kill -CONT ${owner.pid}\` `
+      + `or terminate it, then rejoin.`;
+  }
+  return preamble + who
+    + `and did not answer the register handshake in time. It may be busy rather than stuck, `
+    + `so inspect pid ${owner.pid} before acting; ${tail}`;
+}

--- a/pi-extension/src/session/socket_owner.ts
+++ b/pi-extension/src/session/socket_owner.ts
@@ -27,10 +27,15 @@ const HALTED_STATES: Record<string, string> = {
  * so it no longer holds the socket the scan found it on. This is reachable
  * rather than theoretical: the owner can exit between reading the socket table
  * and reading its state.
+ *
+ * Linux reports dead under two codes. `proc(5)` gives `X` from 2.6.0 onward
+ * and `x` on 2.6.33 through 3.13, and a missed code would be classified as
+ * working and told it may be busy.
  */
 const EXITED_STATES: Record<string, string> = {
   Z: "a zombie",
   X: "dead",
+  x: "dead",
 };
 
 /**

--- a/pi-extension/src/session/socket_owner.ts
+++ b/pi-extension/src/session/socket_owner.ts
@@ -14,25 +14,39 @@ import { basename } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 /**
- * Kernel process states in which a process cannot run its event loop, so no
- * amount of waiting produces a register_ack. Any other state is reported as
- * observed and nothing is inferred from it: a healthy broker under load can
- * miss a fixed deadline, and that is not evidence of a fault.
+ * States a process can be resumed from. These are the only ones that prove no
+ * amount of waiting produces a register_ack while leaving something to act on.
  */
 const HALTED_STATES: Record<string, string> = {
   T: "suspended",
   t: "stopped by a debugger",
+};
+
+/**
+ * States in which the process is already gone. Its descriptors are released,
+ * so it no longer holds the socket the scan found it on. This is reachable
+ * rather than theoretical: the owner can exit between reading the socket table
+ * and reading its state.
+ */
+const EXITED_STATES: Record<string, string> = {
   Z: "a zombie",
   X: "dead",
 };
 
+/**
+ * What can be done about the owner, which is the only distinction the message
+ * acts on. A boolean cannot carry it: a stopped process is resumable, an exited
+ * one needs nothing, and a working one must not be touched on this evidence
+ * alone, because a healthy broker under load can miss a fixed deadline.
+ */
+export type OwnerLiveness = "halted" | "exited" | "active";
+
 export type SocketOwner = {
   pid: number;
   command: string;
-  /** Kernel state as observed, e.g. "suspended" or "running". */
+  /** Kernel state as observed, e.g. "suspended" or "in uninterruptible sleep". */
   state: string;
-  /** True only when the state itself proves the process cannot answer. */
-  halted: boolean;
+  liveness: OwnerLiveness;
 };
 
 /** Listening sockets report `01`; queued and connected ones do not. */
@@ -87,13 +101,40 @@ async function pidHoldingInode(inode: string, deadline: number): Promise<number 
   return null;
 }
 
-async function readState(pid: number): Promise<{ state: string; halted: boolean }> {
+/**
+ * Every state Linux reports in `/proc/<pid>/stat`, in words an operator can
+ * read back. Describing an unresponsive owner demands the state it is actually
+ * in: calling a process in uninterruptible sleep "running" would misdirect the
+ * person deciding what to do about it.
+ */
+const STATE_LABELS: Record<string, string> = {
+  R: "running",
+  S: "sleeping",
+  D: "in uninterruptible sleep",
+  I: "idle",
+  ...EXITED_STATES,
+  ...HALTED_STATES,
+};
+
+/**
+ * Exported so the classification can be tested for every state directly. A
+ * process cannot be driven into each one on demand, and the branch chosen here
+ * decides whether an operator is told to kill something.
+ */
+export function describeState(code: string): { state: string; liveness: OwnerLiveness } {
+  const has = (table: Record<string, string>) =>
+    Object.prototype.hasOwnProperty.call(table, code);
+  return {
+    state: STATE_LABELS[code] ?? `in state ${code}`,
+    liveness: has(HALTED_STATES) ? "halted" : has(EXITED_STATES) ? "exited" : "active",
+  };
+}
+
+async function readState(pid: number): Promise<{ state: string; liveness: OwnerLiveness }> {
   const stat = await readFile(`/proc/${pid}/stat`, "utf8");
   // The command field is parenthesized and may itself contain spaces or
   // parentheses, so the state character is read after the final ')'.
-  const code = stat.slice(stat.lastIndexOf(")") + 2).trim().charAt(0);
-  const halted = Object.prototype.hasOwnProperty.call(HALTED_STATES, code);
-  return { state: halted ? HALTED_STATES[code] : "running", halted };
+  return describeState(stat.slice(stat.lastIndexOf(")") + 2).trim().charAt(0));
 }
 
 /**
@@ -117,8 +158,8 @@ async function lookup(sockPath: string, deadline: number): Promise<SocketOwner |
   if (inode === null) return null;
   const pid = await pidHoldingInode(inode, deadline);
   if (pid === null) return null;
-  const { state, halted } = await readState(pid);
-  return { pid, command: await readCommand(pid), state, halted };
+  const { state, liveness } = await readState(pid);
+  return { pid, command: await readCommand(pid), state, liveness };
 }
 
 /**
@@ -146,28 +187,34 @@ export async function describeSocketOwner(
 
 /**
  * The operator-facing half of a registration timeout. Names the blocker when it
- * is known, and always ends with the same instruction so callers can rely on
- * one recovery contract regardless of what was discoverable.
+ * is known, and always closes with "then rejoin." so callers can assert one
+ * recovery contract regardless of what was discoverable.
  *
- * Only a halted owner earns a specific command. Missing a fixed deadline does
- * not prove a process is broken, and advising an operator to kill a busy broker
- * would turn a slow mesh into a destroyed one.
+ * Each branch says only what its evidence supports. Resuming is offered for a
+ * stopped process and nothing else: it is incoherent for one that is already
+ * running or already gone, and acting on it would destroy a broker whose only
+ * fault was missing a fixed deadline under load.
  */
 export function describeRegistrationBlocker(sockPath: string, owner: SocketOwner | null): string {
   const preamble = `${sockPath} has a listener `;
-  const tail = "resume or terminate it, then rejoin.";
   if (owner === null) {
     return preamble
-      + "that never answered the register handshake. Its owning process is probably suspended "
-      + `or blocked; ${tail}`;
+      + "that never answered the register handshake, and its owner could not be identified; "
+      + "inspect the process holding that socket before acting, then rejoin.";
   }
   const who = `owned by pid ${owner.pid} (${owner.command}), which is ${owner.state} `;
-  if (owner.halted) {
-    return preamble + who
-      + `and cannot answer the register handshake. Resume it with \`kill -CONT ${owner.pid}\` `
-      + `or terminate it, then rejoin.`;
+  switch (owner.liveness) {
+    case "halted":
+      return preamble + who
+        + `and cannot answer the register handshake. Resume it with \`kill -CONT ${owner.pid}\` `
+        + "or terminate it, then rejoin.";
+    case "exited":
+      return preamble + who
+        + "and exited without answering the register handshake. It has already released the "
+        + "socket and needs nothing done to it, then rejoin.";
+    case "active":
+      return preamble + who
+        + "and did not answer the register handshake in time. It may be busy rather than stuck, "
+        + `so inspect pid ${owner.pid} before acting, then rejoin.`;
   }
-  return preamble + who
-    + `and did not answer the register handshake in time. It may be busy rather than stuck, `
-    + `so inspect pid ${owner.pid} before acting; ${tail}`;
 }


### PR DESCRIPTION
Joining a session fails with `register_ack timeout` when a broker listener exists but its process cannot answer: on POSIX, AF_UNIX `connect()` completes once the kernel queues the connection, so election cannot tell a live broker from a suspended one. Each failure leaked a client descriptor, and a leader that hit one kept the broker path bound, leaving an idle session brokering the mesh while it reported `join failed`.

- Centralize registration-failure cleanup: clear the timer and pre-ACK listener, drop the socket reference, destroy the socket.
- Release the broker path when a leader cannot register itself. Close the candidate on every `_cmdJoin` failure, not only when superseded.
- Release the descriptor at the deadline, then diagnose under a 250 ms budget, so the report never widens the leak it explains.
- Name the blocking process instead of guessing. Read the command from `/proc/<pid>/cmdline`, since `comm` reports `MainThread` for a Node process and identifies nothing in `ps`.
- Prescribe only what the evidence supports. A stopped owner gets `kill -CONT <pid>`; an exited one has already released the socket; a working one is described and left alone, because missing a fixed deadline is not proof of a fault. Every branch closes with the same instruction.

Measured on 0.5.5 (`/proc/net/unix`): 158 entries in `St=02`, 0 accepted. The backlog entries are kernel-owned and belong to the suspended listener, so they are unchanged by this fix; the client descriptors are not. Recovery stays manual by design.

Each fix proven red first; 813 tests, `pnpm typecheck`, and `pnpm build` pass.
