### PR TITLE
fix(extension): retry initial relay connect instead of stranding agents offline

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -5122,6 +5122,95 @@ describe("relay reconnect", () => {
     }
   });
 
+  test("initial relay.connect failure schedules a start retry; retry success starts normally", async () => {
+    vi.useFakeTimers();
+    try {
+      // First connect fails (boot-time DNS/TUN race, relay briefly down, …).
+      _defaultConnectImpl = () => Promise.reject(new Error("getaddrinfo ENOTFOUND relay.example"));
+      captureHandler("remote-pi");
+      const ctx = makeMockCtx();
+      await _connectForTest(ctx);
+
+      expect(relayInstances).toHaveLength(1);
+      // Not half-started: no relay, but a retry is pending.
+      expect(_getState()).toBe("idle");
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("retrying in the background"),
+        "error",
+      );
+
+      // Network recovers before the first backoff fires.
+      _defaultConnectImpl = async () => undefined;
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // Retry re-ran the full start: new RelayClient, fully started.
+      expect(relayInstances).toHaveLength(2);
+      expect(_getState()).toBe("started");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("initial connect keeps retrying with backoff while the relay stays down", async () => {
+    vi.useFakeTimers();
+    try {
+      _defaultConnectImpl = () => Promise.reject(new Error("ECONNREFUSED"));
+      captureHandler("remote-pi");
+      await _connectForTest(makeMockCtx());
+      expect(relayInstances).toHaveLength(1);
+      expect(_getState()).toBe("idle");
+
+      let prevCount = relayInstances.length;
+      for (const delay of [1_000, 2_000, 5_000]) {
+        await vi.advanceTimersByTimeAsync(delay);
+        expect(relayInstances.length).toBe(prevCount + 1);
+        expect(relayInstances.at(-1)!.close).toHaveBeenCalledTimes(1);
+        expect(_getState()).toBe("idle");
+        prevCount = relayInstances.length;
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("RoomAlreadyOpenError on initial connect does NOT schedule a start retry", async () => {
+    vi.useFakeTimers();
+    try {
+      _defaultConnectImpl = async () => {
+        throw new MockRoomAlreadyOpenError("AbCdEfGhIjKl");
+      };
+      captureHandler("remote-pi");
+      await _connectForTest(makeMockCtx("/tmp/remote-pi-dup-initial"));
+      expect(relayInstances).toHaveLength(1);
+
+      // Retrying a deterministic room conflict would fight the incumbent.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(relayInstances).toHaveLength(1);
+      expect(_getState()).toBe("idle");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("/remote-pi stop during the initial-retry window cancels the pending retry", async () => {
+    vi.useFakeTimers();
+    try {
+      _defaultConnectImpl = () => Promise.reject(new Error("ENOTFOUND"));
+      captureHandler("remote-pi");
+      await _connectForTest(makeMockCtx());
+      expect(relayInstances).toHaveLength(1);
+
+      const stop = captureHandler("remote-pi stop");
+      await stop("", makeMockCtx());
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(relayInstances).toHaveLength(1);
+      expect(_getState()).toBe("idle");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("stale reconnect candidate cannot replace a stop/start Relay lifecycle", async () => {
     const staleConnect = deferred<void>();
     let staleConnectReleased = false;

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -1149,6 +1149,12 @@ function _getSyncLimit(): number {
 const RECONNECT_BACKOFFS_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
 let _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let _reconnectAttempt = 0;
+// Initial-connect retry: a FAILED first `relay.connect()` (boot-time DNS not
+// ready, relay briefly down, …) must not strand the agent offline forever.
+// Distinct from `_reconnectTimer` (which only handles post-close reconnects)
+// because the failed lifecycle never reached `_state === "started"`.
+let _initialConnectRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let _initialConnectRetryAttempt = 0;
 // Every initial connect/reconnect candidate captures this generation. Stop,
 // relay-off, and an unexpected close invalidate older async continuations.
 let _relayLifecycleGeneration = 0;
@@ -1406,6 +1412,12 @@ function _goIdle(byeReason?: import("./protocol/types.js").ByeReason): void {
     _reconnectTimer = null;
   }
   _reconnectAttempt = 0;
+  // Same for a pending initial-connect retry (stop wins over retry).
+  if (_initialConnectRetryTimer !== null) {
+    clearTimeout(_initialConnectRetryTimer);
+    _initialConnectRetryTimer = null;
+  }
+  _initialConnectRetryAttempt = 0;
 
   _stopAutoListener?.();
   _stopAutoListener = null;
@@ -1530,6 +1542,38 @@ function _scheduleReconnect(
     _reconnectTimer = null;
     if (!_isCurrentReconnect(lifecycleGeneration, url)) return;
     void _attemptReconnect(lifecycleGeneration, url);
+  }, delay);
+}
+
+/**
+ * Retry loop for a FAILED INITIAL `relay.connect()`. The close-driven
+ * reconnect path (`_scheduleReconnect`) only exists once a connection was
+ * established; before this, a boot-time DNS/TUN race or a briefly down relay
+ * stranded daemons offline until manual restart. Re-entering `_cmdStart` as a
+ * whole (rather than publishing a relay-less "started" state) keeps every
+ * post-connect invariant — SelfRevoke producer, bridge attach, footer —
+ * identical to a manual `/remote-pi` retry.
+ *
+ * Invalidation mirrors `_scheduleReconnect`: `_goIdle` and any newer
+ * `_cmdStart`/stop cycle bump `_relayLifecycleGeneration`, which stale timers
+ * observe before acting. `ctx` is captured the same way a user re-running the
+ * command would re-supply it; daemon ctxs are stable for the process lifetime.
+ */
+function _scheduleInitialConnectRetry(
+  lifecycleGeneration: number,
+  ctx: Pick<ExtensionContext, "ui" | "cwd">,
+): void {
+  if (_initialConnectRetryTimer !== null) return; // already scheduled
+
+  const idx = Math.min(_initialConnectRetryAttempt, RECONNECT_BACKOFFS_MS.length - 1);
+  const delay = RECONNECT_BACKOFFS_MS[idx]!;
+  _initialConnectRetryAttempt += 1;
+
+  _initialConnectRetryTimer = setTimeout(() => {
+    _initialConnectRetryTimer = null;
+    if (lifecycleGeneration !== _relayLifecycleGeneration) return; // stopped/replaced
+    if (_disposed || _state !== "idle" || _relay !== null) return;
+    void _cmdStart(ctx);
   }, delay);
 }
 
@@ -2986,7 +3030,14 @@ async function _cmdStart(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<voi
       );
       return;
     }
-    ctx.ui.notify(`[remote-pi] relay connect failed: ${String(err)}`, "error");
+    // Not RoomAlreadyOpenError (deterministic conflict, stays fatal above):
+    // keep retrying in the background so a transient DNS/network/relay outage
+    // at process start cannot strand a daemon offline until manual restart.
+    ctx.ui.notify(
+      `[remote-pi] relay connect failed: ${String(err)} — retrying in the background`,
+      "error",
+    );
+    _scheduleInitialConnectRetry(lifecycleGeneration, ctx);
     return;
   }
 
@@ -3003,6 +3054,12 @@ async function _cmdStart(ctx: Pick<ExtensionContext, "ui" | "cwd">): Promise<voi
   _peerShort = myShort;
   _myRoomId = roomId;
   _state = "started";
+  // A successful start settles the initial-connect retry loop.
+  if (_initialConnectRetryTimer !== null) {
+    clearTimeout(_initialConnectRetryTimer);
+    _initialConnectRetryTimer = null;
+  }
+  _initialConnectRetryAttempt = 0;
   // Set _sessionStartedAt ONLY on first /remote-pi start since process boot.
   // Subsequent start cycles (after stop) preserve the original epoch so the
   // app keeps treating it as the same session (and merges new events from


### PR DESCRIPTION
## Problem

A failed **initial** `relay.connect()` strands the agent offline forever.

Real-world repro (Windows, TUN-mode proxy): the OS service starts `pi-supervisord` at logon **before** the network/DNS is ready. Every supervised daemon (`pi --mode rpc`) then fails its first relay connect with `getaddrinfo ENOTFOUND` — and stays offline for hours. `remote-pi daemon status` reports `running` (the process is alive), but no WebSocket to the relay ever exists, so the mobile app shows the workspaces offline. Only a manual `remote-pi daemon restart` recovers them.

Root cause: on initial-connect failure, `_cmdStart` just notifies and returns:

```ts
ctx.ui.notify(`[remote-pi] relay connect failed: ${String(err)}`, error);
return; // ← no retry is ever scheduled
```

The existing backoff reconnect loop (`_scheduleReconnect`, 1s→30s) only engages from `_onRelayClose` — i.e. for connections that were **established first**. A first-connect failure never reaches `_state === started`, so nothing retries.

## Fix

On initial-connect failure, schedule a background retry that **re-enters `_cmdStart` as a whole**, sharing the existing `RECONNECT_BACKOFFS_MS` ladder.

Re-entering the full start — instead of publishing a relay-less `started` state into the close-driven reconnect path — is deliberate: `_cmdStart`'s post-connect block creates the SelfRevoke producer, seeds `_sessionStartedAt`, installs listeners and attaches the bridge. Routing initial retries through `_attemptReconnect` would skip that setup (e.g. `_attachBridgeIfReady` would never fire with no SelfRevoke topology), producing a half-initialized session. Re-entry makes a background retry byte-for-byte equivalent to a user re-running `/remote-pi`.

Semantics:
- `RoomAlreadyOpenError` stays **fatal** — retrying a deterministic room conflict would fight the incumbent agent.
- Invalidation mirrors the existing machinery: `_goIdle` and any newer start/stop cycle bump `_relayLifecycleGeneration`, which stale timers re-check before acting; `/remote-pi stop` during the retry window cancels the pending retry (verified by test).
- While retrying, the agent stays `idle` (no half-started state); each failed attempt re-notifies and re-schedules with the shared backoff (capped at 30s).

## Tests

Four new cases in `extension.test.ts` (fake timers, existing MockRelay harness):

1. initial failure → retry fires after 1s → success → fully `started`
2. sustained failures → backoff progression continues, state stays `idle`, rejected candidates closed
3. `RoomAlreadyOpenError` on initial connect → **no** retry
4. `/remote-pi stop` during the retry window → no further attempts

`src/extension.test.ts`: **187/187 pass**. (Note: `src/daemon/supervisor.test.ts` and `src/session/e2e.test.ts` have 24 failures on this Windows dev box that reproduce identically on a clean `main` checkout — pre-existing, unrelated to this change.)

## Out of scope / follow-ups

- Surfacing a "relay reconnecting since …" hint in `daemon status` would make this class of issue visible without `netstat`; happy to file separately.