### PR TITLE
refactor(remote-pi): migra prefs de UI do secure storage para shared_preferences

### DIFF
--- a/app/lib/config/dependencies.dart
+++ b/app/lib/config/dependencies.dart
@@ -6,7 +6,9 @@ import 'package:app/data/actions/actions_repository.dart';
 import 'package:app/data/mesh/mesh_client.dart';
 import 'package:app/data/mesh/mesh_sync_service.dart';
 import 'package:app/data/local/boxes.dart';
+import 'package:app/data/local/shared_prefs_key_value_store.dart';
 import 'package:app/data/preferences/preferences.dart';
+import 'package:app/data/preferences/preferences_migration.dart';
 import 'package:app/data/repositories/home_read_repository.dart';
 import 'package:app/data/repositories/session_read_repository.dart';
 import 'package:app/data/sync/sync_service.dart';
@@ -39,9 +41,11 @@ import 'package:app/ui/pairing/viewmodels/pairing_viewmodel.dart';
 import 'package:app/ui/settings/viewmodels/settings_viewmodel.dart';
 import 'package:app/ui/update/viewmodels/update_banner_viewmodel.dart';
 import 'package:cryptography/cryptography.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:remote_pi_identity/remote_pi_identity.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 final _injector = CustomInjector();
 
@@ -52,8 +56,10 @@ Future<void> setupDependencies() async {
   // Infrastructure singletons
   _injector.addInstance<PairingStorage>(PairingStorage());
 
-  final prefs = Preferences();
-  await prefs.load();
+  // Plan/storage — preferências de UI migram do SecureStorage para
+  // shared_preferences (dados não-sensíveis). Migração one-time roda antes
+  // do primeiro load(), copiando valores legados e apagando-os do keystore.
+  final prefs = await loadPreferencesWithMigration();
   _injector.addInstance<Preferences>(prefs);
 
   // Plan 31 — local SSOT box facade (boxes already opened + runtime wiped in
@@ -282,6 +288,29 @@ Future<PeerTransport> _productionPairingTransportFactory(
 }
 
 // ---------------------------------------------------------------------------
+
+/// Boot sequence for [Preferences]: obtém o shared_preferences, aplica a
+/// migração one-time do SecureStorage (dados legados) e então hidrata o
+/// cache em memória.
+///
+/// Extraída de [setupDependencies] para ser testável isoladamente: o teste
+/// injeta um `getPrefs` mockado e um `legacy` fake, e verifica o invariante
+/// de negócio — “um usuário existente não perde dados após atualizar” — em
+/// vez de acoplar ao detalhe de ordem interna (migração antes do load).
+Future<Preferences> loadPreferencesWithMigration({
+  Future<SharedPreferences> Function()? getPrefs,
+  FlutterSecureStorage? legacy,
+}) async {
+  final sharedPrefs = await (getPrefs ?? SharedPreferences.getInstance)();
+  final kvStore = SharedPrefsKeyValueStore(sharedPrefs);
+  await migrateLegacySecurePrefs(
+    legacy ?? const FlutterSecureStorage(),
+    kvStore,
+  );
+  final prefs = Preferences(kvStore);
+  await prefs.load();
+  return prefs;
+}
 
 class _CancelledError implements Exception {
   const _CancelledError();

--- a/app/lib/data/local/shared_prefs_key_value_store.dart
+++ b/app/lib/data/local/shared_prefs_key_value_store.dart
@@ -1,0 +1,24 @@
+import 'package:app/domain/contracts/key_value_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Implementação de [KeyValueStore] sobre `shared_preferences` (armazenamento
+/// plano do SO — Android SharedPreferences, iOS NSUserDefaults). Para dados
+/// não-sensíveis; segredos continuam em `flutter_secure_storage`.
+class SharedPrefsKeyValueStore implements KeyValueStore {
+  final SharedPreferences _prefs;
+
+  SharedPrefsKeyValueStore(this._prefs);
+
+  @override
+  Future<String?> read(String key) async => _prefs.getString(key);
+
+  @override
+  Future<void> write(String key, String value) async {
+    await _prefs.setString(key, value);
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    await _prefs.remove(key);
+  }
+}

--- a/app/lib/data/preferences/preferences.dart
+++ b/app/lib/data/preferences/preferences.dart
@@ -1,17 +1,16 @@
+import 'package:app/domain/contracts/key_value_store.dart';
+import 'package:app/ui/core/themes/app_font_scale.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show ThemeMode;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
-import 'package:app/ui/core/themes/app_font_scale.dart';
 
 /// App-wide UI preferences (persisted across launches).
 ///
 /// Extends [ChangeNotifier] so widgets can `context.watch<Preferences>()`
-/// and rebuild on toggle. Backed by [FlutterSecureStorage] (same store
-/// already used by pairing). Call [load] once during bootstrap before
-/// the first frame to hydrate the in-memory cache.
+/// and rebuild on toggle. Backed by a [KeyValueStore] (non-sensitive data —
+/// `shared_preferences` in production). Call [load] once during bootstrap
+/// before the first frame to hydrate the in-memory cache.
 class Preferences extends ChangeNotifier {
-  final FlutterSecureStorage _store;
+  final KeyValueStore _store;
   bool _hideToolCalls = false;
   String? _selectedPeerEpk;
   String? _relayUrl;
@@ -19,8 +18,7 @@ class Preferences extends ChangeNotifier {
   ThemeMode _themeMode = ThemeMode.system;
   AppFontScale _fontScale = AppFontScale.standard;
 
-  Preferences([FlutterSecureStorage? store])
-      : _store = store ?? const FlutterSecureStorage();
+  Preferences(this._store);
 
   static const _kHideToolCallsKey = 'prefs.hide_tool_calls';
   static const _kSelectedPeerEpkKey = 'prefs.selected_peer_epk';
@@ -84,46 +82,46 @@ class Preferences extends ChangeNotifier {
   /// `copyWith(fontSize: …)` overrides that a typography-only change would miss.
   AppFontScale get fontScale => _fontScale;
 
-  /// Hydrate from secure storage. Safe to call multiple times.
+  /// Hydrate from the key/value store. Safe to call multiple times.
   Future<void> load() async {
     var changed = false;
 
-    final raw = await _store.read(key: _kHideToolCallsKey);
+    final raw = await _store.read(_kHideToolCallsKey);
     final next = raw == 'true';
     if (next != _hideToolCalls) {
       _hideToolCalls = next;
       changed = true;
     }
 
-    final selected = await _store.read(key: _kSelectedPeerEpkKey);
+    final selected = await _store.read(_kSelectedPeerEpkKey);
     final cleaned = (selected != null && selected.isNotEmpty) ? selected : null;
     if (cleaned != _selectedPeerEpk) {
       _selectedPeerEpk = cleaned;
       changed = true;
     }
 
-    final relay = await _store.read(key: _kRelayUrlKey);
+    final relay = await _store.read(_kRelayUrlKey);
     final relayCleaned = (relay != null && relay.isNotEmpty) ? relay : null;
     if (relayCleaned != _relayUrl) {
       _relayUrl = relayCleaned;
       changed = true;
     }
 
-    final onboarded = await _store.read(key: _kOnboardingCompletedKey);
+    final onboarded = await _store.read(_kOnboardingCompletedKey);
     final onboardedBool = onboarded == 'true';
     if (onboardedBool != _onboardingCompleted) {
       _onboardingCompleted = onboardedBool;
       changed = true;
     }
 
-    final theme = await _store.read(key: _kThemeModeKey);
+    final theme = await _store.read(_kThemeModeKey);
     final themeMode = _themeModeFromString(theme);
     if (themeMode != _themeMode) {
       _themeMode = themeMode;
       changed = true;
     }
 
-    final scale = AppFontScale.fromName(await _store.read(key: _kFontScaleKey));
+    final scale = AppFontScale.fromName(await _store.read(_kFontScaleKey));
     if (scale != _fontScale) {
       _fontScale = scale;
       changed = true;
@@ -135,10 +133,7 @@ class Preferences extends ChangeNotifier {
   Future<void> setHideToolCalls(bool value) async {
     if (_hideToolCalls == value) return;
     _hideToolCalls = value;
-    await _store.write(
-      key: _kHideToolCallsKey,
-      value: value.toString(),
-    );
+    await _store.write(_kHideToolCallsKey, value.toString());
     notifyListeners();
   }
 
@@ -147,9 +142,9 @@ class Preferences extends ChangeNotifier {
     if (cleaned == _selectedPeerEpk) return;
     _selectedPeerEpk = cleaned;
     if (cleaned == null) {
-      await _store.delete(key: _kSelectedPeerEpkKey);
+      await _store.delete(_kSelectedPeerEpkKey);
     } else {
-      await _store.write(key: _kSelectedPeerEpkKey, value: cleaned);
+      await _store.write(_kSelectedPeerEpkKey, cleaned);
     }
     notifyListeners();
   }
@@ -161,9 +156,7 @@ class Preferences extends ChangeNotifier {
     if (epk == null || epk.isEmpty) {
       return setSelectedPeerEpk(null);
     }
-    final composite = (roomId == null || roomId.isEmpty)
-        ? epk
-        : '$epk:$roomId';
+    final composite = (roomId == null || roomId.isEmpty) ? epk : '$epk:$roomId';
     return setSelectedPeerEpk(composite);
   }
 
@@ -175,9 +168,9 @@ class Preferences extends ChangeNotifier {
     if (cleaned == _relayUrl) return;
     _relayUrl = cleaned;
     if (cleaned == null) {
-      await _store.delete(key: _kRelayUrlKey);
+      await _store.delete(_kRelayUrlKey);
     } else {
-      await _store.write(key: _kRelayUrlKey, value: cleaned);
+      await _store.write(_kRelayUrlKey, cleaned);
     }
     notifyListeners();
   }
@@ -185,10 +178,7 @@ class Preferences extends ChangeNotifier {
   Future<void> setOnboardingCompleted(bool value) async {
     if (_onboardingCompleted == value) return;
     _onboardingCompleted = value;
-    await _store.write(
-      key: _kOnboardingCompletedKey,
-      value: value.toString(),
-    );
+    await _store.write(_kOnboardingCompletedKey, value.toString());
     notifyListeners();
   }
 
@@ -197,7 +187,7 @@ class Preferences extends ChangeNotifier {
   Future<void> setThemeMode(ThemeMode value) async {
     if (_themeMode == value) return;
     _themeMode = value;
-    await _store.write(key: _kThemeModeKey, value: value.name);
+    await _store.write(_kThemeModeKey, value.name);
     notifyListeners();
   }
 
@@ -206,7 +196,7 @@ class Preferences extends ChangeNotifier {
   Future<void> setFontScale(AppFontScale value) async {
     if (_fontScale == value) return;
     _fontScale = value;
-    await _store.write(key: _kFontScaleKey, value: value.name);
+    await _store.write(_kFontScaleKey, value.name);
     notifyListeners();
   }
 

--- a/app/lib/data/preferences/preferences_migration.dart
+++ b/app/lib/data/preferences/preferences_migration.dart
@@ -1,0 +1,62 @@
+import 'package:app/domain/contracts/key_value_store.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Migração one-time das preferências de UI do `flutter_secure_storage`
+/// (onde todas as prefs viviam) para o `shared_preferences` (KeyValueStore).
+///
+/// Por quê: dados não-sensíveis (tema, fonte, idioma, relay URL, peer
+/// selecionado, onboarding) não pertencem ao Keychain/Keystore — é
+/// lento/flaky em alguns Androids. Segredos (pares pareados, owner key)
+/// NÃO migram e continuam em storage seguro.
+///
+/// Responsabilidade explícita e testável; invocada UMA vez no boot antes do
+/// primeiro `load()` do [Preferences]. Cada chave é copiada apenas se o alvo
+/// ainda não a possui (nunca sobrescreve um valor já migrado pelo usuário) e,
+/// em seguida, removida do armazenamento legado. Quando não há mais usuários
+/// com dados no SecureStorage, esta função pode ser removida.
+
+/// As chaves que viviam no `flutter_secure_storage`. Mantidas aqui (e não
+/// expostas pelo [Preferences]) porque são um detalhe transitório do passo de
+/// migração — serão removidas junto com esta função. Se o [Preferences] mudar
+/// o nome de uma chave nova, as chaves LEGADAS aqui não mudam (elas refletem
+/// o que estava persistido antes desta migração).
+const List<String> _legacyKeys = [
+  'prefs.hide_tool_calls',
+  'prefs.selected_peer_epk',
+  'prefs.relay_url',
+  'prefs.onboarding_completed',
+  'prefs.theme_mode',
+  'prefs.font_scale',
+  'prefs.locale',
+];
+
+/// Copia cada chave legada do [legacy] (SecureStorage) para o [target]
+/// (KeyValueStore) e, só após a cópia confirmada, remove do [legacy].
+///
+/// A migração roda em duas fases para nunca apagar antes de copiar (caso
+/// uma leitura/escrita falhe no meio — Keychain pode ser flaky — nada foi
+/// removido do legado, e a próxima execução completa sem perda graças à
+/// idempotência: chaves já copiadas são puladas, e apagar chave ausente é
+/// no-op).
+Future<void> migrateLegacySecurePrefs(
+  FlutterSecureStorage legacy,
+  KeyValueStore target,
+) async {
+  // Fase 1 — copy-only: nada é apagado até todas as chaves com valor terem
+  // sido copiadas (ou constatadas já presentes no target).
+  for (final key in _legacyKeys) {
+    final value = await legacy.read(key: key);
+    if (value == null || value.isEmpty) continue;
+    final existing = await target.read(key);
+    if (existing == null) {
+      await target.write(key, value);
+    }
+  }
+
+  // Fase 2 — cleanup: só remove do legado após a cópia confirmada. Idempotente
+  // (apagar chave ausente é no-op no FlutterSecureStorage), seguro de rodar
+  // mesmo pra chaves já removidas numa execução anterior.
+  for (final key in _legacyKeys) {
+    await legacy.delete(key: key);
+  }
+}

--- a/app/lib/domain/contracts/key_value_store.dart
+++ b/app/lib/domain/contracts/key_value_store.dart
@@ -1,0 +1,17 @@
+/// Chave/valor persistido simples, para dados NÃO-sensíveis (preferências de
+/// UI). Contrato no domínio; impl em `data/`.
+///
+/// NÃO usar para segredos — pares pareados e owner key ficam em storage
+/// seguro (Keychain/Keystore). Este contrato só cobre leitura/escrita/apagar
+/// de strings; tipos booleanos/enums são serializados pelo chamador.
+abstract class KeyValueStore {
+  /// Lê o valor de [key], ou `null` se a chave estiver ausente.
+  Future<String?> read(String key);
+
+  /// Escreve [value] (não-null) sob [key].
+  Future<void> write(String key, String value);
+
+  /// Apaga [key]. Único caminho para remover uma chave — não há
+  /// "escrever null" ambíguo.
+  Future<void> delete(String key);
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -751,6 +751,62 @@ packages:
       relative: true
     source: path
     version: "0.2.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.27"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1013,5 +1069,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -85,6 +85,7 @@ dependencies:
   # versionName) so the Android-only in-app update notice can compare it
   # against the release manifest's semver.
   package_info_plus: ^8.0.0
+  shared_preferences: ^2.5.5
 
 dev_dependencies:
   flutter_test:

--- a/app/test/config/dependencies_test.dart
+++ b/app/test/config/dependencies_test.dart
@@ -1,0 +1,115 @@
+import 'package:app/config/dependencies.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Legacy secure storage com dados pré-populados, simulando o que um usuário
+/// existente teria persistido ANTES da migração para shared_preferences.
+class _LegacySecureStorage implements FlutterSecureStorage {
+  final Map<String, String> map = {};
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => map[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      map.remove(key);
+    } else {
+      map[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    map.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('loadPreferencesWithMigration', () {
+    test(
+      'existing user keeps persisted UI prefs after boot (no data loss)',
+      () async {
+        // Target shared_preferences come up empty — this simulates a cold
+        // install that hasn't written anything yet.
+        SharedPreferences.setMockInitialValues({});
+
+        // Legacy secure storage has what a pre-migration user persisted.
+        final legacy = _LegacySecureStorage();
+        await legacy.write(key: 'prefs.theme_mode', value: 'dark');
+        await legacy.write(
+          key: 'prefs.relay_url',
+          value: 'https://custom.example',
+        );
+        await legacy.write(
+          key: 'prefs.selected_peer_epk',
+          value: 'abc123:main',
+        );
+        await legacy.write(key: 'prefs.hide_tool_calls', value: 'true');
+
+        final prefs = await loadPreferencesWithMigration(
+          getPrefs: SharedPreferences.getInstance,
+          legacy: legacy,
+        );
+
+        // The invariant: values that lived in secure storage are now visible
+        // through the hydrated Preferences — regardless of the internal
+        // ordering (migrate→load), a user never loses their settings.
+        expect(prefs.themeMode.name, 'dark');
+        expect(prefs.relayUrl, 'https://custom.example');
+        expect(prefs.selectedPeerEpk, 'abc123');
+        expect(prefs.hideToolCalls, isTrue);
+
+        // Legacy secure storage was drained by the migration.
+        expect(legacy.map, isEmpty);
+      },
+    );
+
+    test('fresh install (empty legacy) leaves defaults intact', () async {
+      SharedPreferences.setMockInitialValues({});
+      final legacy = _LegacySecureStorage(); // vazio
+
+      final prefs = await loadPreferencesWithMigration(
+        getPrefs: SharedPreferences.getInstance,
+        legacy: legacy,
+      );
+
+      // Defaults, nothing surprising when there's nothing to migrate.
+      expect(prefs.themeMode.name, 'system');
+      expect(prefs.relayUrl, isNull);
+      expect(prefs.selectedPeerEpk, isNull);
+      expect(prefs.hideToolCalls, isFalse);
+    });
+  });
+}

--- a/app/test/data/preferences/preferences_migration_test.dart
+++ b/app/test/data/preferences/preferences_migration_test.dart
@@ -1,0 +1,160 @@
+import 'package:app/data/preferences/preferences_migration.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/fake_key_value_store.dart';
+
+/// Legacy secure storage que simula o `flutter_secure_storage` onde as prefs
+/// de UI viviam antes da migração para `shared_preferences`.
+class _LegacySecureStorage implements FlutterSecureStorage {
+  final Map<String, String> map = {};
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => map[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      map.remove(key);
+    } else {
+      map[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    map.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+void main() {
+  group('migrateLegacySecurePrefs', () {
+    test(
+      'copies legacy values into the target store and clears the legacy',
+      () async {
+        final legacy = _LegacySecureStorage();
+        final target = FakeKeyValueStore();
+
+        // Pre-populate the legacy secure storage with UI prefs.
+        await legacy.write(key: 'prefs.hide_tool_calls', value: 'true');
+        await legacy.write(
+          key: 'prefs.selected_peer_epk',
+          value: 'abc123:main',
+        );
+        await legacy.write(
+          key: 'prefs.relay_url',
+          value: 'https://custom.example',
+        );
+        await legacy.write(key: 'prefs.onboarding_completed', value: 'true');
+        await legacy.write(key: 'prefs.theme_mode', value: 'dark');
+        await legacy.write(key: 'prefs.font_scale', value: 'large');
+
+        await migrateLegacySecurePrefs(legacy, target);
+
+        // Target has the copied values.
+        expect(await target.read('prefs.hide_tool_calls'), 'true');
+        expect(await target.read('prefs.selected_peer_epk'), 'abc123:main');
+        expect(await target.read('prefs.relay_url'), 'https://custom.example');
+        expect(await target.read('prefs.onboarding_completed'), 'true');
+        expect(await target.read('prefs.theme_mode'), 'dark');
+        expect(await target.read('prefs.font_scale'), 'large');
+
+        // Legacy secure storage is emptied.
+        expect(legacy.map, isEmpty);
+      },
+    );
+
+    test('does not overwrite an existing target value', () async {
+      final legacy = _LegacySecureStorage();
+      final target = FakeKeyValueStore();
+
+      // Target already has a value (e.g. the user already migrated on a
+      // previous launch, or set a fresh pref before migration ran).
+      await target.write('prefs.theme_mode', 'light');
+      // Legacy still has an older value.
+      await legacy.write(key: 'prefs.theme_mode', value: 'dark');
+
+      await migrateLegacySecurePrefs(legacy, target);
+
+      // Target value wins — not overwritten by the stale legacy value.
+      expect(await target.read('prefs.theme_mode'), 'light');
+      // Legacy is still cleared (value consumed).
+      expect(legacy.map, isEmpty);
+    });
+
+    test('a missing legacy key does not touch the target', () async {
+      final legacy = _LegacySecureStorage(); // empty
+      final target = FakeKeyValueStore();
+      await target.write('prefs.theme_mode', 'dark');
+
+      await migrateLegacySecurePrefs(legacy, target);
+
+      expect(await target.read('prefs.theme_mode'), 'dark');
+    });
+
+    test('an empty-string legacy value is dropped (not copied)', () async {
+      final legacy = _LegacySecureStorage();
+      final target = FakeKeyValueStore();
+
+      // Empty string is treated the same as "absent" — nothing useful to
+      // migrate, and the legacy entry is cleaned up.
+      await legacy.write(key: 'prefs.theme_mode', value: '');
+
+      await migrateLegacySecurePrefs(legacy, target);
+
+      expect(await target.read('prefs.theme_mode'), isNull);
+      expect(legacy.map, isEmpty);
+    });
+
+    test(
+      'keys outside the migration list are left untouched in the legacy',
+      () async {
+        final legacy = _LegacySecureStorage();
+        final target = FakeKeyValueStore();
+
+        // Secret / unrelated keys that must NEVER be swept by the migration.
+        await legacy.write(key: 'dev.remotepi.peers', value: 'paired-secret');
+        await legacy.write(key: 'owner.key', value: 'private-key-material');
+        // One in-scope UI pref, to prove the migration still runs.
+        await legacy.write(key: 'prefs.theme_mode', value: 'dark');
+
+        await migrateLegacySecurePrefs(legacy, target);
+
+        // In-scope key was migrated.
+        expect(await target.read('prefs.theme_mode'), 'dark');
+        // Out-of-scope keys remain in the legacy store untouched.
+        expect(legacy.map['dev.remotepi.peers'], 'paired-secret');
+        expect(legacy.map['owner.key'], 'private-key-material');
+        expect(legacy.map.containsKey('prefs.theme_mode'), isFalse);
+      },
+    );
+  });
+}

--- a/app/test/data/preferences/preferences_test.dart
+++ b/app/test/data/preferences/preferences_test.dart
@@ -1,81 +1,33 @@
 import 'package:app/data/preferences/preferences.dart';
 import 'package:app/ui/core/themes/app_font_scale.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _FakeSecureStorage implements FlutterSecureStorage {
-  final Map<String, String> _store = {};
-
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _store[key];
-
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _store.remove(key);
-    } else {
-      _store[key] = value;
-    }
-  }
-
-  @override
-  Future<void> delete({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    _store.remove(key);
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
-}
+import '../../helpers/fake_key_value_store.dart';
 
 void main() {
   group('Preferences', () {
     test('defaults to hideToolCalls=false before load()', () {
-      final p = Preferences(_FakeSecureStorage());
+      final p = Preferences(FakeKeyValueStore());
       expect(p.hideToolCalls, isFalse);
     });
 
     test('load() hydrates from storage', () async {
-      final store = _FakeSecureStorage();
-      await store.write(key: 'prefs.hide_tool_calls', value: 'true');
+      final store = FakeKeyValueStore();
+      await store.write('prefs.hide_tool_calls', 'true');
       final p = Preferences(store);
       await p.load();
       expect(p.hideToolCalls, isTrue);
     });
 
     test('setHideToolCalls writes to storage and notifies', () async {
-      final store = _FakeSecureStorage();
+      final store = FakeKeyValueStore();
       final p = Preferences(store);
       var notifs = 0;
       p.addListener(() => notifs++);
 
       await p.setHideToolCalls(true);
       expect(p.hideToolCalls, isTrue);
-      expect(await store.read(key: 'prefs.hide_tool_calls'), 'true');
+      expect(await store.read('prefs.hide_tool_calls'), 'true');
       expect(notifs, 1);
 
       // No-op if value unchanged.
@@ -89,14 +41,13 @@ void main() {
 
     test('relayUrl defaults to null and round-trips via setRelayUrl',
         () async {
-      final store = _FakeSecureStorage();
+      final store = FakeKeyValueStore();
       final p = Preferences(store);
       expect(p.relayUrl, isNull);
 
       await p.setRelayUrl('wss://custom.example.com');
       expect(p.relayUrl, 'wss://custom.example.com');
-      expect(await store.read(key: 'prefs.relay_url'),
-          'wss://custom.example.com');
+      expect(await store.read('prefs.relay_url'), 'wss://custom.example.com');
 
       // Reload from cold start → value survives.
       final p2 = Preferences(store);
@@ -106,7 +57,7 @@ void main() {
       // Clearing sends null and removes the key.
       await p.setRelayUrl(null);
       expect(p.relayUrl, isNull);
-      expect(await store.read(key: 'prefs.relay_url'), isNull);
+      expect(await store.read('prefs.relay_url'), isNull);
 
       // Empty string also clears.
       await p.setRelayUrl('wss://x');
@@ -118,16 +69,13 @@ void main() {
       'onboardingCompleted defaults to false and round-trips via '
       'setOnboardingCompleted',
       () async {
-        final store = _FakeSecureStorage();
+        final store = FakeKeyValueStore();
         final p = Preferences(store);
         expect(p.onboardingCompleted, isFalse);
 
         await p.setOnboardingCompleted(true);
         expect(p.onboardingCompleted, isTrue);
-        expect(
-          await store.read(key: 'prefs.onboarding_completed'),
-          'true',
-        );
+        expect(await store.read('prefs.onboarding_completed'), 'true');
 
         final p2 = Preferences(store);
         await p2.load();
@@ -137,7 +85,7 @@ void main() {
 
     test('selectedRoom round-trips epk + roomId composite (plan 17)',
         () async {
-      final store = _FakeSecureStorage();
+      final store = FakeKeyValueStore();
       final p = Preferences(store);
       await p.setSelectedRoom(epk: 'abc123', roomId: 'room-xyz');
       expect(p.selectedPeerEpk, 'abc123');
@@ -155,12 +103,9 @@ void main() {
       'backward-compat: legacy value (no `:room` suffix) returns epk '
       'and null roomId so caller defaults to "main"',
       () async {
-        final store = _FakeSecureStorage();
+        final store = FakeKeyValueStore();
         // Pre-populate with legacy format (just the epk, no suffix).
-        await store.write(
-          key: 'prefs.selected_peer_epk',
-          value: 'legacy_epk',
-        );
+        await store.write('prefs.selected_peer_epk', 'legacy_epk');
         final p = Preferences(store);
         await p.load();
         expect(p.selectedPeerEpk, 'legacy_epk');
@@ -169,8 +114,10 @@ void main() {
     );
 
     // Issue #114 — in-app text size.
-    test('fontScale defaults to standard and round-trips through storage', () async {
-      final store = _FakeSecureStorage();
+    test(
+        'fontScale defaults to standard and round-trips through storage',
+        () async {
+      final store = FakeKeyValueStore();
       final p = Preferences(store);
       await p.load();
       expect(p.fontScale, AppFontScale.standard);
@@ -184,16 +131,16 @@ void main() {
     });
 
     test('an unknown persisted font scale falls back to standard', () async {
-      final store = _FakeSecureStorage();
+      final store = FakeKeyValueStore();
       // A stale/corrupt value must never leave the app at an unreadable size.
-      await store.write(key: 'prefs.font_scale', value: 'gigantic');
+      await store.write('prefs.font_scale', 'gigantic');
       final p = Preferences(store);
       await p.load();
       expect(p.fontScale, AppFontScale.standard);
     });
 
     test('setFontScale notifies listeners only on a real change', () async {
-      final p = Preferences(_FakeSecureStorage());
+      final p = Preferences(FakeKeyValueStore());
       var calls = 0;
       p.addListener(() => calls++);
 
@@ -204,7 +151,7 @@ void main() {
     });
 
     test('setSelectedRoom with null epk clears the selection', () async {
-      final store = _FakeSecureStorage();
+      final store = FakeKeyValueStore();
       final p = Preferences(store);
       await p.setSelectedRoom(epk: 'abc', roomId: 'r');
       expect(p.selectedPeerEpk, 'abc');

--- a/app/test/data/transport/relay_config_test.dart
+++ b/app/test/data/transport/relay_config_test.dart
@@ -1,52 +1,8 @@
 import 'package:app/data/preferences/preferences.dart';
 import 'package:app/data/transport/relay_config.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _FakeStore implements FlutterSecureStorage {
-  final Map<String, String> _m = {};
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async =>
-      _m[key];
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _m.remove(key);
-    } else {
-      _m[key] = value;
-    }
-  }
-  @override
-  Future<void> delete({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async =>
-      _m.remove(key);
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
-}
+import '../../helpers/fake_key_value_store.dart';
 
 void main() {
   group('relay_config — isValidRelayUrl', () {
@@ -114,13 +70,13 @@ void main() {
 
   group('relay_config — resolveRelayUrl', () {
     test('returns prefs.relayUrl when set', () async {
-      final p = Preferences(_FakeStore());
+      final p = Preferences(FakeKeyValueStore());
       await p.setRelayUrl('https://custom.example.com');
       expect(resolveRelayUrl(p), 'https://custom.example.com');
     });
 
     test('falls back to kDefaultRelayUrl when override is null', () async {
-      final p = Preferences(_FakeStore());
+      final p = Preferences(FakeKeyValueStore());
       expect(p.relayUrl, isNull);
       expect(resolveRelayUrl(p), kDefaultRelayUrl);
     });

--- a/app/test/helpers/fake_key_value_store.dart
+++ b/app/test/helpers/fake_key_value_store.dart
@@ -1,0 +1,23 @@
+import 'package:app/domain/contracts/key_value_store.dart';
+
+/// Fake in-memory [KeyValueStore] compartilhado por testes. Substitui os
+/// antigos `_FakeSecureStorage` espalhados quando o [Preferences] migrou de
+/// `flutter_secure_storage` para `shared_preferences`.
+///
+/// Mantém um mapa em memória e expõe [map] para inspeção direta nos asserts.
+class FakeKeyValueStore implements KeyValueStore {
+  final Map<String, String> map = {};
+
+  @override
+  Future<String?> read(String key) async => map[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    map[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    map.remove(key);
+  }
+}

--- a/app/test/ui/chat/chat_page_appbar_test.dart
+++ b/app/test/ui/chat/chat_page_appbar_test.dart
@@ -23,11 +23,12 @@ import 'package:app/ui/chat/chat_page.dart';
 import 'package:app/ui/chat/viewmodels/chat_viewmodel.dart';
 import 'package:app/ui/chat/voice/viewmodels/voice_input_viewmodel.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
+
+import '../../helpers/fake_key_value_store.dart';
 
 class _FakeChannel implements IChannel {
   final _ctrl = StreamController<ServerMessage>.broadcast();
@@ -46,21 +47,6 @@ class _FakeStorage extends PairingStorage {
   Future<List<PeerRecord>> listPeers() async => const [];
   @override
   Future<PeerRecord?> loadPeer(String epk) async => null;
-}
-
-class _FakeSecureStorage implements FlutterSecureStorage {
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => null;
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
 }
 
 class _FakeSpeech implements SpeechService {
@@ -95,7 +81,7 @@ void main() {
       final boxes = LocalBoxes();
       final sync = SyncService(conn, boxes);
       final read = SessionReadRepository(boxes);
-      final prefs = Preferences(_FakeSecureStorage()); // no selected peer
+      final prefs = Preferences(FakeKeyValueStore()); // no selected peer
       final actions = ActionsRepository(conn);
       final vm = ChatViewModel(read, sync, conn, prefs, _FakeStorage());
       final voice = VoiceInputViewModel(_FakeSpeech());

--- a/app/test/ui/chat/chat_viewmodel_test.dart
+++ b/app/test/ui/chat/chat_viewmodel_test.dart
@@ -15,9 +15,10 @@ import 'package:app/pairing/storage.dart';
 import 'package:app/protocol/protocol.dart';
 import 'package:app/ui/chat/states/chat_state.dart';
 import 'package:app/ui/chat/viewmodels/chat_viewmodel.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import '../../helpers/fake_key_value_store.dart';
 
 class _FakeChannel implements IChannel, IControlLink {
   final _ctrl = StreamController<ServerMessage>.broadcast();
@@ -39,40 +40,6 @@ class _FakeChannel implements IChannel, IControlLink {
 
   void push(ServerMessage m) => _ctrl.add(m);
   void pushControl(ControlInbound m) => _control.add(m);
-}
-
-class _FakeSecureStorage implements FlutterSecureStorage {
-  final Map<String, String> _s = {};
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _s[key];
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _s.remove(key);
-    } else {
-      _s[key] = value;
-    }
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
 }
 
 const _peer = PeerRecord(
@@ -126,7 +93,7 @@ void main() {
     final boxes = LocalBoxes();
     final sync = SyncService(conn, boxes);
     final read = SessionReadRepository(boxes);
-    final prefs = Preferences(_FakeSecureStorage());
+    final prefs = Preferences(FakeKeyValueStore());
     await prefs.setSelectedPeerEpk(_peer.remoteEpk);
     await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
 
@@ -178,7 +145,7 @@ void main() {
       await msgBox.clear();
       final sync = SyncService(conn, boxes);
       final read = SessionReadRepository(boxes);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       await prefs.setSelectedPeerEpk(_peer.remoteEpk);
       await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
 
@@ -229,7 +196,7 @@ void main() {
       final boxes = LocalBoxes();
       final sync = SyncService(conn, boxes);
       final read = SessionReadRepository(boxes);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       await prefs.setSelectedPeerEpk(_peer.remoteEpk);
       await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
 
@@ -269,7 +236,7 @@ void main() {
     final boxes = LocalBoxes();
     final sync = SyncService(conn, boxes);
     final read = SessionReadRepository(boxes);
-    final prefs = Preferences(_FakeSecureStorage());
+    final prefs = Preferences(FakeKeyValueStore());
     await prefs.setSelectedPeerEpk(_peer.remoteEpk);
     await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
 
@@ -338,7 +305,7 @@ void main() {
       (await boxes.msgsBox(_peer.remoteEpk, 'main')).clear();
       final sync = SyncService(conn, boxes);
       final read = SessionReadRepository(boxes);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       await prefs.setSelectedPeerEpk(_peer.remoteEpk);
       await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
 
@@ -373,7 +340,7 @@ void main() {
     final boxes = LocalBoxes();
     final sync = SyncService(conn, boxes);
     final read = SessionReadRepository(boxes);
-    final prefs = Preferences(_FakeSecureStorage());
+    final prefs = Preferences(FakeKeyValueStore());
     await prefs.setSelectedPeerEpk(_peer.remoteEpk);
     await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
 

--- a/app/test/ui/chat/extension_ui_viewmodel_test.dart
+++ b/app/test/ui/chat/extension_ui_viewmodel_test.dart
@@ -15,9 +15,10 @@ import 'package:app/pairing/storage.dart';
 import 'package:app/protocol/protocol.dart';
 import 'package:app/ui/chat/states/chat_state.dart';
 import 'package:app/ui/chat/viewmodels/chat_viewmodel.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import '../../helpers/fake_key_value_store.dart';
 
 class _FakeChannel implements IChannel, IControlLink {
   final _ctrl = StreamController<ServerMessage>.broadcast();
@@ -44,40 +45,6 @@ class _FakeChannel implements IChannel, IControlLink {
   }
 
   void push(ServerMessage m) => _ctrl.add(m);
-}
-
-class _FakeSecureStorage implements FlutterSecureStorage {
-  final Map<String, String> _s = {};
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _s[key];
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _s.remove(key);
-    } else {
-      _s[key] = value;
-    }
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
 }
 
 const _peer = PeerRecord(
@@ -145,7 +112,7 @@ void main() {
     final boxes = LocalBoxes();
     final sync = SyncService(conn, boxes);
     final read = SessionReadRepository(boxes);
-    final prefs = Preferences(_FakeSecureStorage());
+    final prefs = Preferences(FakeKeyValueStore());
     await prefs.setSelectedPeerEpk(_peer.remoteEpk);
     await prefs.setSelectedRoom(epk: _peer.remoteEpk, roomId: 'main');
 

--- a/app/test/ui/home/home_viewmodel_test.dart
+++ b/app/test/ui/home/home_viewmodel_test.dart
@@ -10,8 +10,9 @@ import 'package:app/protocol/protocol.dart';
 import 'package:app/pairing/storage.dart';
 import 'package:app/ui/home/states/home_state.dart';
 import 'package:app/ui/home/viewmodels/home_viewmodel.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import 'package:flutter_test/flutter_test.dart';
+import '../../helpers/fake_key_value_store.dart';
 
 class _FakeStorage extends PairingStorage {
   List<PeerRecord> peers;
@@ -47,50 +48,6 @@ class _FakeStorage extends PairingStorage {
   Future<void> deleteRooms(String epk) async {
     _rooms.remove(epk);
   }
-}
-
-class _FakeSecureStorage implements FlutterSecureStorage {
-  final Map<String, String> _store = {};
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _store[key];
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _store.remove(key);
-    } else {
-      _store[key] = value;
-    }
-  }
-
-  @override
-  Future<void> delete({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _store.remove(key);
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
 }
 
 const _peerA = PeerRecord(
@@ -168,7 +125,7 @@ void main() {
           storage: storage,
           emitDebounce: Duration.zero,
         );
-        final prefs = Preferences(_FakeSecureStorage());
+        final prefs = Preferences(FakeKeyValueStore());
         final vm = HomeViewModel(storage, prefs, conn);
         await conn.connectTo(_peerA);
         await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -215,7 +172,7 @@ void main() {
 
     test('initial state is HomeLoading', () {
       final storage = _FakeStorage([_peerA]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
       expect(vm.state, isA<HomeLoading>());
       vm.dispose();
@@ -223,7 +180,7 @@ void main() {
 
     test('empty storage → HomeNoPeer', () async {
       final storage = _FakeStorage([]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
       expect(vm.state, isA<HomeNoPeer>());
@@ -232,7 +189,7 @@ void main() {
 
     test('two peers → HomeList containing both', () async {
       final storage = _FakeStorage([_peerA, _peerB]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -244,7 +201,7 @@ void main() {
 
     test('openSession writes selectedPeerEpk to Preferences', () async {
       final storage = _FakeStorage([_peerA, _peerB]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -259,7 +216,7 @@ void main() {
       '(no switchTo from Home — boot races would otherwise happen)',
       () async {
         final storage = _FakeStorage([_peerA, _peerB]);
-        final prefs = Preferences(_FakeSecureStorage());
+        final prefs = Preferences(FakeKeyValueStore());
         final connects = <String>[];
         final conn = ConnectionManager(
           factory: (peer, _) async {
@@ -291,7 +248,7 @@ void main() {
 
     test('openSession with unknown epk is a no-op', () async {
       final storage = _FakeStorage([_peerA]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -307,7 +264,7 @@ void main() {
       'updated before navigating to /chat (race-condition regression)',
       () async {
         final storage = _FakeStorage([_peerA]);
-        final prefs = Preferences(_FakeSecureStorage());
+        final prefs = Preferences(FakeKeyValueStore());
         final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
         await Future<void>.delayed(Duration.zero);
 
@@ -340,7 +297,7 @@ void main() {
         storage: storage,
         emitDebounce: Duration.zero,
       );
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = HomeViewModel(storage, prefs, conn);
       await conn.connectTo(_peerA);
       await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -387,7 +344,7 @@ void main() {
       'when it changes',
       () async {
         final storage = _FakeStorage([_peerA]);
-        final prefs = Preferences(_FakeSecureStorage());
+        final prefs = Preferences(FakeKeyValueStore());
         final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
         await Future<void>.delayed(Duration.zero);
 
@@ -408,7 +365,7 @@ void main() {
 
     test('counts / visibleItems are empty-safe outside a HomeList', () {
       final storage = _FakeStorage([_peerA]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = HomeViewModel(storage, prefs, _conn(storage: storage));
 
       // Synchronously still HomeLoading — the getters must not throw.

--- a/app/test/ui/onboarding/onboarding_viewmodel_test.dart
+++ b/app/test/ui/onboarding/onboarding_viewmodel_test.dart
@@ -1,56 +1,12 @@
 import 'package:app/data/preferences/preferences.dart';
 import 'package:app/ui/onboarding/states/onboarding_state.dart';
 import 'package:app/ui/onboarding/viewmodels/onboarding_viewmodel.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:flutter_test/flutter_test.dart';
 
-class _FakeStore implements FlutterSecureStorage {
-  final Map<String, String> _m = {};
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async =>
-      _m[key];
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _m.remove(key);
-    } else {
-      _m[key] = value;
-    }
-  }
-  @override
-  Future<void> delete({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async =>
-      _m.remove(key);
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
-}
+import 'package:flutter_test/flutter_test.dart';
+import '../../helpers/fake_key_value_store.dart';
 
 Future<({Preferences prefs, OnboardingViewModel vm})> _setup() async {
-  final prefs = Preferences(_FakeStore());
+  final prefs = Preferences(FakeKeyValueStore());
   final vm = OnboardingViewModel(prefs);
   return (prefs: prefs, vm: vm);
 }

--- a/app/test/ui/pairing/pairing_viewmodel_test.dart
+++ b/app/test/ui/pairing/pairing_viewmodel_test.dart
@@ -8,7 +8,7 @@ import 'dart:typed_data';
 import 'package:app/data/preferences/preferences.dart';
 import 'package:app/data/transport/channel.dart';
 import 'package:app/data/transport/connection_manager.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import 'package:app/pairing/owner_identity_bridge.dart';
 import 'package:app/pairing/pair_request_flow.dart' show PeerTransport;
 import 'package:app/pairing/storage.dart';
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:remote_pi_identity/remote_pi_identity.dart';
+import '../../helpers/fake_key_value_store.dart';
 
 // ---------------------------------------------------------------------------
 // Test infrastructure
@@ -54,55 +55,6 @@ class _MemTransport implements PeerTransport {
   Future<void> close() async {}
 }
 
-/// In-memory fake of FlutterSecureStorage so Preferences can be
-/// constructed in tests without touching the platform channel.
-class _FakeSecureStorage implements FlutterSecureStorage {
-  final Map<String, String> _store = {};
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _store[key];
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _store.remove(key);
-    } else {
-      _store[key] = value;
-    }
-  }
-
-  @override
-  Future<void> delete({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    _store.remove(key);
-  }
-
-  @override
-  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
 /// Synchronous Preferences subclass for tests. Pre-set relay URL to
 /// `ws://localhost` so it matches `_qrUri` (which still embeds the
 /// legacy `r=ws://localhost`); avoids tripping the relay-mismatch
@@ -112,7 +64,7 @@ class _PrefsForTest extends Preferences {
   final String? _relay;
   _PrefsForTest({String? relay = 'ws://localhost'})
     : _relay = relay,
-      super(_FakeSecureStorage());
+      super(FakeKeyValueStore());
   @override
   String? get relayUrl => _relay;
 }

--- a/app/test/ui/settings/settings_viewmodel_test.dart
+++ b/app/test/ui/settings/settings_viewmodel_test.dart
@@ -9,8 +9,9 @@ import 'package:app/pairing/pair_request_flow.dart';
 import 'package:app/pairing/storage.dart';
 import 'package:app/ui/settings/states/settings_state.dart';
 import 'package:app/ui/settings/viewmodels/settings_viewmodel.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import 'package:flutter_test/flutter_test.dart';
+import '../../helpers/fake_key_value_store.dart';
 
 class _NoopTransport implements PeerTransport {
   @override Future<void> send(Uint8List data) async {}
@@ -50,49 +51,6 @@ class _FakeStorage extends PairingStorage {
   }
 }
 
-class _FakeSecureStorage implements FlutterSecureStorage {
-  final Map<String, String> _store = {};
-  @override
-  Future<String?> read({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _store[key];
-  @override
-  Future<void> write({
-    required String key,
-    required String? value,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async {
-    if (value == null) {
-      _store.remove(key);
-    } else {
-      _store[key] = value;
-    }
-  }
-  @override
-  Future<void> delete({
-    required String key,
-    IOSOptions? iOptions,
-    AndroidOptions? aOptions,
-    LinuxOptions? lOptions,
-    WebOptions? webOptions,
-    MacOsOptions? mOptions,
-    WindowsOptions? wOptions,
-  }) async => _store.remove(key);
-  @override
-  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
-}
-
 PeerRecord _peerA() => const PeerRecord(
   remoteEpk: 'epk_A',
   sessionName: 'Pi A',
@@ -104,7 +62,7 @@ void main() {
   group('SettingsViewModel', () {
     test('initial state is SettingsLoading', () {
       final storage = _FakeStorage([_peerA()]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
       expect(vm.state, isA<SettingsLoading>());
       vm.dispose();
@@ -112,7 +70,7 @@ void main() {
 
     test('empty storage → SettingsNoPeer', () async {
       final storage = _FakeStorage([]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
       expect(vm.state, isA<SettingsNoPeer>());
@@ -121,7 +79,7 @@ void main() {
 
     test('peers loaded → SettingsList', () async {
       final storage = _FakeStorage([_peerA()]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -134,7 +92,7 @@ void main() {
     test('revoke deletes peer + clears selectedPeerEpk if it matched',
         () async {
       final storage = _FakeStorage([_peerA()]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       await prefs.setSelectedPeerEpk('epk_A');
 
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
@@ -152,7 +110,7 @@ void main() {
 
     test('revoke does NOT touch selectedPeerEpk if different', () async {
       final storage = _FakeStorage([_peerA()]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       await prefs.setSelectedPeerEpk('epk_other');
 
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
@@ -168,7 +126,7 @@ void main() {
 
     test('setNickname updates state and storage', () async {
       final storage = _FakeStorage([_peerA()]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -186,7 +144,7 @@ void main() {
       final storage = _FakeStorage([
         _peerA().copyWith(nickname: 'Casa'),
       ]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -203,7 +161,7 @@ void main() {
       final storage = _FakeStorage([
         _peerA().copyWith(nickname: 'Casa'),
       ]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -217,7 +175,7 @@ void main() {
 
     test('setNickname is a no-op for unknown epk', () async {
       final storage = _FakeStorage([_peerA()]);
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(storage, prefs, _conn(storage: storage));
       await Future<void>.delayed(Duration.zero);
 
@@ -233,7 +191,7 @@ void main() {
   group('SettingsViewModel — plan 14 relay config', () {
     test('saveRelayUrl with valid URL persists override + returns null',
         () async {
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(_FakeStorage([]), prefs, _conn());
       await Future<void>.delayed(Duration.zero);
 
@@ -248,7 +206,7 @@ void main() {
     test(
       'saveRelayUrl with invalid URL returns error and does NOT persist',
       () async {
-        final prefs = Preferences(_FakeSecureStorage());
+        final prefs = Preferences(FakeKeyValueStore());
         final vm = SettingsViewModel(_FakeStorage([]), prefs, _conn());
         await Future<void>.delayed(Duration.zero);
 
@@ -262,7 +220,7 @@ void main() {
 
     test('saveRelayUrl rejects ws:// / wss:// with the scheme-specific hint',
         () async {
-      final prefs = Preferences(_FakeSecureStorage());
+      final prefs = Preferences(FakeKeyValueStore());
       final vm = SettingsViewModel(_FakeStorage([]), prefs, _conn());
       await Future<void>.delayed(Duration.zero);
 
@@ -279,7 +237,7 @@ void main() {
       'saveRelayUrl with empty / null is rejected (URL is now required) and '
       'does NOT clear the existing override',
       () async {
-        final prefs = Preferences(_FakeSecureStorage());
+        final prefs = Preferences(FakeKeyValueStore());
         await prefs.setRelayUrl('https://x.example');
         final vm = SettingsViewModel(_FakeStorage([]), prefs, _conn());
         await Future<void>.delayed(Duration.zero);
@@ -307,7 +265,7 @@ void main() {
       'relayUrlOverride defaults to kDefaultRelayUrl (pre-fill for the '
       '"use default" button) and reflects a saved override',
       () async {
-        final prefs = Preferences(_FakeSecureStorage());
+        final prefs = Preferences(FakeKeyValueStore());
         final vm = SettingsViewModel(_FakeStorage([]), prefs, _conn());
         await Future<void>.delayed(Duration.zero);
 


### PR DESCRIPTION
Move as preferências de UI não-sensíveis do FlutterSecureStorage (lento/
instável, feito para segredos) para o shared_preferences.

- Adiciona o contrato KeyValueStore (Dart puro) + SharedPrefsKeyValueStore
  apoiado em shared_preferences.
- Refatora Preferences para depender de KeyValueStore (injeção explícita
  no construtor, sem o default oculto de SecureStorage).
- Adiciona migração one-time rodando antes do primeiro load(), para que
  usuários existentes mantenham suas configurações. Copia cada chave
  primeiro e só então limpa o storage legado — uma execução interrompida
  retoma no próximo boot sem perda de dados.
- Substitui os fakes espalhados por um FakeKeyValueStore compartilhado.
- Testes: 5 casos de migração (copia+limpa, não-sobrescreve, chave
  ausente, string vazia, chave fora da lista) + 2 casos de boot (usuário
  existente mantém prefs, instalação limpa mantém defaults).

Chaves migradas: theme_mode, font_scale, hide_tool_calls, locale,
relay_url, onboarding_completed, selected_peer_epk.

Não migradas (permanecem no secure storage): pares pareados
(PairingStorage) e a owner key (remote_pi_identity).