### PR TITLE
feat(cockpit): decorações SCM no gutter e overview do editor

### DIFF
--- a/cockpit/analysis_options.yaml
+++ b/cockpit/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/cockpit/lib/app/cockpit/cockpit_module.dart
+++ b/cockpit/lib/app/cockpit/cockpit_module.dart
@@ -24,6 +24,7 @@ import 'package:cockpit/app/cockpit/data/filesystem/folder_lister_impl.dart';
 import 'package:cockpit/app/cockpit/data/filesystem/git_binary.dart';
 import 'package:cockpit/app/cockpit/data/filesystem/git_command_runner_impl.dart';
 import 'package:cockpit/app/cockpit/data/filesystem/git_diff_reader_impl.dart';
+import 'package:cockpit/app/cockpit/data/filesystem/git_head_baseline_reader_impl.dart';
 import 'package:cockpit/app/cockpit/data/filesystem/git_history_reader_impl.dart';
 import 'package:cockpit/app/cockpit/data/filesystem/git_status_reader_impl.dart';
 import 'package:cockpit/app/cockpit/data/filesystem/session_history_impl.dart';
@@ -58,8 +59,11 @@ import 'package:cockpit/app/cockpit/domain/contracts/file_system_reader.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/folder_lister.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_command_runner.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_diff_reader.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/git_head_baseline_reader.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_history_reader.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_status_reader.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_baseline_cache.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_line_decoration_calculator.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/notifier.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/project_repository.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/realm_repository.dart';
@@ -187,6 +191,11 @@ Future<Module> buildCockpitModule() async {
         ..addLazySingleton<WorktreeManager>(WorktreeManagerImpl.new)
         ..addLazySingleton<GitCommandRunner>(GitCommandRunnerImpl.new)
         ..addLazySingleton<GitDiffReader>(GitDiffReaderImpl.new)
+        ..addLazySingleton<GitHeadBaselineReader>(GitHeadBaselineReaderImpl.new)
+        ..addLazySingleton<ScmBaselineCache>(ScmBaselineCache.new)
+        ..addInstance<ScmLineDecorationCalculator>(
+          const ScmLineDecorationCalculator(),
+        )
         ..addLazySingleton<GitHistoryReader>(GitHistoryReaderImpl.new)
         ..addInstance<SessionHistory>(const SessionHistoryImpl())
         ..addInstance<TerminalGatewayFactory>(const PtyTerminalGatewayFactory())

--- a/cockpit/lib/app/cockpit/data/filesystem/git_head_baseline_reader_impl.dart
+++ b/cockpit/lib/app/cockpit/data/filesystem/git_head_baseline_reader_impl.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cockpit/app/cockpit/data/filesystem/git_binary.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/git_head_baseline_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_head_baseline.dart';
+
+/// Lê blobs de `HEAD` via `git rev-parse` / `git cat-file` — sem working tree.
+class GitHeadBaselineReaderImpl implements GitHeadBaselineReader {
+  GitHeadBaselineReaderImpl(this._gitBinary);
+
+  final GitBinary _gitBinary;
+
+  static const int _maxTextBytes = 2 * 1024 * 1024;
+
+  @override
+  Future<String?> resolveHeadIdentity(String repoPath) async {
+    try {
+      final git = await _gitBinary.resolve();
+      final result = await Process.run(git, [
+        '-C',
+        repoPath,
+        'rev-parse',
+        'HEAD',
+      ]);
+      if (result.exitCode != 0) return null;
+      final id = (result.stdout as String).trim();
+      return id.isEmpty ? null : id;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<GitHeadBaseline?> readTrackedText(
+    String repoPath,
+    String absPath,
+  ) async {
+    try {
+      final git = await _gitBinary.resolve();
+      final rel = _relative(repoPath, absPath);
+      if (rel == null || rel.isEmpty || rel.startsWith('..')) return null;
+
+      final head = await resolveHeadIdentity(repoPath);
+      if (head == null) return null;
+
+      // Existe no snapshot HEAD? (cobre untracked/ignored/novo sem blob).
+      final exists = await Process.run(git, [
+        '-C',
+        repoPath,
+        'cat-file',
+        '-e',
+        '$head:$rel',
+      ]);
+      if (exists.exitCode != 0) return null;
+
+      final blob = await Process.run(git, [
+        '-C',
+        repoPath,
+        'cat-file',
+        '-p',
+        '$head:$rel',
+      ], stdoutEncoding: null);
+      if (blob.exitCode != 0) return null;
+
+      final bytes = _asBytes(blob.stdout);
+      if (bytes == null) return null;
+      if (bytes.length > _maxTextBytes) return null;
+      if (_isBinary(bytes)) return null;
+
+      return GitHeadBaseline(
+        headIdentity: head,
+        content: utf8.decode(bytes, allowMalformed: true),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String? _relative(String repoPath, String absPath) {
+    final root = repoPath.endsWith('/')
+        ? repoPath.substring(0, repoPath.length - 1)
+        : repoPath;
+    final abs = absPath.endsWith('/') && absPath.length > 1
+        ? absPath.substring(0, absPath.length - 1)
+        : absPath;
+    if (abs == root) return '';
+    final prefix = '$root/';
+    if (!abs.startsWith(prefix)) return null;
+    return abs.substring(prefix.length);
+  }
+
+  static Uint8List? _asBytes(Object? stdout) {
+    if (stdout is Uint8List) return stdout;
+    if (stdout is List<int>) return Uint8List.fromList(stdout);
+    if (stdout is String) return Uint8List.fromList(utf8.encode(stdout));
+    return null;
+  }
+
+  /// Heurística alinhada ao Git: NUL nos primeiros 8 KiB ⇒ binário.
+  static bool _isBinary(Uint8List bytes) {
+    final n = bytes.length < 8192 ? bytes.length : 8192;
+    for (var i = 0; i < n; i++) {
+      if (bytes[i] == 0) return true;
+    }
+    return false;
+  }
+}

--- a/cockpit/lib/app/cockpit/domain/contracts/git_head_baseline_reader.dart
+++ b/cockpit/lib/app/cockpit/domain/contracts/git_head_baseline_reader.dart
@@ -1,0 +1,14 @@
+import 'package:cockpit/app/cockpit/domain/entities/git_head_baseline.dart';
+
+/// Obtém o baseline textual de um path no snapshot `HEAD`.
+///
+/// Nunca usa working tree nem index como conteúdo de comparação. Falhas e
+/// paths inelegíveis devolvem `null` — sem lançar.
+abstract class GitHeadBaselineReader {
+  /// Identidade estável de `HEAD` no [repoPath], ou `null` se falhar.
+  Future<String?> resolveHeadIdentity(String repoPath);
+
+  /// Blob textual de [absPath] em `HEAD`, ou `null` se o path não estiver no
+  /// snapshot rastreado, for binário, ou a leitura falhar.
+  Future<GitHeadBaseline?> readTrackedText(String repoPath, String absPath);
+}

--- a/cockpit/lib/app/cockpit/domain/entities/git_head_baseline.dart
+++ b/cockpit/lib/app/cockpit/domain/entities/git_head_baseline.dart
@@ -1,0 +1,10 @@
+/// Conteúdo textual de um arquivo rastreado no commit apontado por `HEAD`.
+class GitHeadBaseline {
+  const GitHeadBaseline({required this.headIdentity, required this.content});
+
+  /// Identidade estável de `HEAD` (`git rev-parse HEAD`) no momento da leitura.
+  final String headIdentity;
+
+  /// Texto do blob em `HEAD` (UTF-8 tolerante).
+  final String content;
+}

--- a/cockpit/lib/app/cockpit/domain/entities/scm_line_decorations.dart
+++ b/cockpit/lib/app/cockpit/domain/entities/scm_line_decorations.dart
@@ -1,0 +1,58 @@
+/// Marcadores SCM imutáveis do buffer atual em relação ao baseline `HEAD`.
+///
+/// [addedLines] e [modifiedLines] usam numeração **base 1** das linhas atuais.
+/// [removalBoundaries] usa fronteiras `0..lineCount`: `0` = antes da primeira
+/// linha; `lineCount` = depois da última. Fronteiras repetidas são consolidadas
+/// no [Set].
+class ScmLineDecorations {
+  const ScmLineDecorations({
+    required this.addedLines,
+    required this.modifiedLines,
+    required this.removalBoundaries,
+  });
+
+  static const empty = ScmLineDecorations(
+    addedLines: <int>{},
+    modifiedLines: <int>{},
+    removalBoundaries: <int>{},
+  );
+
+  /// Linhas atuais (base 1) introduzidas sem correspondente no baseline.
+  final Set<int> addedLines;
+
+  /// Linhas atuais (base 1) que substituem linhas do baseline.
+  final Set<int> modifiedLines;
+
+  /// Fronteiras `0..lineCount` onde linhas do baseline foram removidas.
+  final Set<int> removalBoundaries;
+
+  bool get isEmpty =>
+      addedLines.isEmpty && modifiedLines.isEmpty && removalBoundaries.isEmpty;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScmLineDecorations &&
+        _setEq(addedLines, other.addedLines) &&
+        _setEq(modifiedLines, other.modifiedLines) &&
+        _setEq(removalBoundaries, other.removalBoundaries);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    Object.hashAllUnordered(addedLines),
+    Object.hashAllUnordered(modifiedLines),
+    Object.hashAllUnordered(removalBoundaries),
+  );
+
+  @override
+  String toString() =>
+      'ScmLineDecorations(added: $addedLines, modified: $modifiedLines, '
+      'removals: $removalBoundaries)';
+
+  static bool _setEq(Set<int> a, Set<int> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    return a.containsAll(b);
+  }
+}

--- a/cockpit/lib/app/cockpit/domain/services/scm_baseline_cache.dart
+++ b/cockpit/lib/app/cockpit/domain/services/scm_baseline_cache.dart
@@ -1,0 +1,56 @@
+import 'package:cockpit/app/cockpit/domain/contracts/git_head_baseline_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_head_baseline.dart';
+
+/// Cache de baseline por `(gitRoot, path, headIdentity)`.
+///
+/// Entradas de uma revisão antiga não são reutilizadas: a chave inclui a
+/// identidade de `HEAD`. [invalidateRepo] limpa tudo de uma root (retarget /
+/// troca de contexto).
+class ScmBaselineCache {
+  ScmBaselineCache(this._reader);
+
+  final GitHeadBaselineReader _reader;
+
+  final Map<String, GitHeadBaseline> _entries = <String, GitHeadBaseline>{};
+  final Map<String, String?> _headByRepo = <String, String?>{};
+
+  /// Resolve identidade de `HEAD` (com cache curto por root).
+  Future<String?> headIdentity(String repoPath) async {
+    if (_headByRepo.containsKey(repoPath)) return _headByRepo[repoPath];
+    final id = await _reader.resolveHeadIdentity(repoPath);
+    _headByRepo[repoPath] = id;
+    return id;
+  }
+
+  /// Baseline textual cacheado, ou `null` se inelegível/falha.
+  Future<GitHeadBaseline?> baselineFor(String repoPath, String absPath) async {
+    final head = await headIdentity(repoPath);
+    if (head == null) return null;
+
+    final key = _key(repoPath, absPath, head);
+    final cached = _entries[key];
+    if (cached != null) return cached;
+
+    final fresh = await _reader.readTrackedText(repoPath, absPath);
+    if (fresh == null) return null;
+    // Só cacheia se a identidade ainda bate (HEAD pode ter mudado durante I/O).
+    if (fresh.headIdentity != head) return fresh;
+    _entries[key] = fresh;
+    return fresh;
+  }
+
+  /// Descarta cache de [repoPath] (ex.: revisão Git mudou).
+  void invalidateRepo(String repoPath) {
+    _headByRepo.remove(repoPath);
+    _entries.removeWhere((key, _) => key.startsWith('$repoPath\u0000'));
+  }
+
+  /// Invalida todas as roots (ex.: refresh global).
+  void invalidateAll() {
+    _headByRepo.clear();
+    _entries.clear();
+  }
+
+  static String _key(String repoPath, String absPath, String head) =>
+      '$repoPath\u0000$absPath\u0000$head';
+}

--- a/cockpit/lib/app/cockpit/domain/services/scm_line_decoration_calculator.dart
+++ b/cockpit/lib/app/cockpit/domain/services/scm_line_decoration_calculator.dart
@@ -1,0 +1,179 @@
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
+
+/// Calcula [ScmLineDecorations] comparando o texto do baseline `HEAD` com o
+/// buffer atual, em memória — sem I/O nem processo Git.
+///
+/// Em cada bloco misto, pares posicionais viram modificações; sobras atuais
+/// viram adições; sobras do baseline viram **uma** fronteira de remoção.
+class ScmLineDecorationCalculator {
+  const ScmLineDecorationCalculator();
+
+  ScmLineDecorations calculate({
+    required String baseline,
+    required String current,
+  }) {
+    if (baseline == current) return ScmLineDecorations.empty;
+
+    final a = _splitLines(baseline);
+    final b = _splitLines(current);
+    final ops = _diffOps(a, b);
+
+    final added = <int>{};
+    final modified = <int>{};
+    final removals = <int>{};
+
+    var j = 0;
+    var opIndex = 0;
+
+    while (opIndex < ops.length) {
+      final op = ops[opIndex];
+      if (op == _Op.equal) {
+        j++;
+        opIndex++;
+        continue;
+      }
+
+      var deleteCount = 0;
+      var insertCount = 0;
+      while (opIndex < ops.length) {
+        final kind = ops[opIndex];
+        if (kind == _Op.equal) break;
+        if (kind == _Op.delete) {
+          deleteCount++;
+        } else {
+          insertCount++;
+        }
+        opIndex++;
+      }
+
+      final pairs = deleteCount < insertCount ? deleteCount : insertCount;
+      for (var p = 0; p < pairs; p++) {
+        modified.add(j + p + 1);
+      }
+      for (var p = pairs; p < insertCount; p++) {
+        added.add(j + p + 1);
+      }
+      if (deleteCount > pairs) {
+        // Fronteira após as linhas atuais do bloco (ou antes da próxima
+        // sobrevivente quando o bloco é só remoção).
+        final boundary = j + insertCount;
+        removals.add(boundary);
+      }
+
+      j += insertCount;
+    }
+
+    if (added.isEmpty && modified.isEmpty && removals.isEmpty) {
+      return ScmLineDecorations.empty;
+    }
+    return ScmLineDecorations(
+      addedLines: added,
+      modifiedLines: modified,
+      removalBoundaries: removals,
+    );
+  }
+
+  /// Mesma regra do editor: `split('\n')` — `"a\n"` vira `["a", ""]`.
+  static List<String> _splitLines(String text) => text.split('\n');
+
+  /// Myers O(ND) simplificado → lista de ops alinhadas às sequências.
+  static List<_Op> _diffOps(List<String> a, List<String> b) {
+    final n = a.length;
+    final m = b.length;
+    if (n == 0 && m == 0) return const <_Op>[];
+    if (n == 0) return List<_Op>.filled(m, _Op.insert);
+    if (m == 0) return List<_Op>.filled(n, _Op.delete);
+
+    final max = n + m;
+    final offset = max;
+    final v = List<int>.filled(2 * max + 1, 0);
+    final trace = <List<int>>[];
+
+    for (var d = 0; d <= max; d++) {
+      final vSnapshot = List<int>.from(v);
+      for (var k = -d; k <= d; k += 2) {
+        late int x;
+        if (k == -d || (k != d && v[offset + k - 1] < v[offset + k + 1])) {
+          x = v[offset + k + 1];
+        } else {
+          x = v[offset + k - 1] + 1;
+        }
+        var y = x - k;
+        while (x < n && y < m && a[x] == b[y]) {
+          x++;
+          y++;
+        }
+        v[offset + k] = x;
+        if (x >= n && y >= m) {
+          trace.add(vSnapshot);
+          return _backtrack(trace, v, a, b, d, offset);
+        }
+      }
+      trace.add(vSnapshot);
+    }
+    // Fallback (não deveria ocorrer): tratar tudo como substituição.
+    return <_Op>[
+      ...List<_Op>.filled(n, _Op.delete),
+      ...List<_Op>.filled(m, _Op.insert),
+    ];
+  }
+
+  static List<_Op> _backtrack(
+    List<List<int>> trace,
+    List<int> finalV,
+    List<String> a,
+    List<String> b,
+    int dFinal,
+    int offset,
+  ) {
+    final ops = <_Op>[];
+    var x = a.length;
+    var y = b.length;
+    // Inclui o V final no trace lógico.
+    final all = [...trace, List<int>.from(finalV)];
+
+    for (var d = dFinal; d > 0; d--) {
+      final v = all[d];
+      final k = x - y;
+      late int prevK;
+      if (k == -d || (k != d && v[offset + k - 1] < v[offset + k + 1])) {
+        prevK = k + 1;
+      } else {
+        prevK = k - 1;
+      }
+      final prevX = v[offset + prevK];
+      final prevY = prevX - prevK;
+
+      while (x > prevX && y > prevY) {
+        ops.add(_Op.equal);
+        x--;
+        y--;
+      }
+      if (x == prevX) {
+        ops.add(_Op.insert);
+        y--;
+      } else {
+        ops.add(_Op.delete);
+        x--;
+      }
+      x = prevX;
+      y = prevY;
+    }
+    while (x > 0 && y > 0) {
+      ops.add(_Op.equal);
+      x--;
+      y--;
+    }
+    while (x > 0) {
+      ops.add(_Op.delete);
+      x--;
+    }
+    while (y > 0) {
+      ops.add(_Op.insert);
+      y--;
+    }
+    return ops.reversed.toList(growable: false);
+  }
+}
+
+enum _Op { equal, insert, delete }

--- a/cockpit/lib/app/cockpit/ui/session/file_viewer_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/file_viewer_session.dart
@@ -112,6 +112,7 @@ class FileViewerSession extends PaneItem {
   void attachScmCoordinator(ScmLineDecorationCoordinator coordinator) {
     scmCoordinator?.dispose();
     scmCoordinator = coordinator;
+    notifyListeners();
   }
 
   void clearScmDecorations() {

--- a/cockpit/lib/app/cockpit/ui/session/file_viewer_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/file_viewer_session.dart
@@ -1,5 +1,7 @@
 import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
+import 'package:cockpit/app/cockpit/ui/session/scm_line_decoration_coordinator.dart';
 
 /// Uma aba de viewer read-only de arquivo (texto/markdown/imagem). O conteúdo
 /// ([view]) já vem classificado/lido pela VM (binário/vídeo nem chega aqui).
@@ -45,6 +47,7 @@ class FileViewerSession extends PaneItem {
   void retarget(String newPath) {
     if (newPath == path) return;
     path = newPath;
+    scmCoordinator?.onSessionPathChanged();
     notifyListeners();
   }
 
@@ -94,19 +97,28 @@ class FileViewerSession extends PaneItem {
   /// compara o tick pra disparar de novo mesmo sem mudança de [revealLine]).
   int revealTick = 0;
 
-  /// Linhas do working tree decoradas no gutter pelo Source Control.
-  Set<int> addedLines = const {};
-  Set<int> modifiedLines = const {};
-  Set<int> removedLines = const {};
+  /// Decorações SCM do buffer atual vs `HEAD` (estado derivado, efêmero).
+  ScmLineDecorations scmDecorations = ScmLineDecorations.empty;
 
-  void setGitChangeLines({
-    required Set<int> added,
-    required Set<int> modified,
-    required Set<int> removed,
-  }) {
-    addedLines = added;
-    modifiedLines = modified;
-    removedLines = removed;
+  /// Coordenador reativo; criado pela VM em aberturas textuais elegíveis.
+  ScmLineDecorationCoordinator? scmCoordinator;
+
+  void setScmDecorations(ScmLineDecorations value) {
+    if (scmDecorations == value) return;
+    scmDecorations = value;
+    notifyListeners();
+  }
+
+  void attachScmCoordinator(ScmLineDecorationCoordinator coordinator) {
+    scmCoordinator?.dispose();
+    scmCoordinator = coordinator;
+  }
+
+  void clearScmDecorations() {
+    scmCoordinator?.dispose();
+    scmCoordinator = null;
+    if (scmDecorations.isEmpty) return;
+    scmDecorations = ScmLineDecorations.empty;
     notifyListeners();
   }
 
@@ -116,5 +128,12 @@ class FileViewerSession extends PaneItem {
     revealSelect = select;
     revealTick++;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    scmCoordinator?.dispose();
+    scmCoordinator = null;
+    super.dispose();
   }
 }

--- a/cockpit/lib/app/cockpit/ui/session/scm_line_decoration_coordinator.dart
+++ b/cockpit/lib/app/cockpit/ui/session/scm_line_decoration_coordinator.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_baseline_cache.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_line_decoration_calculator.dart';
+import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
+import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
+
+/// Coordena baseline Git + debounce do buffer → [FileViewerSession.scmDecorations].
+///
+/// Publicação assíncrona só ocorre quando sessão, path, identidade do baseline
+/// e buffer revision ainda são os da solicitação.
+class ScmLineDecorationCoordinator {
+  ScmLineDecorationCoordinator({
+    required this.session,
+    required this.cache,
+    required this.calculator,
+    required this.resolveGitRoot,
+    this.debounce = const Duration(milliseconds: 120),
+  });
+
+  final FileViewerSession session;
+  final ScmBaselineCache cache;
+  final ScmLineDecorationCalculator calculator;
+  final String? Function(String absPath) resolveGitRoot;
+  final Duration debounce;
+
+  CodeEditingController? _controller;
+  Timer? _debounce;
+  int _bufferRevision = 0;
+  String? _baselineContent;
+  String? _baselineHead;
+  bool _disposed = false;
+  bool _loadingBaseline = false;
+
+  /// Liga o controller do editor e inicia o ciclo (baseline + cálculo).
+  void attachController(CodeEditingController controller) {
+    if (_disposed) return;
+    if (identical(_controller, controller)) return;
+    _detachControllerOnly();
+    _controller = controller;
+    controller.addListener(_onBufferChanged);
+    _clearPublished();
+    unawaited(_reloadBaselineAndSchedule());
+  }
+
+  /// Troca de path (preview reuse / retarget) — limpa e recarrega.
+  void onSessionPathChanged() {
+    if (_disposed) return;
+    _debounce?.cancel();
+    _bufferRevision++;
+    _baselineContent = null;
+    _baselineHead = null;
+    _clearPublished();
+    if (_controller != null) {
+      unawaited(_reloadBaselineAndSchedule());
+    }
+  }
+
+  /// Revisão Git mudou — invalida baseline da root e recalcula.
+  void onGitRevisionChanged() {
+    if (_disposed) return;
+    final root = resolveGitRoot(session.path);
+    if (root != null) cache.invalidateRepo(root);
+    _baselineContent = null;
+    _baselineHead = null;
+    _bufferRevision++;
+    unawaited(_reloadBaselineAndSchedule());
+  }
+
+  /// Buffer adotou conteúdo externo (watcher).
+  void onExternalContentAdopted() {
+    if (_disposed || _controller == null) return;
+    _scheduleCalculate();
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _debounce?.cancel();
+    _debounce = null;
+    _detachControllerOnly();
+    _clearPublished();
+  }
+
+  void _detachControllerOnly() {
+    _controller?.removeListener(_onBufferChanged);
+    _controller = null;
+  }
+
+  void _onBufferChanged() => _scheduleCalculate();
+
+  void _clearPublished() {
+    session.setScmDecorations(ScmLineDecorations.empty);
+  }
+
+  Future<void> _reloadBaselineAndSchedule() async {
+    if (_disposed) return;
+    if (session.scratch) {
+      _baselineContent = null;
+      _baselineHead = null;
+      _clearPublished();
+      return;
+    }
+
+    final path = session.path;
+    final root = resolveGitRoot(path);
+    if (root == null) {
+      _baselineContent = null;
+      _baselineHead = null;
+      _clearPublished();
+      return;
+    }
+
+    _loadingBaseline = true;
+    final requestPath = path;
+    final baseline = await cache.baselineFor(root, path);
+    _loadingBaseline = false;
+    if (_disposed || session.path != requestPath) return;
+
+    if (baseline == null) {
+      _baselineContent = null;
+      _baselineHead = null;
+      _clearPublished();
+      return;
+    }
+
+    _baselineContent = baseline.content;
+    _baselineHead = baseline.headIdentity;
+    _scheduleCalculate(immediate: true);
+  }
+
+  void _scheduleCalculate({bool immediate = false}) {
+    if (_disposed || _controller == null) return;
+    _debounce?.cancel();
+    final revision = ++_bufferRevision;
+    if (immediate) {
+      unawaited(_calculate(revision));
+      return;
+    }
+    _debounce = Timer(debounce, () => unawaited(_calculate(revision)));
+  }
+
+  Future<void> _calculate(int revision) async {
+    if (_disposed) return;
+    final controller = _controller;
+    final baseline = _baselineContent;
+    final head = _baselineHead;
+    final path = session.path;
+    if (controller == null || baseline == null || head == null) {
+      if (!_loadingBaseline) _clearPublished();
+      return;
+    }
+
+    final current = controller.text;
+    final sessionId = session.id;
+    final calc = calculator;
+
+    // Cede o frame atual e calcula fora do caminho síncrono de pintura.
+    final result = await Future<ScmLineDecorations>(() {
+      return calc.calculate(baseline: baseline, current: current);
+    });
+
+    if (_disposed) return;
+    if (session.id != sessionId) return;
+    if (session.path != path) return;
+    if (_baselineHead != head) return;
+    if (revision != _bufferRevision) return;
+
+    session.setScmDecorations(result);
+  }
+}

--- a/cockpit/lib/app/cockpit/ui/session/scm_line_decoration_coordinator.dart
+++ b/cockpit/lib/app/cockpit/ui/session/scm_line_decoration_coordinator.dart
@@ -10,6 +10,10 @@ import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
 ///
 /// Publicação assíncrona só ocorre quando sessão, path, identidade do baseline
 /// e buffer revision ainda são os da solicitação.
+///
+/// Reloads de baseline usam [_baselineEpoch]: um resultado atrasado (ex.: root
+/// errada no boot antes do `git.refresh`) não pode limpar/publicar por cima
+/// de um reload mais novo.
 class ScmLineDecorationCoordinator {
   ScmLineDecorationCoordinator({
     required this.session,
@@ -28,6 +32,7 @@ class ScmLineDecorationCoordinator {
   CodeEditingController? _controller;
   Timer? _debounce;
   int _bufferRevision = 0;
+  int _baselineEpoch = 0;
   String? _baselineContent;
   String? _baselineHead;
   bool _disposed = false;
@@ -54,6 +59,9 @@ class ScmLineDecorationCoordinator {
     _clearPublished();
     if (_controller != null) {
       unawaited(_reloadBaselineAndSchedule());
+    } else {
+      _baselineEpoch++;
+      _loadingBaseline = false;
     }
   }
 
@@ -77,6 +85,7 @@ class ScmLineDecorationCoordinator {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _baselineEpoch++;
     _debounce?.cancel();
     _debounce = null;
     _detachControllerOnly();
@@ -96,9 +105,13 @@ class ScmLineDecorationCoordinator {
 
   Future<void> _reloadBaselineAndSchedule() async {
     if (_disposed) return;
+    final epoch = ++_baselineEpoch;
+
     if (session.scratch) {
+      if (epoch != _baselineEpoch) return;
       _baselineContent = null;
       _baselineHead = null;
+      _loadingBaseline = false;
       _clearPublished();
       return;
     }
@@ -106,17 +119,20 @@ class ScmLineDecorationCoordinator {
     final path = session.path;
     final root = resolveGitRoot(path);
     if (root == null) {
+      if (epoch != _baselineEpoch) return;
       _baselineContent = null;
       _baselineHead = null;
+      _loadingBaseline = false;
       _clearPublished();
       return;
     }
 
     _loadingBaseline = true;
-    final requestPath = path;
     final baseline = await cache.baselineFor(root, path);
+    if (_disposed || epoch != _baselineEpoch) return;
+
     _loadingBaseline = false;
-    if (_disposed || session.path != requestPath) return;
+    if (session.path != path) return;
 
     if (baseline == null) {
       _baselineContent = null;

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -223,6 +223,10 @@ class CockpitViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Garante coordenador SCM na sessão (abertura, restore ou mount do FileViewer).
+  void ensureScmCoordinator(FileViewerSession session) =>
+      _ensureScmCoordinator(session);
+
   void _ensureScmCoordinator(FileViewerSession session) {
     final editable =
         session.view is FileViewText ||
@@ -4192,12 +4196,17 @@ class CockpitViewModel extends ChangeNotifier {
         if (path == null) return false;
         final view = await _fileReader.read(path);
         if (view is FileViewUnsupported) return false;
-        _sessions[id] = FileViewerSession(
+        final viewer = FileViewerSession(
           id: id,
           projectId: project.id,
           path: path,
           view: view,
         );
+        // Same pipeline as openFile: SCM coordinator + live-reload.
+        // Without this, restored tabs have no diff gutter until reopen.
+        _ensureScmCoordinator(viewer);
+        _sessions[id] = viewer;
+        _watchFileViewer(viewer);
         return true;
       case 'diff':
         final path = desc['path'] as String?;

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -23,7 +23,10 @@ import 'package:cockpit/app/cockpit/domain/contracts/folder_lister.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_command_runner.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_diff_reader.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_history_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
 import 'package:cockpit/app/cockpit/domain/exceptions/git_history_error.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_baseline_cache.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_line_decoration_calculator.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/layout_loader.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/notifier.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/project_repository.dart';
@@ -58,6 +61,7 @@ import 'package:cockpit/app/cockpit/domain/value_objects/uid.dart';
 import 'package:cockpit/app/cockpit/domain/entities/session_info.dart';
 import 'package:cockpit/app/cockpit/domain/entities/thinking_level.dart';
 import 'package:cockpit/app/cockpit/domain/entities/worktree.dart';
+import 'package:cockpit/app/cockpit/ui/session/scm_line_decoration_coordinator.dart';
 import 'package:cockpit/app/core/data/lsp/lsp_server_pool.dart';
 import 'package:cockpit/app/core/data/lsp/lsp_text_edit.dart';
 import 'package:cockpit/app/core/domain/entities/lsp_diagnostic.dart';
@@ -127,6 +131,8 @@ class CockpitViewModel extends ChangeNotifier {
     this._taskRunner,
     this._dbService,
     this._layoutLoader,
+    this._scmBaselineCache,
+    this._scmCalculator,
   ) {
     // Contexto do shell que o GitController precisa (page-scoped, mesma vida).
     git
@@ -136,7 +142,8 @@ class CockpitViewModel extends ChangeNotifier {
       ..pollTargets = _gitPollTargets
       ..onStructuralFsChange = _bumpFileTree
       ..onPoll = _reconcileOpenWorktrees;
-    git.addListener(notifyListeners);
+    _lastGitRevision = git.revision;
+    git.addListener(_onGitNotify);
     realmCtrl.addListener(notifyListeners);
   }
 
@@ -198,7 +205,44 @@ class CockpitViewModel extends ChangeNotifier {
   final GitDiffReader _gitDiff;
   final GitHistoryReader _gitHistory;
   final AutomationController _automation;
+  final ScmBaselineCache _scmBaselineCache;
+  final ScmLineDecorationCalculator _scmCalculator;
   AutomationSelection? _automationSelection;
+  int _lastGitRevision = 0;
+
+  void _onGitNotify() {
+    final rev = git.revision;
+    if (rev != _lastGitRevision) {
+      _lastGitRevision = rev;
+      for (final s in _sessions.values) {
+        if (s is FileViewerSession) {
+          s.scmCoordinator?.onGitRevisionChanged();
+        }
+      }
+    }
+    notifyListeners();
+  }
+
+  void _ensureScmCoordinator(FileViewerSession session) {
+    final editable =
+        session.view is FileViewText ||
+        session.view is FileViewMarkdown ||
+        session.view is FileViewSvg;
+    if (session.scratch || !editable) {
+      session.clearScmDecorations();
+      return;
+    }
+    // Não recria se já existe — o FileViewer mantém o controller ligado.
+    if (session.scmCoordinator != null) return;
+    session.attachScmCoordinator(
+      ScmLineDecorationCoordinator(
+        session: session,
+        cache: _scmBaselineCache,
+        calculator: _scmCalculator,
+        resolveGitRoot: (path) => rootContaining(session.projectId, path),
+      ),
+    );
+  }
 
   void setAutomationSelection(AutomationSelection? selection) {
     _automationSelection = selection;
@@ -641,9 +685,6 @@ class CockpitViewModel extends ChangeNotifier {
     String? inPane,
     bool isPreview = true,
     int? revealLine,
-    Set<int>? addedLines,
-    Set<int>? modifiedLines,
-    Set<int>? removedLines,
   }) async {
     final projectId = _selectedProjectId;
     final tree = _activeTree;
@@ -664,15 +705,7 @@ class CockpitViewModel extends ChangeNotifier {
         // Se já aberto, só seleciona (mas transforma preview em normal se não é preview).
         if (s.path == path) {
           if (!isPreview && s.isPreview) s.pin();
-          if (addedLines != null &&
-              modifiedLines != null &&
-              removedLines != null) {
-            s.setGitChangeLines(
-              added: addedLines,
-              modified: modifiedLines,
-              removed: removedLines,
-            );
-          }
+          _ensureScmCoordinator(s);
           if (revealLine != null) s.reveal(revealLine, select: false);
           _trees[projectId] = updateLeaf(
             tree,
@@ -698,13 +731,9 @@ class CockpitViewModel extends ChangeNotifier {
       previewCandidate.view = view;
       previewCandidate.dirty = false;
       previewCandidate.revealLine = null;
-      if (addedLines != null && modifiedLines != null && removedLines != null) {
-        previewCandidate.setGitChangeLines(
-          added: addedLines,
-          modified: modifiedLines,
-          removed: removedLines,
-        );
-      }
+      previewCandidate.setScmDecorations(ScmLineDecorations.empty);
+      _ensureScmCoordinator(previewCandidate);
+      previewCandidate.scmCoordinator?.onSessionPathChanged();
       if (revealLine != null) {
         previewCandidate.reveal(revealLine, select: false);
       } else {
@@ -727,13 +756,7 @@ class CockpitViewModel extends ChangeNotifier {
       view: view,
       isPreview: isPreview,
     );
-    if (addedLines != null && modifiedLines != null && removedLines != null) {
-      viewer.setGitChangeLines(
-        added: addedLines,
-        modified: modifiedLines,
-        removed: removedLines,
-      );
-    }
+    _ensureScmCoordinator(viewer);
     if (revealLine != null) viewer.reveal(revealLine, select: false);
     _sessions[viewer.id] = viewer;
     _watchFileViewer(viewer);
@@ -789,8 +812,9 @@ class CockpitViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Abre uma mudanca no arquivo normal, revelando a primeira linha afetada.
-  /// Arquivos apagados nao existem mais no working tree e continuam no diff.
+  /// Abre uma mudança do Source Control no editor normal. Decorações vêm do
+  /// coordenador SCM (buffer vs `HEAD`), não de uma injeção pontual do diff.
+  /// Arquivos apagados não existem mais no working tree e continuam no diff.
   Future<void> openChangedFile(String path) async {
     final projectId = _selectedProjectId;
     if (projectId == null) return;
@@ -801,66 +825,7 @@ class CockpitViewModel extends ChangeNotifier {
     if (_selectedProjectId != projectId || diff.kind == FileDiffKind.deleted) {
       return;
     }
-    final changes = _gitChangeLines(diff);
-    await openFile(
-      path,
-      isPreview: false,
-      revealLine: changes.firstLine,
-      addedLines: changes.added,
-      modifiedLines: changes.modified,
-      removedLines: changes.removed,
-    );
-  }
-
-  ({Set<int> added, Set<int> modified, Set<int> removed, int? firstLine})
-  _gitChangeLines(FileDiff diff) {
-    final added = <int>{};
-    final modified = <int>{};
-    final removed = <int>{};
-    int? firstLine;
-    final pendingRemoved = <DiffLine>[];
-    final pendingAdded = <DiffLine>[];
-
-    void flush() {
-      final pairs = pendingRemoved.length < pendingAdded.length
-          ? pendingRemoved.length
-          : pendingAdded.length;
-      for (var index = 0; index < pairs; index++) {
-        final line = pendingAdded[index].newLine;
-        if (line != null) modified.add(line);
-      }
-      for (final line in pendingAdded.skip(pairs)) {
-        if (line.newLine != null) added.add(line.newLine!);
-      }
-      for (final line in pendingRemoved.skip(pairs)) {
-        if (line.oldLine != null) removed.add(line.oldLine!);
-      }
-      pendingRemoved.clear();
-      pendingAdded.clear();
-    }
-
-    for (final hunk in diff.hunks) {
-      for (final line in hunk.lines) {
-        if (line.kind != DiffLineKind.context) {
-          firstLine ??= line.newLine ?? line.oldLine;
-        }
-        switch (line.kind) {
-          case DiffLineKind.removed:
-            pendingRemoved.add(line);
-          case DiffLineKind.added:
-            pendingAdded.add(line);
-          case DiffLineKind.context:
-            flush();
-        }
-      }
-      flush();
-    }
-    return (
-      added: added,
-      modified: modified,
-      removed: removed,
-      firstLine: firstLine,
-    );
+    await openFile(path, isPreview: false);
   }
 
   /// Abre uma tab `.dbq` **untitled** (scratch, VSCode-style): buffer em
@@ -4745,7 +4710,7 @@ class CockpitViewModel extends ChangeNotifier {
     unawaited(_statusServer.stop());
     // O GitController é dono dos próprios timers/watchers; o módulo o
     // descarta junto com a rota. Aqui só desligamos o repasse de notify.
-    git.removeListener(notifyListeners);
+    git.removeListener(_onGitNotify);
     realmCtrl.removeListener(notifyListeners);
     for (final t in _saveTimers.values) {
       t.cancel();

--- a/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
@@ -2,23 +2,24 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/editor_overview_ruler.dart';
 import 'package:cockpit/app/core/domain/entities/lsp_diagnostic.dart';
 import 'package:cockpit/app/core/ui/clamping_scroll_behavior.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/app_tooltip.dart';
 import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
+import 'package:flutter/gestures.dart' show PointerHoverEvent;
 import 'package:flutter/material.dart'
     show
         Icon,
         Icons,
+        InputBorder,
+        InputDecoration,
         Scrollbar,
         ScrollbarOrientation,
+        SystemMouseCursors,
         TextField,
-        InputDecoration,
-        InputBorder,
-        TextInputType,
-        SystemMouseCursors;
-import 'package:flutter/gestures.dart' show PointerHoverEvent;
+        TextInputType;
 import 'package:flutter/services.dart' show HardwareKeyboard;
 import 'package:flutter/widgets.dart';
 
@@ -208,8 +209,8 @@ class _CodeEditorState extends State<CodeEditor> {
   }
 
   /// Rola até a linha [oneBased] (base 1). Busca a seleciona; Source Control
-  /// apenas posiciona o cursor e deixa as decoracoes Git explicarem a mudanca.
-  void _reveal(int oneBased) {
+  /// e overview SCM apenas posicionam o cursor.
+  void _reveal(int oneBased, {bool? select}) {
     final text = widget.controller.text;
     final lines = text.split('\n');
     final idx = oneBased - 1;
@@ -219,10 +220,11 @@ class _CodeEditorState extends State<CodeEditor> {
       start += lines[i].length + 1; // +1 do '\n'
     }
     final end = start + lines[idx].length;
+    final doSelect = select ?? widget.revealSelect;
     // Extent no INÍCIO da linha (base no fim): a seleção cobre a linha inteira
     // igual, mas o `bringIntoView` do campo segue o extent → rola a horizontal
     // pra esquerda (início), em vez de empurrar pro fim da linha.
-    widget.controller.selection = widget.revealSelect
+    widget.controller.selection = doSelect
         ? TextSelection(baseOffset: end, extentOffset: start)
         : TextSelection.collapsed(offset: start);
     widget.focusNode.requestFocus();
@@ -655,11 +657,13 @@ class _CodeEditorState extends State<CodeEditor> {
   Widget _editorScroll() {
     final syntax = context.syntax;
     final typo = context.typo;
+    final colors = context.colors;
     final codeStyle = typo.mono.copyWith(color: syntax.base);
     final numStyle = typo.mono.copyWith(
       color: syntax.base.withValues(alpha: 0.4),
     );
     final lineCount = _lineCount;
+    final scm = widget.scmDecorations;
     return Scrollbar(
       controller: _horizontal,
       thumbVisibility: true,
@@ -671,118 +675,186 @@ class _CodeEditorState extends State<CodeEditor> {
         // O shadcn adiciona uma scrollbar vertical automática a cada Scrollable
         // desktop. Gutter e TextField precisam de scrolls próprios para ficarem
         // sincronizados, mas suas barras duplicariam a barra deste painel.
-        child: ScrollConfiguration(
-          behavior: const _CodeEditorScrollBehavior(),
-          // Topo: frame FIXO fora dos scrolls (gutter e campo em y=0, lockstep).
-          // Fundo: a folga mora DENTRO dos scrolls (`_padBottom` no ListView e no
-          // contentPadding do campo) — senão a última linha assenta no fio do
-          // viewport e a scrollbar horizontal (overlay) corta o número/texto.
-          child: Padding(
-            padding: const EdgeInsets.only(top: _padTop),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Gutter — scroll próprio (travado ao input) espelhando `_vertical`.
-                //
-                // `ListView.builder` (e não `Column`): com uma Column, um arquivo
-                // de 5k linhas materializava 5000 Rows+Texts A CADA rebuild — e
-                // rebuild acontece até quando o mouse cruza uma linha (o tooltip
-                // de diagnostic faz setState). Virtualizado, só as ~40 linhas
-                // visíveis são construídas, e `severityForLine` (que varre os
-                // diagnostics) roda só pra elas.
-                //
-                // `itemExtent: _lineHeight` é o que mantém o alinhamento 1:1 com
-                // o texto — mesma métrica que o campo usa por linha — e ainda dá
-                // scroll O(1) (o `jumpTo` do `_syncGutter` não precisa medir os
-                // itens anteriores). Largura fixa porque a ListView, ao contrário
-                // da Column dentro do SingleChildScrollView, não é intrínseca:
-                // sem isso o gutter esticaria e comeria o campo.
-                Padding(
-                  padding: const EdgeInsets.only(left: 14, right: 14),
-                  child: SizedBox(
-                    width: _iconSlot + _digitsWidth,
-                    child: ListView.builder(
-                      controller: _gutter,
-                      physics: const NeverScrollableScrollPhysics(),
-                      padding: const EdgeInsets.only(bottom: _padBottom),
-                      itemExtent: _lineHeight,
-                      itemCount: lineCount,
-                      itemBuilder: (context, i) => _gutterLine(i + 1, numStyle),
-                    ),
-                  ),
-                ),
-                Container(width: 1, color: syntax.base.withValues(alpha: 0.15)),
-                Expanded(
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      // Largura mínima = viewport (menos o padding H). Sem isso, o
-                      // IntrinsicWidth colapsa o campo a ~0 quando o arquivo está
-                      // vazio (recém-criado) → sem área pra clicar/digitar.
-                      final minWidth = (constraints.maxWidth - 30).clamp(
-                        0.0,
-                        double.infinity,
-                      );
-                      return SingleChildScrollView(
-                        controller: _horizontal,
-                        scrollDirection: Axis.horizontal,
-                        padding: const EdgeInsets.only(left: 14, right: 16),
-                        // `TextField` (e não `EditableText` cru) pra ganhar os
-                        // gestos de seleção do desktop: arrastar com o mouse,
-                        // duplo-clique, Cmd+A. O highlight vem do `buildTextSpan`
-                        // do controller; a decoração é zerada (sem borda/fundo).
-                        child: ConstrainedBox(
-                          constraints: BoxConstraints(minWidth: minWidth),
-                          child: IntrinsicWidth(
-                            child: TextField(
-                              controller: widget.controller,
-                              focusNode: widget.focusNode,
-                              // O campo é o DONO do scroll vertical (scroll interno)
-                              // → fica parado no espaço global e a âncora da seleção
-                              // não escorrega durante o auto-scroll do drag.
-                              scrollController: _vertical,
-                              style: codeStyle,
-                              cursorColor: syntax.base,
-                              maxLines: null,
-                              minLines: null,
-                              // Preenche a altura do viewport e rola o conteúdo
-                              // internamente; o gutter espelha via `_syncGutter`.
-                              expands: true,
-                              keyboardType: TextInputType.multiline,
-                              // `onTap` do próprio TextField dispara DEPOIS que o
-                              // toque já moveu `controller.selection` pra posição
-                              // clicada (comportamento interno do EditableText) —
-                              // por isso lemos a seleção aqui, não num
-                              // GestureDetector externo (que veria a seleção ANTIGA,
-                              // antes do TextField processar o tap).
-                              onTap: _definitionModeActive
-                                  ? _onDefinitionTap
-                                  : null,
-                              // TextField sempre define seu PRÓPRIO cursor (I-beam)
-                              // por padrão — sobrescreve o `MouseRegion` externo, que
-                              // nunca vencia a resolução de cursor (o descendente mais
-                              // específico ganha). Precisa ser setado aqui pra virar
-                              // clicável de fato durante o hover de definition.
-                              mouseCursor: _defCursor,
-                              decoration: const InputDecoration(
-                                isCollapsed: true,
-                                border: InputBorder.none,
-                                // Mesma folga do gutter — mantém lockstep no fim.
-                                contentPadding: EdgeInsets.only(
-                                  bottom: _padBottom,
-                                ),
-                              ),
-                            ),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Positioned.fill(
+              child: ScrollConfiguration(
+                behavior: const _CodeEditorScrollBehavior(),
+                // Topo: frame FIXO fora dos scrolls (gutter e campo em y=0, lockstep).
+                // Fundo: a folga mora DENTRO dos scrolls (`_padBottom` no ListView e no
+                // contentPadding do campo) — senão a última linha assenta no fio do
+                // viewport e a scrollbar horizontal (overlay) corta o número/texto.
+                child: Padding(
+                  padding: const EdgeInsets.only(top: _padTop),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Gutter — scroll próprio (travado ao input) espelhando `_vertical`.
+                      //
+                      // `ListView.builder` (e não `Column`): com uma Column, um arquivo
+                      // de 5k linhas materializava 5000 Rows+Texts A CADA rebuild — e
+                      // rebuild acontece até quando o mouse cruza uma linha (o tooltip
+                      // de diagnostic faz setState). Virtualizado, só as ~40 linhas
+                      // visíveis são construídas, e `severityForLine` (que varre os
+                      // diagnostics) roda só pra elas.
+                      //
+                      // `itemExtent: _lineHeight` é o que mantém o alinhamento 1:1 com
+                      // o texto — mesma métrica que o campo usa por linha — e ainda dá
+                      // scroll O(1) (o `jumpTo` do `_syncGutter` não precisa medir os
+                      // itens anteriores). Largura fixa porque a ListView, ao contrário
+                      // da Column dentro do SingleChildScrollView, não é intrínseca:
+                      // sem isso o gutter esticaria e comeria o campo.
+                      Padding(
+                        padding: const EdgeInsets.only(left: 14, right: 14),
+                        child: SizedBox(
+                          width: _iconSlot + _digitsWidth,
+                          child: ListView.builder(
+                            controller: _gutter,
+                            physics: const NeverScrollableScrollPhysics(),
+                            padding: const EdgeInsets.only(bottom: _padBottom),
+                            itemExtent: _lineHeight,
+                            itemCount: lineCount,
+                            itemBuilder: (context, i) =>
+                                _gutterLine(i + 1, numStyle),
                           ),
                         ),
-                      );
-                    },
+                      ),
+                      Container(
+                        width: 1,
+                        color: syntax.base.withValues(alpha: 0.15),
+                      ),
+                      Expanded(
+                        child: LayoutBuilder(
+                          builder: (context, constraints) {
+                            // Largura mínima = viewport (menos o padding H). Sem isso, o
+                            // IntrinsicWidth colapsa o campo a ~0 quando o arquivo está
+                            // vazio (recém-criado) → sem área pra clicar/digitar.
+                            final minWidth = (constraints.maxWidth - 30).clamp(
+                              0.0,
+                              double.infinity,
+                            );
+                            return SingleChildScrollView(
+                              controller: _horizontal,
+                              scrollDirection: Axis.horizontal,
+                              padding: const EdgeInsets.only(
+                                left: 14,
+                                right: 16,
+                              ),
+                              // `TextField` (e não `EditableText` cru) pra ganhar os
+                              // gestos de seleção do desktop: arrastar com o mouse,
+                              // duplo-clique, Cmd+A. O highlight vem do `buildTextSpan`
+                              // do controller; a decoração é zerada (sem borda/fundo).
+                              child: ConstrainedBox(
+                                constraints: BoxConstraints(minWidth: minWidth),
+                                child: IntrinsicWidth(
+                                  child: TextField(
+                                    controller: widget.controller,
+                                    focusNode: widget.focusNode,
+                                    // O campo é o DONO do scroll vertical (scroll interno)
+                                    // → fica parado no espaço global e a âncora da seleção
+                                    // não escorrega durante o auto-scroll do drag.
+                                    scrollController: _vertical,
+                                    style: codeStyle,
+                                    cursorColor: syntax.base,
+                                    maxLines: null,
+                                    minLines: null,
+                                    // Preenche a altura do viewport e rola o conteúdo
+                                    // internamente; o gutter espelha via `_syncGutter`.
+                                    expands: true,
+                                    keyboardType: TextInputType.multiline,
+                                    // `onTap` do próprio TextField dispara DEPOIS que o
+                                    // toque já moveu `controller.selection` pra posição
+                                    // clicada (comportamento interno do EditableText) —
+                                    // por isso lemos a seleção aqui, não num
+                                    // GestureDetector externo (que veria a seleção ANTIGA,
+                                    // antes do TextField processar o tap).
+                                    onTap: _definitionModeActive
+                                        ? _onDefinitionTap
+                                        : null,
+                                    // TextField sempre define seu PRÓPRIO cursor (I-beam)
+                                    // por padrão — sobrescreve o `MouseRegion` externo, que
+                                    // nunca vencia a resolução de cursor (o descendente mais
+                                    // específico ganha). Precisa ser setado aqui pra virar
+                                    // clicável de fato durante o hover de definition.
+                                    mouseCursor: _defCursor,
+                                    decoration: const InputDecoration(
+                                      isCollapsed: true,
+                                      border: InputBorder.none,
+                                      // Mesma folga do gutter — mantém lockstep no fim.
+                                      contentPadding: EdgeInsets.only(
+                                        bottom: _padBottom,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-              ],
+              ),
             ),
-          ),
+            // Overview multi-coluna sob a scrollbar (git agora; diagnostics depois).
+            // A Scrollbar pai pinta o thumb por cima desta strip.
+            if (!scm.isEmpty)
+              Positioned(
+                key: const ValueKey('git-scm-overview'),
+                top: _padTop,
+                right: 0,
+                bottom: 0,
+                width: kOverviewGitColumnWidth,
+                child: EditorOverviewRuler(
+                  lineCount: lineCount,
+                  onJumpToLine: (line) => _reveal(line, select: false),
+                  columns: [
+                    // Direita = sob a scrollbar. Colunas futuras (errors) entram
+                    // à esquerda desta.
+                    OverviewRulerColumn(
+                      lane: OverviewRulerLane.git,
+                      width: kOverviewGitColumnWidth,
+                      marks: _scmOverviewMarks(
+                        scm,
+                        added: colors.online,
+                        modified: colors.accent,
+                        deleted: colors.gitDeleted,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
         ),
       ),
     );
   }
+}
+
+/// Converte [ScmLineDecorations] em marcas da coluna Git do overview.
+List<OverviewRulerMark> _scmOverviewMarks(
+  ScmLineDecorations scm, {
+  required Color added,
+  required Color modified,
+  required Color deleted,
+}) {
+  final marks = <OverviewRulerMark>[
+    for (final range in overviewMergedLineRanges(scm.addedLines))
+      OverviewRulerMark.range(
+        startLine: range.$1,
+        endLine: range.$2,
+        color: added,
+      ),
+    for (final range in overviewMergedLineRanges(scm.modifiedLines))
+      OverviewRulerMark.range(
+        startLine: range.$1,
+        endLine: range.$2,
+        color: modified,
+      ),
+    for (final b in scm.removalBoundaries)
+      OverviewRulerMark.boundary(boundary: b, color: deleted),
+  ];
+  return marks;
 }

--- a/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
 import 'package:cockpit/app/core/domain/entities/lsp_diagnostic.dart';
 import 'package:cockpit/app/core/ui/clamping_scroll_behavior.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
@@ -49,9 +50,7 @@ class CodeEditor extends StatefulWidget {
     this.revealLine,
     this.revealSelect = true,
     this.revealTick = 0,
-    this.addedLines = const {},
-    this.modifiedLines = const {},
-    this.removedLines = const {},
+    this.scmDecorations = ScmLineDecorations.empty,
     this.revealMatchStart,
     this.revealMatchTick = 0,
     this.onGoToDefinition,
@@ -73,10 +72,8 @@ class CodeEditor extends StatefulWidget {
   /// Sobe a cada novo pedido de reveal → re-dispara mesmo pra mesma linha.
   final int revealTick;
 
-  /// Decoracoes Git no gutter, com linhas base 1.
-  final Set<int> addedLines;
-  final Set<int> modifiedLines;
-  final Set<int> removedLines;
+  /// Decorações SCM no gutter (linhas base 1 + fronteiras de remoção).
+  final ScmLineDecorations scmDecorations;
 
   /// Offset (UTF-16) do início do match atual da busca **no arquivo** (Cmd+F) a
   /// revelar — rola vertical **e** horizontalmente até ele, sem tocar na seleção
@@ -498,22 +495,52 @@ class _CodeEditorState extends State<CodeEditor> {
         ),
       );
     }
-    final marker = widget.addedLines.contains(oneBased)
+    final scm = widget.scmDecorations;
+    final marker = scm.addedLines.contains(oneBased)
         ? context.colors.online
-        : widget.modifiedLines.contains(oneBased)
+        : scm.modifiedLines.contains(oneBased)
         ? context.colors.accent
-        : widget.removedLines.contains(oneBased)
-        ? context.colors.gitDeleted
         : null;
+    final removalBefore = scm.removalBoundaries.contains(oneBased - 1);
+    final removalAfter =
+        oneBased == _lineCount && scm.removalBoundaries.contains(_lineCount);
+    final hasScm = marker != null || removalBefore || removalAfter;
+    final deleted = context.colors.gitDeleted;
     return Stack(
-      key: marker == null ? null : ValueKey('git-change-line:$oneBased'),
+      key: hasScm ? ValueKey('git-change-line:$oneBased') : null,
       children: [
         if (marker != null)
           Positioned(
             top: 0,
             bottom: 0,
             left: 0,
-            child: Container(width: 2, color: marker),
+            child: IgnorePointer(child: Container(width: 2, color: marker)),
+          ),
+        if (removalBefore)
+          Positioned(
+            top: 0,
+            left: 0,
+            child: IgnorePointer(
+              child: Container(
+                key: ValueKey('git-removal-boundary:${oneBased - 1}'),
+                width: 6,
+                height: 2,
+                color: deleted,
+              ),
+            ),
+          ),
+        if (removalAfter)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            child: IgnorePointer(
+              child: Container(
+                key: ValueKey('git-removal-boundary:$_lineCount'),
+                width: 6,
+                height: 2,
+                color: deleted,
+              ),
+            ),
           ),
         Row(
           mainAxisSize: MainAxisSize.min,

--- a/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
@@ -314,6 +314,44 @@ class _CodeEditorState extends State<CodeEditor> {
   // Hover de diagnostic ao nível de **linha** (não de coluna): mostra a(s)
   // mensagem(ns) da linha sob o mouse. Suficiente pro "suporte secundário".
   double _lineHeight = 18; // px por linha; recalculado no build via TextPainter
+
+  // Geometria publicada pelo ScrollPosition do TextField. A Scrollbar usa
+  // estes mesmos valores para pintar sua trilha e o overview deve compartilhar
+  // essa referência, em vez de inferi-la pela altura do Stack.
+  double? _overviewContentExtent;
+  double? _overviewViewportExtent;
+
+  bool _updateOverviewMetrics(ScrollMetricsNotification notification) {
+    if (notification.metrics.axis != Axis.vertical) return false;
+    final metrics = notification.metrics;
+    final contentExtent =
+        metrics.maxScrollExtent -
+        metrics.minScrollExtent +
+        metrics.viewportDimension;
+    final viewportExtent = metrics.viewportDimension;
+    if (_overviewContentExtent == contentExtent &&
+        _overviewViewportExtent == viewportExtent) {
+      return false;
+    }
+    setState(() {
+      _overviewContentExtent = contentExtent;
+      _overviewViewportExtent = viewportExtent;
+    });
+    return false;
+  }
+
+  bool _isEditorVerticalScroll(ScrollNotification notification) {
+    if (notification.metrics.axis != Axis.vertical || !_vertical.hasClients) {
+      return false;
+    }
+    final notificationContext = notification.context;
+    if (notificationContext == null) return false;
+    return identical(
+      Scrollable.maybeOf(notificationContext)?.position,
+      _vertical.position,
+    );
+  }
+
   /// Frame de padding no topo, fora dos scrolls — gutter e campo começam em y=0.
   static const double _padTop = 14;
 
@@ -456,6 +494,12 @@ class _CodeEditorState extends State<CodeEditor> {
     // de texto repinta sozinho via buildTextSpan; o gutter depende de setState).
     if ((n != _lineCount || !identical(diag, _lastDiag)) && mounted) {
       setState(() {
+        if (n != _lineCount) {
+          // Não pinte um frame com a extensão do documento anterior. O novo
+          // layout publicará as métricas corretas logo após esta reconstrução.
+          _overviewContentExtent = null;
+          _overviewViewportExtent = null;
+        }
         _lineCount = n;
         _lastDiag = diag;
       });
@@ -664,170 +708,176 @@ class _CodeEditorState extends State<CodeEditor> {
     );
     final lineCount = _lineCount;
     final scm = widget.scmDecorations;
+    // `_padTop` fica FORA do Scrollbar vertical: trilha do thumb, overview e
+    // viewport do TextField compartilham a mesma altura (senão os ticks
+    // desalinhavam do scroll por 14px no topo).
     return Scrollbar(
       controller: _horizontal,
       thumbVisibility: true,
       scrollbarOrientation: ScrollbarOrientation.bottom,
       notificationPredicate: (n) => n.metrics.axis == Axis.horizontal,
-      child: Scrollbar(
-        controller: _vertical,
-        notificationPredicate: (n) => n.metrics.axis == Axis.vertical,
-        // O shadcn adiciona uma scrollbar vertical automática a cada Scrollable
-        // desktop. Gutter e TextField precisam de scrolls próprios para ficarem
-        // sincronizados, mas suas barras duplicariam a barra deste painel.
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            Positioned.fill(
-              child: ScrollConfiguration(
-                behavior: const _CodeEditorScrollBehavior(),
-                // Topo: frame FIXO fora dos scrolls (gutter e campo em y=0, lockstep).
-                // Fundo: a folga mora DENTRO dos scrolls (`_padBottom` no ListView e no
-                // contentPadding do campo) — senão a última linha assenta no fio do
-                // viewport e a scrollbar horizontal (overlay) corta o número/texto.
-                child: Padding(
-                  padding: const EdgeInsets.only(top: _padTop),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Gutter — scroll próprio (travado ao input) espelhando `_vertical`.
-                      //
-                      // `ListView.builder` (e não `Column`): com uma Column, um arquivo
-                      // de 5k linhas materializava 5000 Rows+Texts A CADA rebuild — e
-                      // rebuild acontece até quando o mouse cruza uma linha (o tooltip
-                      // de diagnostic faz setState). Virtualizado, só as ~40 linhas
-                      // visíveis são construídas, e `severityForLine` (que varre os
-                      // diagnostics) roda só pra elas.
-                      //
-                      // `itemExtent: _lineHeight` é o que mantém o alinhamento 1:1 com
-                      // o texto — mesma métrica que o campo usa por linha — e ainda dá
-                      // scroll O(1) (o `jumpTo` do `_syncGutter` não precisa medir os
-                      // itens anteriores). Largura fixa porque a ListView, ao contrário
-                      // da Column dentro do SingleChildScrollView, não é intrínseca:
-                      // sem isso o gutter esticaria e comeria o campo.
-                      Padding(
-                        padding: const EdgeInsets.only(left: 14, right: 14),
-                        child: SizedBox(
-                          width: _iconSlot + _digitsWidth,
-                          child: ListView.builder(
-                            controller: _gutter,
-                            physics: const NeverScrollableScrollPhysics(),
-                            padding: const EdgeInsets.only(bottom: _padBottom),
-                            itemExtent: _lineHeight,
-                            itemCount: lineCount,
-                            itemBuilder: (context, i) =>
-                                _gutterLine(i + 1, numStyle),
-                          ),
-                        ),
-                      ),
-                      Container(
-                        width: 1,
-                        color: syntax.base.withValues(alpha: 0.15),
-                      ),
-                      Expanded(
-                        child: LayoutBuilder(
-                          builder: (context, constraints) {
-                            // Largura mínima = viewport (menos o padding H). Sem isso, o
-                            // IntrinsicWidth colapsa o campo a ~0 quando o arquivo está
-                            // vazio (recém-criado) → sem área pra clicar/digitar.
-                            final minWidth = (constraints.maxWidth - 30).clamp(
-                              0.0,
-                              double.infinity,
-                            );
-                            return SingleChildScrollView(
-                              controller: _horizontal,
-                              scrollDirection: Axis.horizontal,
-                              padding: const EdgeInsets.only(
-                                left: 14,
-                                right: 16,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: _padTop),
+          Expanded(
+            child: Scrollbar(
+              controller: _vertical,
+              // Há dois scrollables verticais sob esta barra (gutter e campo).
+              // Aceitar o gutter faria o thumb trocar de geometria conforme a
+              // ordem das notificações, enquanto o overview segue o campo.
+              notificationPredicate: _isEditorVerticalScroll,
+              // O shadcn adiciona uma scrollbar vertical automática a cada
+              // Scrollable desktop. Gutter e TextField precisam de scrolls
+              // próprios para ficarem sincronizados, mas suas barras
+              // duplicariam a barra deste painel.
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  Positioned.fill(
+                    child: ScrollConfiguration(
+                      behavior: const _CodeEditorScrollBehavior(),
+                      // Folga inferior DENTRO dos scrolls (`_padBottom`) — a
+                      // última linha assenta acima da scrollbar horizontal.
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // Gutter — scroll próprio (travado ao input) espelhando
+                          // `_vertical`.
+                          //
+                          // `ListView.builder` (e não `Column`): com uma Column, um
+                          // arquivo de 5k linhas materializava 5000 Rows+Texts A
+                          // CADA rebuild — e rebuild acontece até quando o mouse
+                          // cruza uma linha (o tooltip de diagnostic faz setState).
+                          // Virtualizado, só as ~40 linhas visíveis são construídas,
+                          // e `severityForLine` (que varre os diagnostics) roda só
+                          // pra elas.
+                          //
+                          // `itemExtent: _lineHeight` é o que mantém o alinhamento
+                          // 1:1 com o texto — mesma métrica que o campo usa por
+                          // linha — e ainda dá scroll O(1) (o `jumpTo` do
+                          // `_syncGutter` não precisa medir os itens anteriores).
+                          // Largura fixa porque a ListView, ao contrário da Column
+                          // dentro do SingleChildScrollView, não é intrínseca:
+                          // sem isso o gutter esticaria e comeria o campo.
+                          Padding(
+                            padding: const EdgeInsets.only(left: 14, right: 14),
+                            child: SizedBox(
+                              width: _iconSlot + _digitsWidth,
+                              child: ListView.builder(
+                                controller: _gutter,
+                                physics: const NeverScrollableScrollPhysics(),
+                                padding: const EdgeInsets.only(
+                                  bottom: _padBottom,
+                                ),
+                                itemExtent: _lineHeight,
+                                itemCount: lineCount,
+                                itemBuilder: (context, i) =>
+                                    _gutterLine(i + 1, numStyle),
                               ),
-                              // `TextField` (e não `EditableText` cru) pra ganhar os
-                              // gestos de seleção do desktop: arrastar com o mouse,
-                              // duplo-clique, Cmd+A. O highlight vem do `buildTextSpan`
-                              // do controller; a decoração é zerada (sem borda/fundo).
-                              child: ConstrainedBox(
-                                constraints: BoxConstraints(minWidth: minWidth),
-                                child: IntrinsicWidth(
-                                  child: TextField(
-                                    controller: widget.controller,
-                                    focusNode: widget.focusNode,
-                                    // O campo é o DONO do scroll vertical (scroll interno)
-                                    // → fica parado no espaço global e a âncora da seleção
-                                    // não escorrega durante o auto-scroll do drag.
-                                    scrollController: _vertical,
-                                    style: codeStyle,
-                                    cursorColor: syntax.base,
-                                    maxLines: null,
-                                    minLines: null,
-                                    // Preenche a altura do viewport e rola o conteúdo
-                                    // internamente; o gutter espelha via `_syncGutter`.
-                                    expands: true,
-                                    keyboardType: TextInputType.multiline,
-                                    // `onTap` do próprio TextField dispara DEPOIS que o
-                                    // toque já moveu `controller.selection` pra posição
-                                    // clicada (comportamento interno do EditableText) —
-                                    // por isso lemos a seleção aqui, não num
-                                    // GestureDetector externo (que veria a seleção ANTIGA,
-                                    // antes do TextField processar o tap).
-                                    onTap: _definitionModeActive
-                                        ? _onDefinitionTap
-                                        : null,
-                                    // TextField sempre define seu PRÓPRIO cursor (I-beam)
-                                    // por padrão — sobrescreve o `MouseRegion` externo, que
-                                    // nunca vencia a resolução de cursor (o descendente mais
-                                    // específico ganha). Precisa ser setado aqui pra virar
-                                    // clicável de fato durante o hover de definition.
-                                    mouseCursor: _defCursor,
-                                    decoration: const InputDecoration(
-                                      isCollapsed: true,
-                                      border: InputBorder.none,
-                                      // Mesma folga do gutter — mantém lockstep no fim.
-                                      contentPadding: EdgeInsets.only(
-                                        bottom: _padBottom,
-                                      ),
+                            ),
+                          ),
+                          Container(
+                            width: 1,
+                            color: syntax.base.withValues(alpha: 0.15),
+                          ),
+                          Expanded(
+                            child: LayoutBuilder(
+                              builder: (context, constraints) {
+                                // Largura mínima = viewport (menos o padding H).
+                                // Sem isso, o IntrinsicWidth colapsa o campo a ~0
+                                // quando o arquivo está vazio → sem área pra
+                                // clicar/digitar.
+                                final minWidth = (constraints.maxWidth - 30)
+                                    .clamp(0.0, double.infinity);
+                                return SingleChildScrollView(
+                                  controller: _horizontal,
+                                  scrollDirection: Axis.horizontal,
+                                  padding: const EdgeInsets.only(
+                                    left: 14,
+                                    right: 16,
+                                  ),
+                                  child: ConstrainedBox(
+                                    constraints: BoxConstraints(
+                                      minWidth: minWidth,
+                                    ),
+                                    child: IntrinsicWidth(
+                                      child:
+                                          NotificationListener<
+                                            ScrollMetricsNotification
+                                          >(
+                                            onNotification:
+                                                _updateOverviewMetrics,
+                                            child: TextField(
+                                              controller: widget.controller,
+                                              focusNode: widget.focusNode,
+                                              scrollController: _vertical,
+                                              style: codeStyle,
+                                              cursorColor: syntax.base,
+                                              maxLines: null,
+                                              minLines: null,
+                                              expands: true,
+                                              keyboardType:
+                                                  TextInputType.multiline,
+                                              onTap: _definitionModeActive
+                                                  ? _onDefinitionTap
+                                                  : null,
+                                              mouseCursor: _defCursor,
+                                              decoration: const InputDecoration(
+                                                isCollapsed: true,
+                                                border: InputBorder.none,
+                                                contentPadding: EdgeInsets.only(
+                                                  bottom: _padBottom,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
                                     ),
                                   ),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            // Overview multi-coluna sob a scrollbar (git agora; diagnostics depois).
-            // A Scrollbar pai pinta o thumb por cima desta strip.
-            if (!scm.isEmpty)
-              Positioned(
-                key: const ValueKey('git-scm-overview'),
-                top: _padTop,
-                right: 0,
-                bottom: 0,
-                width: kOverviewGitColumnWidth,
-                child: EditorOverviewRuler(
-                  lineCount: lineCount,
-                  onJumpToLine: (line) => _reveal(line, select: false),
-                  columns: [
-                    // Direita = sob a scrollbar. Colunas futuras (errors) entram
-                    // à esquerda desta.
-                    OverviewRulerColumn(
-                      lane: OverviewRulerLane.git,
-                      width: kOverviewGitColumnWidth,
-                      marks: _scmOverviewMarks(
-                        scm,
-                        added: colors.online,
-                        modified: colors.accent,
-                        deleted: colors.gitDeleted,
+                                );
+                              },
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                  // Overview na mesma caixa da Scrollbar vertical (top/bottom
+                  // 0), usando as métricas efetivas do mesmo TextField.
+                  if (!scm.isEmpty &&
+                      _overviewContentExtent != null &&
+                      _overviewViewportExtent != null)
+                    Positioned(
+                      key: const ValueKey('git-scm-overview'),
+                      top: 0,
+                      right: 0,
+                      bottom: 0,
+                      width: kOverviewGitColumnWidth,
+                      child: EditorOverviewRuler(
+                        lineCount: lineCount,
+                        lineHeight: _lineHeight,
+                        scrollContentExtent: _overviewContentExtent,
+                        scrollViewportExtent: _overviewViewportExtent,
+                        onJumpToLine: (line) => _reveal(line, select: false),
+                        columns: [
+                          OverviewRulerColumn(
+                            lane: OverviewRulerLane.git,
+                            width: kOverviewGitColumnWidth,
+                            marks: _scmOverviewMarks(
+                              scm,
+                              added: colors.online,
+                              modified: colors.accent,
+                              deleted: colors.gitDeleted,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
               ),
-          ],
-        ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/code_editor.dart
@@ -24,12 +24,13 @@ import 'package:flutter/widgets.dart';
 
 /// Área **editável** de código com gutter de número de linha.
 ///
-/// Layout: `Row[gutter, divisor, scroll horizontal(campo)]` num frame de padding
-/// vertical de 14px. O campo é um [EditableText] com `expands: true` que **é o
-/// dono do scroll vertical** (scroll interno via [_vertical]); o gutter tem
-/// scroll próprio travado ao input, espelhando [_vertical] via [_syncGutter],
-/// pra alinhar 1:1. `IntrinsicWidth` + scroll horizontal externo fazem a linha
-/// longa **não quebrar**.
+/// Layout: `Row[gutter, divisor, scroll horizontal(campo)]` com frame de 14px
+/// no topo (fora dos scrolls) e folga de 14px no fim do conteúdo (dentro dos
+/// scrolls, acima da scrollbar horizontal). O campo é um [EditableText] com
+/// `expands: true` que **é o dono do scroll vertical** (scroll interno via
+/// [_vertical]); o gutter tem scroll próprio travado ao input, espelhando
+/// [_vertical] via [_syncGutter], pra alinhar 1:1. `IntrinsicWidth` + scroll
+/// horizontal externo fazem a linha longa **não quebrar**.
 ///
 /// Por que o campo é o dono do scroll vertical (e não um container externo):
 /// durante um drag de seleção, o `EditableText` recalcula a âncora convertendo a
@@ -311,8 +312,12 @@ class _CodeEditorState extends State<CodeEditor> {
   // Hover de diagnostic ao nível de **linha** (não de coluna): mostra a(s)
   // mensagem(ns) da linha sob o mouse. Suficiente pro "suporte secundário".
   double _lineHeight = 18; // px por linha; recalculado no build via TextPainter
-  static const double _padTop =
-      14; // frame de padding vertical fora dos scrolls
+  /// Frame de padding no topo, fora dos scrolls — gutter e campo começam em y=0.
+  static const double _padTop = 14;
+
+  /// Folga no fim do scroll vertical (gutter + campo) pra última linha assentar
+  /// acima da scrollbar horizontal (overlay no rodapé do viewport).
+  static const double _padBottom = 14;
   int? _hoverLine;
   List<String> _hoverMsgs = const <String>[];
   double _hoverDx = 0;
@@ -668,11 +673,12 @@ class _CodeEditorState extends State<CodeEditor> {
         // sincronizados, mas suas barras duplicariam a barra deste painel.
         child: ScrollConfiguration(
           behavior: const _CodeEditorScrollBehavior(),
-          // O padding de 14px é um frame FIXO fora dos dois scrolls (gutter e
-          // campo), pra ambos começarem o conteúdo em y=0 e rolarem em lockstep
-          // sem que o inset de topo desalinhe ao rolar.
+          // Topo: frame FIXO fora dos scrolls (gutter e campo em y=0, lockstep).
+          // Fundo: a folga mora DENTRO dos scrolls (`_padBottom` no ListView e no
+          // contentPadding do campo) — senão a última linha assenta no fio do
+          // viewport e a scrollbar horizontal (overlay) corta o número/texto.
           child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 14),
+            padding: const EdgeInsets.only(top: _padTop),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -698,7 +704,7 @@ class _CodeEditorState extends State<CodeEditor> {
                     child: ListView.builder(
                       controller: _gutter,
                       physics: const NeverScrollableScrollPhysics(),
-                      padding: EdgeInsets.zero,
+                      padding: const EdgeInsets.only(bottom: _padBottom),
                       itemExtent: _lineHeight,
                       itemCount: lineCount,
                       itemBuilder: (context, i) => _gutterLine(i + 1, numStyle),
@@ -760,7 +766,10 @@ class _CodeEditorState extends State<CodeEditor> {
                               decoration: const InputDecoration(
                                 isCollapsed: true,
                                 border: InputBorder.none,
-                                contentPadding: EdgeInsets.zero,
+                                // Mesma folga do gutter — mantém lockstep no fim.
+                                contentPadding: EdgeInsets.only(
+                                  bottom: _padBottom,
+                                ),
                               ),
                             ),
                           ),

--- a/cockpit/lib/app/cockpit/ui/widgets/editor_overview_ruler.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/editor_overview_ruler.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// Identificador de coluna no overview à direita do editor.
+///
+/// Ordem visual: da **esquerda → direita** na strip; a coluna mais à direita
+/// fica sob a [Scrollbar] vertical. Hoje só [git]; [diagnostics] entra depois.
+enum OverviewRulerLane { git, diagnostics }
+
+/// Marca proporcional ao documento (linhas base 1, ou fronteira `0..lineCount`).
+@immutable
+class OverviewRulerMark {
+  const OverviewRulerMark.range({
+    required this.startLine,
+    required this.endLine,
+    required this.color,
+  }) : isBoundary = false;
+
+  const OverviewRulerMark.boundary({required int boundary, required this.color})
+    : startLine = boundary,
+      endLine = boundary,
+      isBoundary = true;
+
+  /// Linha base 1 (range) ou índice de fronteira `0..lineCount` (boundary).
+  final int startLine;
+  final int endLine;
+  final Color color;
+  final bool isBoundary;
+}
+
+/// Uma coluna do overview (git, diagnostics, …).
+@immutable
+class OverviewRulerColumn {
+  const OverviewRulerColumn({
+    required this.lane,
+    required this.width,
+    required this.marks,
+  });
+
+  final OverviewRulerLane lane;
+  final double width;
+  final List<OverviewRulerMark> marks;
+
+  bool get isEmpty => marks.isEmpty;
+}
+
+/// Strip multi-coluna sob a scrollbar vertical.
+///
+/// A [Scrollbar] do editor envolve este widget e pinta o thumb **por cima**.
+class EditorOverviewRuler extends StatelessWidget {
+  const EditorOverviewRuler({
+    super.key,
+    required this.columns,
+    required this.lineCount,
+    this.onJumpToLine,
+  });
+
+  /// Colunas da esquerda → direita (direita = sob a scrollbar).
+  final List<OverviewRulerColumn> columns;
+  final int lineCount;
+  final ValueChanged<int>? onJumpToLine;
+
+  double get totalWidth => columns.fold<double>(0, (sum, c) => sum + c.width);
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = [
+      for (final c in columns)
+        if (!c.isEmpty) c,
+    ];
+    if (lineCount <= 0 || visible.isEmpty) return const SizedBox.shrink();
+
+    final width = visible.fold<double>(0, (sum, c) => sum + c.width);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final height = constraints.maxHeight;
+        if (height <= 0) return const SizedBox.shrink();
+        final child = CustomPaint(
+          size: Size(width, height),
+          painter: _OverviewRulerPainter(
+            columns: visible,
+            lineCount: lineCount,
+          ),
+        );
+        final jump = onJumpToLine;
+        if (jump == null) return child;
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (details) {
+            jump(
+              overviewRulerLineForDy(
+                dy: details.localPosition.dy,
+                height: height,
+                lineCount: lineCount,
+              ),
+            );
+          },
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+/// Mapeia Y na faixa do overview → linha base 1.
+@visibleForTesting
+int overviewRulerLineForDy({
+  required double dy,
+  required double height,
+  required int lineCount,
+}) {
+  if (height <= 0 || lineCount <= 0) return 1;
+  final ratio = (dy / height).clamp(0.0, 1.0);
+  return ((ratio * lineCount).floor() + 1).clamp(1, lineCount);
+}
+
+/// @nodoc — alias mantido pros testes existentes.
+@visibleForTesting
+int scmOverviewLineForDy({
+  required double dy,
+  required double height,
+  required int lineCount,
+}) => overviewRulerLineForDy(dy: dy, height: height, lineCount: lineCount);
+
+class _OverviewRulerPainter extends CustomPainter {
+  _OverviewRulerPainter({required this.columns, required this.lineCount});
+
+  final List<OverviewRulerColumn> columns;
+  final int lineCount;
+
+  static const double _minTick = 1.5;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (lineCount <= 0 || size.height <= 0) return;
+    final paint = Paint()..style = PaintingStyle.fill;
+    var x = 0.0;
+    for (final column in columns) {
+      final w = column.width;
+      for (final mark in column.marks) {
+        paint.color = mark.color;
+        if (mark.isBoundary) {
+          final y = (mark.startLine / lineCount) * size.height;
+          final top = (y - _minTick / 2).clamp(0.0, size.height - _minTick);
+          canvas.drawRect(Rect.fromLTWH(x, top, w, _minTick), paint);
+        } else {
+          final top = ((mark.startLine - 1) / lineCount) * size.height;
+          final bottom = (mark.endLine / lineCount) * size.height;
+          final h = (bottom - top).clamp(_minTick, size.height);
+          canvas.drawRect(Rect.fromLTWH(x, top, w, h), paint);
+        }
+      }
+      x += w;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _OverviewRulerPainter old) =>
+      old.lineCount != lineCount || !_sameColumns(old.columns, columns);
+
+  static bool _sameColumns(
+    List<OverviewRulerColumn> a,
+    List<OverviewRulerColumn> b,
+  ) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i].lane != b[i].lane ||
+          a[i].width != b[i].width ||
+          a[i].marks.length != b[i].marks.length) {
+        return false;
+      }
+      for (var j = 0; j < a[i].marks.length; j++) {
+        final m = a[i].marks[j];
+        final n = b[i].marks[j];
+        if (m.startLine != n.startLine ||
+            m.endLine != n.endLine ||
+            m.color != n.color ||
+            m.isBoundary != n.isBoundary) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}
+
+/// Une linhas consecutivas (base 1) em intervalos inclusivos `(start, end)`.
+@visibleForTesting
+Iterable<(int, int)> overviewMergedLineRanges(Set<int> lines) sync* {
+  if (lines.isEmpty) return;
+  final sorted = lines.toList()..sort();
+  var start = sorted.first;
+  var prev = sorted.first;
+  for (var i = 1; i < sorted.length; i++) {
+    final line = sorted[i];
+    if (line == prev + 1) {
+      prev = line;
+      continue;
+    }
+    yield (start, prev);
+    start = line;
+    prev = line;
+  }
+  yield (start, prev);
+}
+
+/// Largura da coluna Git (fina; a scrollbar cobre visualmente).
+const double kOverviewGitColumnWidth = 2;

--- a/cockpit/lib/app/cockpit/ui/widgets/editor_overview_ruler.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/editor_overview_ruler.dart
@@ -1,4 +1,7 @@
-import 'package:flutter/foundation.dart';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart'
+    show ScrollbarTheme, TargetPlatform, Theme;
 import 'package:flutter/widgets.dart';
 
 /// Identificador de coluna no overview à direita do editor.
@@ -47,17 +50,36 @@ class OverviewRulerColumn {
 /// Strip multi-coluna sob a scrollbar vertical.
 ///
 /// A [Scrollbar] do editor envolve este widget e pinta o thumb **por cima**.
+/// O eixo Y usa as extensões efetivas do mesmo scroll que alimenta a
+/// [Scrollbar], evitando estimar a geometria a partir do tamanho do widget.
 class EditorOverviewRuler extends StatelessWidget {
   const EditorOverviewRuler({
     super.key,
     required this.columns,
     required this.lineCount,
+    required this.lineHeight,
+    this.contentPaddingBottom = 0,
+    this.scrollContentExtent,
+    this.scrollViewportExtent,
     this.onJumpToLine,
   });
 
   /// Colunas da esquerda → direita (direita = sob a scrollbar).
   final List<OverviewRulerColumn> columns;
   final int lineCount;
+  final double lineHeight;
+
+  /// Folga no fim do conteúdo scrollável (ex.: acima da scrollbar horizontal).
+  /// Usada apenas como fallback antes de o scroll publicar suas métricas.
+  final double contentPaddingBottom;
+
+  /// Extensões efetivas publicadas pelo [ScrollPosition] da barra vertical.
+  ///
+  /// A Scrollbar usa `viewportDimension` como comprimento físico da trilha e
+  /// `maxScrollExtent - minScrollExtent + viewportDimension` como extensão
+  /// total do conteúdo. O overview precisa usar exatamente os mesmos valores.
+  final double? scrollContentExtent;
+  final double? scrollViewportExtent;
   final ValueChanged<int>? onJumpToLine;
 
   double get totalWidth => columns.fold<double>(0, (sum, c) => sum + c.width);
@@ -68,18 +90,65 @@ class EditorOverviewRuler extends StatelessWidget {
       for (final c in columns)
         if (!c.isEmpty) c,
     ];
-    if (lineCount <= 0 || visible.isEmpty) return const SizedBox.shrink();
+    if (lineCount <= 0 || lineHeight <= 0 || visible.isEmpty) {
+      return const SizedBox.shrink();
+    }
 
     final width = visible.fold<double>(0, (sum, c) => sum + c.width);
     return LayoutBuilder(
       builder: (context, constraints) {
-        final height = constraints.maxHeight;
-        if (height <= 0) return const SizedBox.shrink();
+        final widgetHeight = constraints.maxHeight;
+        if (widgetHeight <= 0) return const SizedBox.shrink();
+        final contentExtent =
+            scrollContentExtent ??
+            overviewContentHeight(
+              lineCount: lineCount,
+              lineHeight: lineHeight,
+              contentPaddingBottom: contentPaddingBottom,
+            );
+        // Material Scrollbar aplica o padding do MediaQuery à trilha e usa o
+        // viewport do ScrollPosition (não a altura do widget que a envolve).
+        final trackPadding = MediaQuery.paddingOf(context);
+        final viewportExtent = scrollViewportExtent ?? widgetHeight;
+        final trackHeight = (viewportExtent - trackPadding.vertical).clamp(
+          0.0,
+          double.infinity,
+        );
+        if (contentExtent <= 0 || trackHeight <= 0) {
+          return const SizedBox.shrink();
+        }
+        final platform = Theme.of(context).platform;
+        final scrollbarTheme = ScrollbarTheme.of(context);
+        final mainAxisMargin = platform == TargetPlatform.iOS
+            ? 3.0
+            : scrollbarTheme.mainAxisMargin ?? 0.0;
+        final minThumbExtent = platform == TargetPlatform.iOS
+            ? 36.0
+            : scrollbarTheme.minThumbLength ?? 48.0;
+        final traversableTrackExtent = (trackHeight - 2 * mainAxisMargin).clamp(
+          0.0,
+          double.infinity,
+        );
+        final geometry = OverviewRulerGeometry(
+          contentExtent: contentExtent,
+          viewportExtent: viewportExtent,
+          trackStart: trackPadding.top + mainAxisMargin,
+          trackExtent: traversableTrackExtent,
+          thumbExtent: overviewScrollbarThumbExtent(
+            contentExtent: contentExtent,
+            viewportExtent: viewportExtent,
+            trackPaddingExtent: trackPadding.vertical,
+            traversableTrackExtent: traversableTrackExtent,
+            minThumbExtent: minThumbExtent,
+          ),
+        );
         final child = CustomPaint(
-          size: Size(width, height),
+          size: Size(width, widgetHeight),
           painter: _OverviewRulerPainter(
             columns: visible,
             lineCount: lineCount,
+            lineHeight: lineHeight,
+            geometry: geometry,
           ),
         );
         final jump = onJumpToLine;
@@ -90,8 +159,11 @@ class EditorOverviewRuler extends StatelessWidget {
             jump(
               overviewRulerLineForDy(
                 dy: details.localPosition.dy,
-                height: height,
+                trackHeight: geometry.trackExtent,
                 lineCount: lineCount,
+                lineHeight: lineHeight,
+                contentExtent: contentExtent,
+                geometry: geometry,
               ),
             );
           },
@@ -102,37 +174,227 @@ class EditorOverviewRuler extends StatelessWidget {
   }
 }
 
-/// Mapeia Y na faixa do overview → linha base 1.
+/// Altura total do conteúdo scrollável (linhas + folga inferior).
+@visibleForTesting
+double overviewContentHeight({
+  required int lineCount,
+  required double lineHeight,
+  double contentPaddingBottom = 0,
+}) => lineCount * lineHeight + contentPaddingBottom;
+
+/// Offset Y no conteúdo no início da linha base 1 (ou fronteira `boundary`).
+@visibleForTesting
+double overviewContentOffsetForLine({
+  required int line,
+  required double lineHeight,
+}) => (line - 1).clamp(0, 1 << 30) * lineHeight;
+
+/// Offset Y no conteúdo para fronteira `0..lineCount`.
+@visibleForTesting
+double overviewContentOffsetForBoundary({
+  required int boundary,
+  required double lineHeight,
+}) => boundary.clamp(0, 1 << 30) * lineHeight;
+
+/// Mapeia offset de conteúdo → Y na trilha (mesma proporção da Scrollbar).
+@visibleForTesting
+double overviewTrackY({
+  required double contentOffset,
+  required double contentHeight,
+  required double trackHeight,
+}) {
+  if (contentHeight <= 0 || trackHeight <= 0) return 0;
+  return (contentOffset / contentHeight).clamp(0.0, 1.0) * trackHeight;
+}
+
+/// Extensão do thumb calculada com as mesmas regras do [ScrollbarPainter].
+@visibleForTesting
+double overviewScrollbarThumbExtent({
+  required double contentExtent,
+  required double viewportExtent,
+  required double trackPaddingExtent,
+  required double traversableTrackExtent,
+  required double minThumbExtent,
+}) {
+  if (contentExtent <= 0 ||
+      viewportExtent <= 0 ||
+      traversableTrackExtent <= 0) {
+    return 0;
+  }
+  final adjustedContentExtent = contentExtent - trackPaddingExtent;
+  if (adjustedContentExtent <= 0) return traversableTrackExtent;
+  final fractionVisible =
+      ((viewportExtent - trackPaddingExtent) / adjustedContentExtent).clamp(
+        0.0,
+        1.0,
+      );
+  final naturalExtent = traversableTrackExtent * fractionVisible;
+  return math
+      .max(naturalExtent, math.min(minThumbExtent, traversableTrackExtent))
+      .clamp(0.0, traversableTrackExtent);
+}
+
+/// Transformação entre offsets do documento e coordenadas da scrollbar.
+///
+/// Quando o Flutter limita o thumb a um tamanho mínimo, uma regra proporcional
+/// simples deixa de coincidir com sua posição. Esta geometria preserva a
+/// posição relativa dentro do thumb: uma linha centralizada no viewport fica
+/// exatamente no centro do thumb, inclusive em arquivos muito longos.
+@immutable
+class OverviewRulerGeometry {
+  const OverviewRulerGeometry({
+    required this.contentExtent,
+    required this.viewportExtent,
+    required this.trackStart,
+    required this.trackExtent,
+    required this.thumbExtent,
+  });
+
+  final double contentExtent;
+  final double viewportExtent;
+  final double trackStart;
+  final double trackExtent;
+  final double thumbExtent;
+
+  double get trackEnd => trackStart + trackExtent;
+
+  double contentToTrack(double contentOffset) {
+    if (contentExtent <= 0 || trackExtent <= 0) return trackStart;
+    final offset = contentOffset.clamp(0.0, contentExtent);
+    if (contentExtent <= viewportExtent ||
+        thumbExtent <= 0 ||
+        thumbExtent >= trackExtent ||
+        viewportExtent <= 0) {
+      return trackStart + (offset / contentExtent) * trackExtent;
+    }
+
+    final halfViewport = viewportExtent / 2;
+    final halfThumb = thumbExtent / 2;
+    if (offset <= halfViewport) {
+      return trackStart + (offset / viewportExtent) * thumbExtent;
+    }
+    if (offset >= contentExtent - halfViewport) {
+      return trackEnd -
+          ((contentExtent - offset) / viewportExtent) * thumbExtent;
+    }
+
+    final scrollableExtent = contentExtent - viewportExtent;
+    final thumbTravel = trackExtent - thumbExtent;
+    return trackStart +
+        halfThumb +
+        ((offset - halfViewport) / scrollableExtent) * thumbTravel;
+  }
+
+  double trackToContent(double dy) {
+    if (contentExtent <= 0 || trackExtent <= 0) return 0;
+    final local = (dy - trackStart).clamp(0.0, trackExtent);
+    if (contentExtent <= viewportExtent ||
+        thumbExtent <= 0 ||
+        thumbExtent >= trackExtent ||
+        viewportExtent <= 0) {
+      return (local / trackExtent) * contentExtent;
+    }
+
+    final halfViewport = viewportExtent / 2;
+    final halfThumb = thumbExtent / 2;
+    if (local <= halfThumb) {
+      return (local / thumbExtent) * viewportExtent;
+    }
+    if (local >= trackExtent - halfThumb) {
+      return contentExtent -
+          ((trackExtent - local) / thumbExtent) * viewportExtent;
+    }
+
+    final scrollableExtent = contentExtent - viewportExtent;
+    final thumbTravel = trackExtent - thumbExtent;
+    return halfViewport +
+        ((local - halfThumb) / thumbTravel) * scrollableExtent;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is OverviewRulerGeometry &&
+      other.contentExtent == contentExtent &&
+      other.viewportExtent == viewportExtent &&
+      other.trackStart == trackStart &&
+      other.trackExtent == trackExtent &&
+      other.thumbExtent == thumbExtent;
+
+  @override
+  int get hashCode => Object.hash(
+    contentExtent,
+    viewportExtent,
+    trackStart,
+    trackExtent,
+    thumbExtent,
+  );
+}
+
+/// Mapeia Y na faixa do overview → linha base 1 (inverso do paint).
 @visibleForTesting
 int overviewRulerLineForDy({
   required double dy,
-  required double height,
+  double trackTop = 0,
+  required double trackHeight,
   required int lineCount,
+  required double lineHeight,
+  double contentPaddingBottom = 0,
+  double? contentExtent,
+  OverviewRulerGeometry? geometry,
 }) {
-  if (height <= 0 || lineCount <= 0) return 1;
-  final ratio = (dy / height).clamp(0.0, 1.0);
-  return ((ratio * lineCount).floor() + 1).clamp(1, lineCount);
+  if (trackHeight <= 0 || lineCount <= 0 || lineHeight <= 0) return 1;
+  final contentHeight =
+      contentExtent ??
+      overviewContentHeight(
+        lineCount: lineCount,
+        lineHeight: lineHeight,
+        contentPaddingBottom: contentPaddingBottom,
+      );
+  final contentY =
+      geometry?.trackToContent(dy) ??
+      ((dy - trackTop) / trackHeight).clamp(0.0, 1.0) * contentHeight;
+  final line = (contentY / lineHeight).floor() + 1;
+  return line.clamp(1, lineCount);
 }
 
-/// @nodoc — alias mantido pros testes existentes.
+/// @nodoc — alias dos testes antigos (proporção simples sem padding).
 @visibleForTesting
 int scmOverviewLineForDy({
   required double dy,
   required double height,
   required int lineCount,
-}) => overviewRulerLineForDy(dy: dy, height: height, lineCount: lineCount);
+}) => overviewRulerLineForDy(
+  dy: dy,
+  trackHeight: height,
+  lineCount: lineCount,
+  lineHeight: 1,
+  contentPaddingBottom: 0,
+);
 
 class _OverviewRulerPainter extends CustomPainter {
-  _OverviewRulerPainter({required this.columns, required this.lineCount});
+  _OverviewRulerPainter({
+    required this.columns,
+    required this.lineCount,
+    required this.lineHeight,
+    required this.geometry,
+  });
 
   final List<OverviewRulerColumn> columns;
   final int lineCount;
+  final double lineHeight;
+  final OverviewRulerGeometry geometry;
 
   static const double _minTick = 1.5;
 
   @override
   void paint(Canvas canvas, Size size) {
-    if (lineCount <= 0 || size.height <= 0) return;
+    if (lineCount <= 0 ||
+        lineHeight <= 0 ||
+        geometry.contentExtent <= 0 ||
+        geometry.trackExtent <= 0 ||
+        size.height <= 0) {
+      return;
+    }
     final paint = Paint()..style = PaintingStyle.fill;
     var x = 0.0;
     for (final column in columns) {
@@ -140,14 +402,36 @@ class _OverviewRulerPainter extends CustomPainter {
       for (final mark in column.marks) {
         paint.color = mark.color;
         if (mark.isBoundary) {
-          final y = (mark.startLine / lineCount) * size.height;
-          final top = (y - _minTick / 2).clamp(0.0, size.height - _minTick);
+          final y = geometry.contentToTrack(
+            overviewContentOffsetForBoundary(
+              boundary: mark.startLine,
+              lineHeight: lineHeight,
+            ),
+          );
+          final top = (y - _minTick / 2).clamp(
+            geometry.trackStart,
+            geometry.trackEnd - _minTick,
+          );
           canvas.drawRect(Rect.fromLTWH(x, top, w, _minTick), paint);
         } else {
-          final top = ((mark.startLine - 1) / lineCount) * size.height;
-          final bottom = (mark.endLine / lineCount) * size.height;
-          final h = (bottom - top).clamp(_minTick, size.height);
-          canvas.drawRect(Rect.fromLTWH(x, top, w, h), paint);
+          final top = geometry.contentToTrack(
+            overviewContentOffsetForLine(
+              line: mark.startLine,
+              lineHeight: lineHeight,
+            ),
+          );
+          final bottom = geometry.contentToTrack(
+            overviewContentOffsetForLine(
+              line: mark.endLine + 1,
+              lineHeight: lineHeight,
+            ),
+          );
+          final h = (bottom - top).clamp(_minTick, geometry.trackExtent);
+          final paintTop = top.clamp(
+            geometry.trackStart,
+            geometry.trackEnd - h,
+          );
+          canvas.drawRect(Rect.fromLTWH(x, paintTop, w, h), paint);
         }
       }
       x += w;
@@ -156,7 +440,10 @@ class _OverviewRulerPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _OverviewRulerPainter old) =>
-      old.lineCount != lineCount || !_sameColumns(old.columns, columns);
+      old.lineCount != lineCount ||
+      old.lineHeight != lineHeight ||
+      old.geometry != geometry ||
+      !_sameColumns(old.columns, columns);
 
   static bool _sameColumns(
     List<OverviewRulerColumn> a,
@@ -186,7 +473,6 @@ class _OverviewRulerPainter extends CustomPainter {
 }
 
 /// Une linhas consecutivas (base 1) em intervalos inclusivos `(start, end)`.
-@visibleForTesting
 Iterable<(int, int)> overviewMergedLineRanges(Set<int> lines) sync* {
   if (lines.isEmpty) return;
   final sorted = lines.toList()..sort();

--- a/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
 import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
 import 'package:cockpit/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/agent_markdown.dart';
@@ -76,6 +77,9 @@ class _FileViewerState extends State<FileViewer> {
   /// Último [FileViewerSession.revealTick] visto — detecta novos pedidos de
   /// "revelar linha" (resultado de busca) vindos da VM.
   int _lastRevealTick = 0;
+
+  /// Últimas decorações SCM publicadas — força rebuild do gutter.
+  ScmLineDecorations _lastScmDecorations = ScmLineDecorations.empty;
 
   CodeEditingController? _ctrl;
   final _focus = FocusNode();
@@ -151,6 +155,7 @@ class _FileViewerState extends State<FileViewer> {
     super.initState();
     _lastObservedPath = widget.session.path;
     _lastRevealTick = widget.session.revealTick;
+    _lastScmDecorations = widget.session.scmDecorations;
     widget.session.addListener(_onSession);
     // Reveal pendente num arquivo markdown/svg → abre direto na fonte (o editor
     // é quem sabe rolar + selecionar a linha; o preview renderizado não).
@@ -162,10 +167,15 @@ class _FileViewerState extends State<FileViewer> {
         ..addListener(_onCtrlChanged);
       // Expõe o save do buffer à sessão pro "Salvar e fechar" (limpo no dispose).
       widget.session.saveDraft = _save;
+      _bindScmCoordinator(_ctrl!);
       _startLsp(text);
     }
     // Aba já nasce focada (ex.: arquivo recém-aberto) → foca o editor.
     _focusEditorIfActive();
+  }
+
+  void _bindScmCoordinator(CodeEditingController controller) {
+    widget.session.scmCoordinator?.attachController(controller);
   }
 
   /// Abre o documento no LSP e passa a escutar os diagnostics deste arquivo.
@@ -251,6 +261,8 @@ class _FileViewerState extends State<FileViewer> {
       _semanticTokens = const <SemanticRange>[];
       _semanticTokensRequested = false;
 
+      widget.session.scmCoordinator?.onSessionPathChanged();
+
       // Recria o controller com o novo conteúdo.
       final text = _editableText;
       if (text != null) {
@@ -258,9 +270,11 @@ class _FileViewerState extends State<FileViewer> {
         _ctrl = CodeEditingController(text: text, language: _language)
           ..addListener(_onCtrlChanged);
         widget.session.saveDraft = _save;
+        _bindScmCoordinator(_ctrl!);
         _startLsp(text);
       } else {
         widget.session.saveDraft = null;
+        widget.session.clearScmDecorations();
       }
       // Força rebuild.
       setState(() {});
@@ -281,6 +295,7 @@ class _FileViewerState extends State<FileViewer> {
         if (mounted && !_dirty && _ctrl != null && _ctrl!.text != text) {
           _ctrl!.text = text;
           _baseline = text;
+          widget.session.scmCoordinator?.onExternalContentAdopted();
           // O disco mudou (agente editou) → mantém o LSP em sync.
           if (_lspOn) {
             unawaited(_vm?.lspChangeDocument(widget.session.path, text));
@@ -320,14 +335,18 @@ class _FileViewerState extends State<FileViewer> {
     });
   }
 
-  /// Reage a mudanças da sessão: novo pedido de reveal (linha de busca) →
-  /// rebuild pra repassar o tick ao [CodeEditor] (e abrir a fonte se markdown).
+  /// Reage a mudanças da sessão: reveal e/ou decorações SCM → rebuild do editor.
   void _onSession() {
-    if (widget.session.revealTick == _lastRevealTick) return;
+    final revealChanged = widget.session.revealTick != _lastRevealTick;
+    final scmChanged = widget.session.scmDecorations != _lastScmDecorations;
+    if (!revealChanged && !scmChanged) return;
     _lastRevealTick = widget.session.revealTick;
+    _lastScmDecorations = widget.session.scmDecorations;
+    final ctrl = _ctrl;
+    if (ctrl != null) _bindScmCoordinator(ctrl);
     if (!mounted) return;
     setState(() {
-      if (_hasPreview) _editing = true;
+      if (revealChanged && _hasPreview) _editing = true;
     });
   }
 
@@ -848,9 +867,7 @@ class _FileViewerState extends State<FileViewer> {
             revealLine: widget.session.revealLine,
             revealSelect: widget.session.revealSelect,
             revealTick: widget.session.revealTick,
-            addedLines: widget.session.addedLines,
-            modifiedLines: widget.session.modifiedLines,
-            removedLines: widget.session.removedLines,
+            scmDecorations: widget.session.scmDecorations,
             revealMatchStart:
                 _findIndex >= 0 && _findIndex < _findMatches.length
                 ? _findMatches[_findIndex].start

--- a/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
@@ -339,11 +339,11 @@ class _FileViewerState extends State<FileViewer> {
   void _onSession() {
     final revealChanged = widget.session.revealTick != _lastRevealTick;
     final scmChanged = widget.session.scmDecorations != _lastScmDecorations;
+    final ctrl = _ctrl;
+    if (ctrl != null) _bindScmCoordinator(ctrl);
     if (!revealChanged && !scmChanged) return;
     _lastRevealTick = widget.session.revealTick;
     _lastScmDecorations = widget.session.scmDecorations;
-    final ctrl = _ctrl;
-    if (ctrl != null) _bindScmCoordinator(ctrl);
     if (!mounted) return;
     setState(() {
       if (revealChanged && _hasPreview) _editing = true;

--- a/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
@@ -1109,7 +1109,9 @@ class _TextViewState extends State<_TextView> {
           controller: _vertical,
           child: SingleChildScrollView(
             controller: _vertical,
-            padding: const EdgeInsets.symmetric(vertical: 14),
+            // Fundo maior que o topo: a scrollbar horizontal é overlay no
+            // rodapé do viewport e cortava a última linha do gutter/código.
+            padding: const EdgeInsets.fromLTRB(0, 14, 0, 28),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/file_viewer.dart
@@ -167,15 +167,25 @@ class _FileViewerState extends State<FileViewer> {
         ..addListener(_onCtrlChanged);
       // Expõe o save do buffer à sessão pro "Salvar e fechar" (limpo no dispose).
       widget.session.saveDraft = _save;
-      _bindScmCoordinator(_ctrl!);
+      _ensureAndBindScm(_ctrl!);
       _startLsp(text);
     }
     // Aba já nasce focada (ex.: arquivo recém-aberto) → foca o editor.
     _focusEditorIfActive();
   }
 
-  void _bindScmCoordinator(CodeEditingController controller) {
+  /// Garante coordenador na sessão (restore/open) e liga o controller.
+  /// Cobre abas restauradas no boot, onde o FileViewer monta sem ter passado
+  /// por `openFile`.
+  void _ensureAndBindScm(CodeEditingController controller) {
+    final vm = _vm ?? context.read<CockpitViewModel>();
+    _vm = vm;
+    vm.ensureScmCoordinator(widget.session);
     widget.session.scmCoordinator?.attachController(controller);
+  }
+
+  void _bindScmCoordinator(CodeEditingController controller) {
+    _ensureAndBindScm(controller);
   }
 
   /// Abre o documento no LSP e passa a escutar os diagnostics deste arquivo.

--- a/cockpit/pubspec.lock
+++ b/cockpit/pubspec.lock
@@ -617,10 +617,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   jni:
     dependency: transitive
     description:
@@ -722,10 +722,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -803,10 +803,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -1208,10 +1208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   timezone:
     dependency: transitive
     description:
@@ -1360,10 +1360,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/cockpit/test/data/git_head_baseline_reader_impl_test.dart
+++ b/cockpit/test/data/git_head_baseline_reader_impl_test.dart
@@ -1,0 +1,180 @@
+import 'dart:io';
+
+import 'package:cockpit/app/cockpit/data/filesystem/git_binary.dart';
+import 'package:cockpit/app/cockpit/data/filesystem/git_head_baseline_reader_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final reader = GitHeadBaselineReaderImpl(GitBinary());
+  late Directory repo;
+
+  Future<ProcessResult> git(List<String> args) =>
+      Process.run('git', args, workingDirectory: repo.path);
+
+  Future<bool> gitAvailable() async {
+    try {
+      return (await Process.run('git', ['--version'])).exitCode == 0;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> write(String rel, String content) =>
+      File('${repo.path}/$rel').writeAsString(content);
+
+  setUp(() async {
+    repo = await Directory.systemTemp.createTemp('cockpit_head_baseline_');
+    await git(['init']);
+    await git(['config', 'user.email', 'test@example.com']);
+    await git(['config', 'user.name', 'Test']);
+    await write('tracked.txt', 'line1\nline2\n');
+    await git(['add', '.']);
+    await git(['commit', '-m', 'init']);
+  });
+
+  tearDown(() async {
+    if (await repo.exists()) await repo.delete(recursive: true);
+  });
+
+  test('tracked file → blob de HEAD', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/tracked.txt',
+    );
+    expect(baseline, isNotNull);
+    expect(baseline!.content, 'line1\nline2\n');
+    expect(baseline.headIdentity, isNotEmpty);
+  });
+
+  test('staged changes não alteram o baseline (ainda HEAD)', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    await write('tracked.txt', 'STAGED\n');
+    await git(['add', 'tracked.txt']);
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/tracked.txt',
+    );
+    expect(baseline!.content, 'line1\nline2\n');
+  });
+
+  test('unstaged changes não alteram o baseline', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    await write('tracked.txt', 'DIRTY\n');
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/tracked.txt',
+    );
+    expect(baseline!.content, 'line1\nline2\n');
+  });
+
+  test('untracked → null', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    await write('new.txt', 'x\n');
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/new.txt',
+    );
+    expect(baseline, isNull);
+  });
+
+  test('ignored → null', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    await write('.gitignore', 'ignored.txt\n');
+    await git(['add', '.gitignore']);
+    await git(['commit', '-m', 'ignore']);
+    await write('ignored.txt', 'nope\n');
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/ignored.txt',
+    );
+    expect(baseline, isNull);
+  });
+
+  test('commit muda a identidade de HEAD e o conteúdo', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    final before = await reader.resolveHeadIdentity(repo.path);
+    await write('tracked.txt', 'after\n');
+    await git(['add', 'tracked.txt']);
+    await git(['commit', '-m', 'change']);
+    final after = await reader.resolveHeadIdentity(repo.path);
+    expect(after, isNot(equals(before)));
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/tracked.txt',
+    );
+    expect(baseline!.content, 'after\n');
+    expect(baseline.headIdentity, after);
+  });
+
+  test('checkout restaura o blob de HEAD', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    final firstHead = await reader.resolveHeadIdentity(repo.path);
+    await write('tracked.txt', 'branchy\n');
+    await git(['checkout', '-b', 'feature']);
+    await git(['add', 'tracked.txt']);
+    await git(['commit', '-m', 'feature']);
+    await git(['checkout', '-']);
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/tracked.txt',
+    );
+    expect(baseline!.headIdentity, firstHead);
+    expect(baseline.content, 'line1\nline2\n');
+  });
+
+  test('falha ao ler HEAD (pasta sem git) → null', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    final orphan = await Directory.systemTemp.createTemp('cockpit_no_git_');
+    addTearDown(() async {
+      if (await orphan.exists()) await orphan.delete(recursive: true);
+    });
+    await File('${orphan.path}/x.txt').writeAsString('x\n');
+    expect(await reader.resolveHeadIdentity(orphan.path), isNull);
+    expect(
+      await reader.readTrackedText(orphan.path, '${orphan.path}/x.txt'),
+      isNull,
+    );
+  });
+
+  test('binário → null', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    await File(
+      '${repo.path}/bin.dat',
+    ).writeAsBytes([0, 1, 2, 0, 255, 0, 10, 0]);
+    await git(['add', 'bin.dat']);
+    await git(['commit', '-m', 'bin']);
+    final baseline = await reader.readTrackedText(
+      repo.path,
+      '${repo.path}/bin.dat',
+    );
+    expect(baseline, isNull);
+  });
+}

--- a/cockpit/test/domain/scm_baseline_cache_test.dart
+++ b/cockpit/test/domain/scm_baseline_cache_test.dart
@@ -1,0 +1,75 @@
+import 'package:cockpit/app/cockpit/domain/contracts/git_head_baseline_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_head_baseline.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_baseline_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeReader implements GitHeadBaselineReader {
+  String? head = 'aaa';
+  final Map<String, String> blobs = <String, String>{};
+  int readCalls = 0;
+  int headCalls = 0;
+
+  @override
+  Future<String?> resolveHeadIdentity(String repoPath) async {
+    headCalls++;
+    return head;
+  }
+
+  @override
+  Future<GitHeadBaseline?> readTrackedText(
+    String repoPath,
+    String absPath,
+  ) async {
+    readCalls++;
+    final content = blobs[absPath];
+    final id = head;
+    if (content == null || id == null) return null;
+    return GitHeadBaseline(headIdentity: id, content: content);
+  }
+}
+
+void main() {
+  test('cacheia por root/path/head e evita releitura', () async {
+    final fake = _FakeReader()..blobs['/repo/a.txt'] = 'v1\n';
+    final cache = ScmBaselineCache(fake);
+
+    final first = await cache.baselineFor('/repo', '/repo/a.txt');
+    final second = await cache.baselineFor('/repo', '/repo/a.txt');
+
+    expect(first!.content, 'v1\n');
+    expect(second, same(first));
+    expect(fake.readCalls, 1);
+  });
+
+  test('mudança de HEAD invalida reuso da entrada antiga', () async {
+    final fake = _FakeReader()..blobs['/repo/a.txt'] = 'v1\n';
+    final cache = ScmBaselineCache(fake);
+
+    await cache.baselineFor('/repo', '/repo/a.txt');
+    fake.head = 'bbb';
+    fake.blobs['/repo/a.txt'] = 'v2\n';
+    cache.invalidateRepo('/repo');
+
+    final next = await cache.baselineFor('/repo', '/repo/a.txt');
+    expect(next!.content, 'v2\n');
+    expect(next.headIdentity, 'bbb');
+    expect(fake.readCalls, 2);
+  });
+
+  test('retarget/invalidateRepo não reusa entradas da root', () async {
+    final fake = _FakeReader()..blobs['/repo/a.txt'] = 'v1\n';
+    final cache = ScmBaselineCache(fake);
+
+    await cache.baselineFor('/repo', '/repo/a.txt');
+    cache.invalidateRepo('/repo');
+    await cache.baselineFor('/repo', '/repo/a.txt');
+    expect(fake.readCalls, 2);
+  });
+
+  test('HEAD ilegível → null sem cachear', () async {
+    final fake = _FakeReader()..head = null;
+    final cache = ScmBaselineCache(fake);
+    expect(await cache.baselineFor('/repo', '/repo/a.txt'), isNull);
+    expect(fake.readCalls, 0);
+  });
+}

--- a/cockpit/test/domain/scm_line_decoration_calculator_test.dart
+++ b/cockpit/test/domain/scm_line_decoration_calculator_test.dart
@@ -1,0 +1,177 @@
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_line_decoration_calculator.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const calc = ScmLineDecorationCalculator();
+
+  group('ScmLineDecorations value', () {
+    test('empty e igualdade por valor', () {
+      expect(ScmLineDecorations.empty.isEmpty, isTrue);
+      final a = ScmLineDecorations(
+        addedLines: {1, 2},
+        modifiedLines: {3},
+        removalBoundaries: {0, 4},
+      );
+      final b = ScmLineDecorations(
+        addedLines: {2, 1},
+        modifiedLines: {3},
+        removalBoundaries: {4, 0},
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(ScmLineDecorations.empty)));
+    });
+  });
+
+  group('cálculo', () {
+    test('conteúdo igual → vazio', () {
+      expect(
+        calc.calculate(baseline: 'a\nb\n', current: 'a\nb\n'),
+        ScmLineDecorations.empty,
+      );
+    });
+
+    test('inserções puras → added', () {
+      final result = calc.calculate(baseline: 'a\nc\n', current: 'a\nb\nc\n');
+      expect(result.addedLines, {2});
+      expect(result.modifiedLines, isEmpty);
+      expect(result.removalBoundaries, isEmpty);
+    });
+
+    test('substituição 1:1 → modified', () {
+      final result = calc.calculate(
+        baseline: 'a\nold\nc\n',
+        current: 'a\nnew\nc\n',
+      );
+      expect(result.modifiedLines, {2});
+      expect(result.addedLines, isEmpty);
+      expect(result.removalBoundaries, isEmpty);
+    });
+
+    test('bloco desbalanceado: mais inserts → modified + added', () {
+      final result = calc.calculate(
+        baseline: 'a\nx\nd\n',
+        current: 'a\ny\nz\nd\n',
+      );
+      expect(result.modifiedLines, {2});
+      expect(result.addedLines, {3});
+      expect(result.removalBoundaries, isEmpty);
+    });
+
+    test('bloco desbalanceado: mais deletes → modified + removal', () {
+      final result = calc.calculate(
+        baseline: 'a\nx\ny\nd\n',
+        current: 'a\nz\nd\n',
+      );
+      expect(result.modifiedLines, {2});
+      expect(result.addedLines, isEmpty);
+      // Sobras do baseline após o par → fronteira depois da linha modificada.
+      expect(result.removalBoundaries, {2});
+    });
+
+    test('remoção no início → boundary 0', () {
+      final result = calc.calculate(
+        baseline: 'gone\na\nb\n',
+        current: 'a\nb\n',
+      );
+      expect(result.removalBoundaries, {0});
+      expect(result.addedLines, isEmpty);
+      expect(result.modifiedLines, isEmpty);
+    });
+
+    test('remoção no meio → boundary antes da sobrevivente', () {
+      final result = calc.calculate(
+        baseline: 'a\ngone\nb\n',
+        current: 'a\nb\n',
+      );
+      // Remoção antes da linha atual 2 ("b") → boundary 1.
+      expect(result.removalBoundaries, {1});
+    });
+
+    test('remoção no fim → boundary após última linha sobrevivente', () {
+      // Sem newline final comum: current ["a","b"] → lineCount 2.
+      final result = calc.calculate(baseline: 'a\nb\ngone', current: 'a\nb');
+      expect(result.removalBoundaries, {2});
+    });
+
+    test('remoção no fim com newline final alinhada', () {
+      // Trailing "" casa nos dois lados; "gone" some antes dele → boundary 2.
+      final result = calc.calculate(
+        baseline: 'a\nb\ngone\n',
+        current: 'a\nb\n',
+      );
+      expect(result.removalBoundaries, {2});
+    });
+
+    test('múltiplas linhas adjacentes removidas → uma fronteira', () {
+      final result = calc.calculate(
+        baseline: 'a\nx\ny\nz\nb\n',
+        current: 'a\nb\n',
+      );
+      expect(result.removalBoundaries, {1});
+      expect(result.removalBoundaries.length, 1);
+    });
+
+    test('arquivo vazio vs conteúdo → linhas novas added', () {
+      // '' → [""]; 'a\nb\n' → ["a","b",""] — o "" final casa → added {1,2}.
+      final result = calc.calculate(baseline: '', current: 'a\nb\n');
+      expect(result.addedLines, {1, 2});
+      expect(result.modifiedLines, isEmpty);
+      expect(result.removalBoundaries, isEmpty);
+    });
+
+    test('conteúdo vs arquivo vazio → remoção', () {
+      final result = calc.calculate(baseline: 'a\nb\n', current: '');
+      expect(result.isEmpty, isFalse);
+    });
+
+    test('newline final preservada (ambos com \\n)', () {
+      final result = calc.calculate(baseline: 'a\nb\n', current: 'a\nB\n');
+      expect(result.modifiedLines, {2});
+      expect(result.addedLines, isEmpty);
+      expect(result.removalBoundaries, isEmpty);
+    });
+
+    test('múltiplos hunks independentes', () {
+      final result = calc.calculate(
+        baseline: 'a\nold1\nc\nold2\ne\n',
+        current: 'a\nnew1\nc\nnew2\ne\n',
+      );
+      expect(result.modifiedLines, {2, 4});
+      expect(result.addedLines, isEmpty);
+      expect(result.removalBoundaries, isEmpty);
+    });
+  });
+
+  test('arquivo grande: cálculo puro via compute, sem I/O', () async {
+    final baseline = StringBuffer();
+    final current = StringBuffer();
+    for (var i = 0; i < 2000; i++) {
+      baseline.writeln('line-$i');
+      if (i == 100) {
+        current.writeln('CHANGED');
+      } else if (i == 500) {
+        current.writeln('line-$i');
+        current.writeln('INSERTED');
+      } else if (i == 1500) {
+        // omit — remoção
+      } else {
+        current.writeln('line-$i');
+      }
+    }
+
+    final args = (baseline: baseline.toString(), current: current.toString());
+    final result = await compute(_calcIsolate, args);
+
+    expect(result.modifiedLines, contains(101));
+    expect(result.addedLines, isNotEmpty);
+    expect(result.removalBoundaries, isNotEmpty);
+  });
+}
+
+ScmLineDecorations _calcIsolate(({String baseline, String current}) args) {
+  const calc = ScmLineDecorationCalculator();
+  return calc.calculate(baseline: args.baseline, current: args.current);
+}

--- a/cockpit/test/ui/code_editor_bottom_scroll_test.dart
+++ b/cockpit/test/ui/code_editor_bottom_scroll_test.dart
@@ -1,0 +1,61 @@
+import 'package:cockpit/app/cockpit/ui/widgets/code_editor.dart';
+import 'package:cockpit/app/core/ui/themes/themes.dart';
+import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
+import 'package:flutter/material.dart' as m show TextField;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+void main() {
+  testWidgets(
+    'no fim do scroll a última linha do gutter fica acima da faixa da scrollbar',
+    (tester) async {
+      final text = List.generate(80, (i) => 'line ${i + 1}').join('\n');
+      final ctrl = CodeEditingController(text: text, language: 'txt');
+
+      await tester.pumpWidget(
+        ShadcnApp(
+          theme: buildTheme(brightness: Brightness.dark),
+          home: Scaffold(
+            child: Center(
+              child: SizedBox(
+                width: 320,
+                height: 220,
+                child: CodeEditor(controller: ctrl, focusNode: FocusNode()),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      ScrollPosition? vert;
+      for (final s in tester.widgetList<Scrollable>(find.byType(Scrollable))) {
+        final pos = s.controller?.position;
+        if (pos != null &&
+            pos.axis == Axis.vertical &&
+            pos.maxScrollExtent > 0) {
+          vert = pos;
+          break;
+        }
+      }
+      expect(vert, isNotNull);
+      vert!.jumpTo(vert.maxScrollExtent);
+      await tester.pumpAndSettle();
+
+      final field = tester.getRect(find.byType(m.TextField));
+      final lastLine = tester.getRect(find.text('80'));
+
+      // Folga de 14px no fim do scroll — a última linha não pode assentar no
+      // fio do viewport (onde a scrollbar horizontal faz overlay).
+      const padBottom = 14.0;
+      expect(
+        lastLine.bottom,
+        lessThanOrEqualTo(field.bottom - padBottom + 0.5),
+        reason:
+            'última linha ainda colada no fundo do campo '
+            '(bottom=${lastLine.bottom}, field=${field.bottom})',
+      );
+      expect(lastLine.height, greaterThan(10));
+    },
+  );
+}

--- a/cockpit/test/ui/code_editor_reveal_test.dart
+++ b/cockpit/test/ui/code_editor_reveal_test.dart
@@ -1,4 +1,6 @@
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/code_editor.dart';
+import 'package:cockpit/app/core/domain/entities/lsp_diagnostic.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
 import 'package:cockpit/app/core/ui/widgets/code_highlight.dart';
@@ -17,26 +19,25 @@ void main() {
     int? revealLine,
     bool revealSelect = true,
     int tick = 0,
-    Set<int> addedLines = const {},
-    Set<int> modifiedLines = const {},
-    Set<int> removedLines = const {},
+    ScmLineDecorations scmDecorations = ScmLineDecorations.empty,
+    Brightness brightness = Brightness.dark,
+    double width = 300,
+    double height = 200,
   }) {
     return ShadcnApp(
-      theme: buildTheme(brightness: Brightness.dark),
+      theme: buildTheme(brightness: brightness),
       home: Scaffold(
         child: Center(
           child: SizedBox(
-            width: 300,
-            height: 200,
+            width: width,
+            height: height,
             child: CodeEditor(
               controller: ctrl,
               focusNode: FocusNode(),
               revealLine: revealLine,
               revealSelect: revealSelect,
               revealTick: tick,
-              addedLines: addedLines,
-              modifiedLines: modifiedLines,
-              removedLines: removedLines,
+              scmDecorations: scmDecorations,
               revealMatchStart: revealStart,
               revealMatchTick: tick,
             ),
@@ -44,6 +45,24 @@ void main() {
         ),
       ),
     );
+  }
+
+  bool hasPaintedColor(WidgetTester tester, Key key, Color expected) {
+    return find
+        .descendant(
+          of: find.byKey(key),
+          matching: find.byWidgetPredicate((w) {
+            if (w is ColoredBox) return w.color == expected;
+            if (w is Container) {
+              if (w.color == expected) return true;
+              final d = w.decoration;
+              return d is BoxDecoration && d.color == expected;
+            }
+            return false;
+          }),
+        )
+        .evaluate()
+        .isNotEmpty;
   }
 
   testWidgets('reveal de match assenta sem travar (scroll anexado)', (
@@ -69,17 +88,167 @@ void main() {
         revealLine: 2,
         revealSelect: false,
         tick: 1,
-        addedLines: const {2},
-        modifiedLines: const {3},
-        removedLines: const {4},
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {2},
+          modifiedLines: {3},
+          removalBoundaries: {3},
+        ),
       ),
     );
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('git-change-line:2')), findsOneWidget);
     expect(find.byKey(const ValueKey('git-change-line:3')), findsOneWidget);
-    expect(find.byKey(const ValueKey('git-change-line:4')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('git-removal-boundary:3')),
+      findsOneWidget,
+    );
     expect(ctrl.selection.isCollapsed, isTrue);
+  });
+
+  testWidgets('SCM gutter usa tokens online/accent/gitDeleted', (tester) async {
+    final ctrl = CodeEditingController(text: 'a\nb\nc\n', language: 'txt');
+    await tester.pumpWidget(
+      harness(
+        ctrl,
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {1},
+          modifiedLines: {2},
+          removalBoundaries: {0, 3},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      hasPaintedColor(
+        tester,
+        const ValueKey('git-change-line:1'),
+        AppColors.dark.online,
+      ),
+      isTrue,
+    );
+    expect(
+      hasPaintedColor(
+        tester,
+        const ValueKey('git-change-line:2'),
+        AppColors.dark.accent,
+      ),
+      isTrue,
+    );
+    expect(
+      hasPaintedColor(
+        tester,
+        const ValueKey('git-removal-boundary:0'),
+        AppColors.dark.gitDeleted,
+      ),
+      isTrue,
+    );
+    expect(
+      hasPaintedColor(
+        tester,
+        const ValueKey('git-removal-boundary:3'),
+        AppColors.dark.gitDeleted,
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('removal boundary 0 aparece na primeira linha visível', (
+    tester,
+  ) async {
+    final ctrl = CodeEditingController(text: 'only\n', language: 'txt');
+    await tester.pumpWidget(
+      harness(
+        ctrl,
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {},
+          modifiedLines: {},
+          removalBoundaries: {0},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    // hasScm → Stack ganha git-change-line:1; o vermelho é o boundary 0.
+    expect(find.byKey(const ValueKey('git-change-line:1')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('git-removal-boundary:0')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('linha SCM fora do viewport não é construída (virtualização)', (
+    tester,
+  ) async {
+    final lines = List.generate(80, (i) => 'line$i').join('\n');
+    final ctrl = CodeEditingController(text: lines, language: 'txt');
+    await tester.pumpWidget(
+      harness(
+        ctrl,
+        height: 160,
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {1, 70},
+          modifiedLines: {},
+          removalBoundaries: {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('git-change-line:1')), findsOneWidget);
+    expect(find.byKey(const ValueKey('git-change-line:70')), findsNothing);
+  });
+
+  testWidgets('marcador SCM não recebe hit test (IgnorePointer)', (
+    tester,
+  ) async {
+    final ctrl = CodeEditingController(text: 'a\nb\nc\n', language: 'txt');
+    await tester.pumpWidget(
+      harness(
+        ctrl,
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {1},
+          modifiedLines: {},
+          removalBoundaries: {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('git-change-line:1')),
+        matching: find.byType(IgnorePointer),
+      ),
+      findsWidgets,
+    );
+  });
+
+  testWidgets('SCM e diagnostic coexistem na mesma linha do gutter', (
+    tester,
+  ) async {
+    final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt')
+      ..diagnostics = const [
+        LspDiagnostic(
+          range: LspRange(LspPosition(0, 0), LspPosition(0, 1)),
+          severity: LspSeverity.error,
+          message: 'boom',
+        ),
+      ];
+    await tester.pumpWidget(
+      harness(
+        ctrl,
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {1},
+          modifiedLines: {},
+          removalBoundaries: {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('git-change-line:1')), findsOneWidget);
+    expect(find.byIcon(Icons.error), findsOneWidget);
   });
 
   testWidgets('reveal repetido (navegação entre matches) assenta', (

--- a/cockpit/test/ui/code_editor_reveal_test.dart
+++ b/cockpit/test/ui/code_editor_reveal_test.dart
@@ -1,5 +1,6 @@
 import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/code_editor.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/editor_overview_ruler.dart';
 import 'package:cockpit/app/core/domain/entities/lsp_diagnostic.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
@@ -222,6 +223,72 @@ void main() {
       ),
       findsWidgets,
     );
+  });
+
+  testWidgets('overview SCM aparece na faixa do scroll vertical', (
+    tester,
+  ) async {
+    final ctrl = CodeEditingController(
+      text: List.generate(40, (i) => 'line$i').join('\n'),
+      language: 'txt',
+    );
+    await tester.pumpWidget(
+      harness(
+        ctrl,
+        height: 240,
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {2, 3, 4},
+          modifiedLines: {20},
+          removalBoundaries: {0, 40},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('git-scm-overview')), findsOneWidget);
+  });
+
+  test('scmOverviewLineForDy mapeia proporção do documento', () {
+    expect(scmOverviewLineForDy(dy: 0, height: 200, lineCount: 40), 1);
+    expect(scmOverviewLineForDy(dy: 100, height: 200, lineCount: 40), 21);
+    expect(scmOverviewLineForDy(dy: 199, height: 200, lineCount: 40), 40);
+    expect(
+      scmOverviewLineForDy(dy: (29.5 / 40) * 200, height: 200, lineCount: 40),
+      30,
+    );
+  });
+
+  testWidgets('tap no overview SCM salta à linha sem selecionar', (
+    tester,
+  ) async {
+    final ctrl = CodeEditingController(
+      text: List.generate(40, (i) => 'line$i').join('\n'),
+      language: 'txt',
+    );
+    await tester.pumpWidget(
+      harness(
+        ctrl,
+        height: 240,
+        scmDecorations: const ScmLineDecorations(
+          addedLines: {30},
+          modifiedLines: {},
+          removalBoundaries: {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final overview = find.byKey(const ValueKey('git-scm-overview'));
+    expect(overview, findsOneWidget);
+    final box = tester.getRect(overview);
+    final dy = (29.5 / 40) * box.height;
+    await tester.tapAt(Offset(box.center.dx, box.top + dy));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    expect(ctrl.selection.isCollapsed, isTrue);
+    final expectedStart =
+        List.generate(29, (i) => 'line$i').join('\n').length + 1;
+    expect(ctrl.selection.baseOffset, expectedStart);
   });
 
   testWidgets('SCM e diagnostic coexistem na mesma linha do gutter', (

--- a/cockpit/test/ui/code_editor_reveal_test.dart
+++ b/cockpit/test/ui/code_editor_reveal_test.dart
@@ -5,6 +5,9 @@ import 'package:cockpit/app/core/domain/entities/lsp_diagnostic.dart';
 import 'package:cockpit/app/core/ui/themes/themes.dart';
 import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
 import 'package:cockpit/app/core/ui/widgets/code_highlight.dart';
+import 'package:flutter/material.dart'
+    as m
+    show Scrollbar, ScrollbarOrientation;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
@@ -246,6 +249,22 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('git-scm-overview')), findsOneWidget);
+    final verticalBar = tester
+        .widgetList<m.Scrollbar>(find.byType(m.Scrollbar))
+        .singleWhere(
+          (bar) => bar.scrollbarOrientation != m.ScrollbarOrientation.bottom,
+        );
+    final metrics = verticalBar.controller!.position;
+    final ruler = tester.widget<EditorOverviewRuler>(
+      find.byType(EditorOverviewRuler),
+    );
+    expect(ruler.scrollViewportExtent, metrics.viewportDimension);
+    expect(
+      ruler.scrollContentExtent,
+      metrics.maxScrollExtent -
+          metrics.minScrollExtent +
+          metrics.viewportDimension,
+    );
   });
 
   test('scmOverviewLineForDy mapeia proporção do documento', () {
@@ -255,6 +274,68 @@ void main() {
     expect(
       scmOverviewLineForDy(dy: (29.5 / 40) * 200, height: 200, lineCount: 40),
       30,
+    );
+  });
+
+  test('overview considera o tamanho mínimo do thumb da scrollbar', () {
+    const lineHeight = 20.0;
+    const lineCount = 400;
+    const contentHeight = 8000.0;
+    const viewport = 212.0;
+    const track = 212.0;
+    final thumb = overviewScrollbarThumbExtent(
+      contentExtent: contentHeight,
+      viewportExtent: viewport,
+      trackPaddingExtent: 0,
+      traversableTrackExtent: track,
+      minThumbExtent: 48,
+    );
+    expect(thumb, 48);
+
+    final geometry = OverviewRulerGeometry(
+      contentExtent: contentHeight,
+      viewportExtent: viewport,
+      trackStart: 0,
+      trackExtent: track,
+      thumbExtent: thumb,
+    );
+
+    // Linha 1 começa no topo da trilha.
+    expect(geometry.contentToTrack(0), 0);
+
+    // Se esse ponto estiver centralizado no viewport, seu indicador coincide
+    // exatamente com o centro do thumb, mesmo com o clamp mínimo de 48 px.
+    const contentPoint = 2010.0;
+    final centeredScrollOffset = contentPoint - viewport / 2;
+    final expectedThumbCenter =
+        (centeredScrollOffset / (contentHeight - viewport)) * (track - thumb) +
+        thumb / 2;
+    final indicatorY = geometry.contentToTrack(contentPoint);
+    expect(indicatorY, closeTo(expectedThumbCenter, 0.001));
+    expect(
+      indicatorY,
+      isNot(
+        closeTo(
+          overviewTrackY(
+            contentOffset: contentPoint,
+            contentHeight: contentHeight,
+            trackHeight: track,
+          ),
+          0.001,
+        ),
+      ),
+    );
+
+    expect(
+      overviewRulerLineForDy(
+        dy: indicatorY,
+        trackHeight: track,
+        lineCount: lineCount,
+        lineHeight: lineHeight,
+        contentExtent: contentHeight,
+        geometry: geometry,
+      ),
+      101,
     );
   });
 
@@ -281,7 +362,14 @@ void main() {
     final overview = find.byKey(const ValueKey('git-scm-overview'));
     expect(overview, findsOneWidget);
     final box = tester.getRect(overview);
-    final dy = (29.5 / 40) * box.height;
+    final ruler = tester.widget<EditorOverviewRuler>(
+      find.byType(EditorOverviewRuler),
+    );
+    final padding = MediaQuery.paddingOf(tester.element(overview));
+    final trackHeight = ruler.scrollViewportExtent! - padding.vertical;
+    final dy =
+        padding.top +
+        ((29.5 * ruler.lineHeight) / ruler.scrollContentExtent!) * trackHeight;
     await tester.tapAt(Offset(box.center.dx, box.top + dy));
     await tester.pumpAndSettle(const Duration(seconds: 1));
 

--- a/cockpit/test/ui/scm_line_decoration_coordinator_test.dart
+++ b/cockpit/test/ui/scm_line_decoration_coordinator_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cockpit/app/cockpit/domain/contracts/git_head_baseline_reader.dart';
 import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
 import 'package:cockpit/app/cockpit/domain/entities/git_head_baseline.dart';
@@ -359,4 +361,70 @@ void main() {
       session.dispose();
     });
   });
+
+  test('stale baseline miss must not wipe decorations from a newer reload', () {
+    // Boot race: attach lê baseline com root ainda errada (demora e volta
+    // null); git.refresh dispara reload novo que publica; o miss atrasado
+    // NÃO pode chamar clear por cima.
+    fakeAsync((async) {
+      final fake = _GatedReader(blobs: {'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache, debounce: Duration.zero);
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+
+      // 1º readTrackedText ficou parado no gate (miss atrasado).
+      async.flushMicrotasks();
+      expect(fake.gates, hasLength(1));
+
+      // Refresh Git → novo reload (2º read) completa e publica.
+      fake.head = 'bbb';
+      coord.onGitRevisionChanged();
+      async.flushMicrotasks();
+      // Libera só o 2º gate (reload novo); o 1º continua pendente.
+      expect(fake.gates, hasLength(2));
+      fake.gates[1].complete();
+      _flush(async);
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      // Miss atrasado completa com null — epoch velho → não limpa.
+      fake.gates[0].complete();
+      _flush(async);
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+}
+
+/// Reader que segura cada [readTrackedText] num [Completer] (teste de race).
+class _GatedReader implements GitHeadBaselineReader {
+  _GatedReader({required this.blobs});
+
+  String? head = 'aaa';
+  final Map<String, String> blobs;
+  final List<Completer<void>> gates = <Completer<void>>[];
+
+  @override
+  Future<String?> resolveHeadIdentity(String repoPath) async => head;
+
+  @override
+  Future<GitHeadBaseline?> readTrackedText(
+    String repoPath,
+    String absPath,
+  ) async {
+    final gate = Completer<void>();
+    gates.add(gate);
+    await gate.future;
+    // 1º read (atrasado): simula root/HEAD ainda inválidos no boot.
+    if (identical(gate, gates.first)) return null;
+    final id = head;
+    final text = blobs[absPath];
+    if (id == null || text == null) return null;
+    return GitHeadBaseline(headIdentity: id, content: text);
+  }
 }

--- a/cockpit/test/ui/scm_line_decoration_coordinator_test.dart
+++ b/cockpit/test/ui/scm_line_decoration_coordinator_test.dart
@@ -1,0 +1,362 @@
+import 'package:cockpit/app/cockpit/domain/contracts/git_head_baseline_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_head_baseline.dart';
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_baseline_cache.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_line_decoration_calculator.dart';
+import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
+import 'package:cockpit/app/cockpit/ui/session/scm_line_decoration_coordinator.dart';
+import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeReader implements GitHeadBaselineReader {
+  _FakeReader({Map<String, String>? blobs})
+    : blobs = blobs ?? <String, String>{};
+
+  String? head = 'aaa';
+  final Map<String, String> blobs;
+  int readCalls = 0;
+
+  @override
+  Future<String?> resolveHeadIdentity(String repoPath) async => head;
+
+  @override
+  Future<GitHeadBaseline?> readTrackedText(
+    String repoPath,
+    String absPath,
+  ) async {
+    readCalls++;
+    final id = head;
+    final text = blobs[absPath];
+    if (id == null || text == null) return null;
+    return GitHeadBaseline(headIdentity: id, content: text);
+  }
+}
+
+FileViewerSession _session({
+  String path = '/repo/a.txt',
+  bool scratch = false,
+}) {
+  return FileViewerSession(
+    id: 's1',
+    projectId: '/repo',
+    path: path,
+    view: const FileViewText('a\nb\n', language: 'txt'),
+    scratch: scratch,
+  );
+}
+
+ScmLineDecorationCoordinator _coord(
+  FileViewerSession session,
+  ScmBaselineCache cache, {
+  String? Function(String path)? resolveGitRoot,
+  Duration debounce = const Duration(milliseconds: 120),
+}) {
+  return ScmLineDecorationCoordinator(
+    session: session,
+    cache: cache,
+    calculator: const ScmLineDecorationCalculator(),
+    resolveGitRoot: resolveGitRoot ?? ((_) => '/repo'),
+    debounce: debounce,
+  );
+}
+
+/// [Future] event-loop callbacks + timers (debounce / `Future(() => …)`).
+void _flush(FakeAsync async) {
+  async.flushMicrotasks();
+  async.elapse(Duration.zero);
+  async.flushMicrotasks();
+}
+
+void main() {
+  test('debounce coalesces rapid buffer edits into one publish', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'a\nb\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache);
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      ctrl.text = 'a\nb\nc\n';
+      ctrl.text = 'a\nb\nc\nd\n';
+      async.elapse(const Duration(milliseconds: 50));
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      async.elapse(const Duration(milliseconds: 80));
+      _flush(async);
+      expect(session.scmDecorations.addedLines, isNotEmpty);
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('unsaved buffer differs from HEAD → decorations without save', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'hello\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache, debounce: Duration.zero);
+      final ctrl = CodeEditingController(
+        text: 'hello\nworld\n',
+        language: 'txt',
+      );
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('undo back to HEAD clears decorations', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'hello\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache);
+      final ctrl = CodeEditingController(text: 'hello\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.isEmpty, isTrue);
+
+      ctrl.text = 'hello\nworld\n';
+      async.elapse(const Duration(milliseconds: 120));
+      _flush(async);
+      expect(session.scmDecorations.isEmpty, isFalse);
+
+      ctrl.text = 'hello\n';
+      async.elapse(const Duration(milliseconds: 120));
+      _flush(async);
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('stale async result is discarded after newer buffer revision', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache);
+      final ctrl = CodeEditingController(text: 'a\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+
+      ctrl.text = 'a\nb\n';
+      async.elapse(const Duration(milliseconds: 120));
+      // Bump revision before the scheduled calculate Future publishes.
+      ctrl.text = 'a\n';
+      _flush(async);
+      async.elapse(const Duration(milliseconds: 120));
+      _flush(async);
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('git revision change reloads baseline and recalculates', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'v1\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache, debounce: Duration.zero);
+      final ctrl = CodeEditingController(text: 'v1\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.isEmpty, isTrue);
+
+      fake.head = 'bbb';
+      fake.blobs['/repo/a.txt'] = 'v2\n';
+      coord.onGitRevisionChanged();
+      _flush(async);
+
+      // Buffer ainda é v1; HEAD agora é v2 → diferença.
+      expect(session.scmDecorations.isEmpty, isFalse);
+      expect(fake.readCalls, greaterThanOrEqualTo(2));
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('external content adoption schedules recalculation', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache);
+      final ctrl = CodeEditingController(text: 'a\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+
+      ctrl.value = const TextEditingValue(text: 'a\nb\n');
+      coord.onExternalContentAdopted();
+      async.elapse(const Duration(milliseconds: 120));
+      _flush(async);
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('preview reuse / path change clears then reloads for new path', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(
+        blobs: {'/repo/old.txt': 'old\n', '/repo/new.txt': 'new\n'},
+      );
+      final cache = ScmBaselineCache(fake);
+      final session = _session(path: '/repo/old.txt');
+      final coord = _coord(session, cache, debounce: Duration.zero);
+      final ctrl = CodeEditingController(text: 'old\nx\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.isEmpty, isFalse);
+
+      session.path = '/repo/new.txt';
+      ctrl.text = 'new\n';
+      session.setScmDecorations(ScmLineDecorations.empty);
+      coord.onSessionPathChanged();
+      _flush(async);
+
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('retarget notifies coordinator and clears stale markers', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session(path: '/repo/a.txt');
+      final coord = _coord(session, cache, debounce: Duration.zero);
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.addedLines, isNotEmpty);
+
+      // b.txt não tem blob no fake → inelegível.
+      session.retarget('/repo/b.txt');
+      _flush(async);
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('dispose cancels pending debounce and keeps empty decorations', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session();
+      final coord = _coord(session, cache);
+      final ctrl = CodeEditingController(text: 'a\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+
+      ctrl.text = 'a\nb\n';
+      coord.dispose();
+      async.elapse(const Duration(milliseconds: 200));
+      _flush(async);
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('outside git root publishes empty and never reads baseline', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/outside/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session(path: '/outside/a.txt');
+      final coord = _coord(
+        session,
+        cache,
+        resolveGitRoot: (_) => null,
+        debounce: Duration.zero,
+      );
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+      expect(fake.readCalls, 0);
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+
+  test('multi-root resolve picks the owning root for baseline lookup', () {
+    fakeAsync((async) {
+      final fake = _FakeReader(blobs: {'/ws/b/file.txt': 'root-b\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = _session(path: '/ws/b/file.txt');
+      String? resolvedRoot;
+      final coord = _coord(
+        session,
+        cache,
+        resolveGitRoot: (path) {
+          if (path.startsWith('/ws/a')) {
+            resolvedRoot = '/ws/a';
+            return '/ws/a';
+          }
+          if (path.startsWith('/ws/b')) {
+            resolvedRoot = '/ws/b';
+            return '/ws/b';
+          }
+          return null;
+        },
+        debounce: Duration.zero,
+      );
+      final ctrl = CodeEditingController(
+        text: 'root-b\nextra\n',
+        language: 'txt',
+      );
+      session.attachScmCoordinator(coord);
+      coord.attachController(ctrl);
+      _flush(async);
+
+      expect(resolvedRoot, '/ws/b');
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      coord.dispose();
+      ctrl.dispose();
+      session.dispose();
+    });
+  });
+}

--- a/cockpit/test/ui/scm_session_integration_test.dart
+++ b/cockpit/test/ui/scm_session_integration_test.dart
@@ -1,0 +1,285 @@
+import 'package:cockpit/app/cockpit/domain/contracts/git_head_baseline_reader.dart';
+import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_head_baseline.dart';
+import 'package:cockpit/app/cockpit/domain/entities/scm_line_decorations.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_baseline_cache.dart';
+import 'package:cockpit/app/cockpit/domain/services/scm_line_decoration_calculator.dart';
+import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
+import 'package:cockpit/app/cockpit/ui/session/scm_line_decoration_coordinator.dart';
+import 'package:cockpit/app/core/ui/widgets/code_editing_controller.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Espelha a política de `_ensureScmCoordinator` / `openFile` / `openChangedFile`
+/// do `CockpitViewModel` sem montar o VM inteiro (31 deps).
+class _FakeReader implements GitHeadBaselineReader {
+  _FakeReader(this.blobs);
+
+  String? head = 'aaa';
+  final Map<String, String> blobs;
+  int readCalls = 0;
+
+  @override
+  Future<String?> resolveHeadIdentity(String repoPath) async => head;
+
+  @override
+  Future<GitHeadBaseline?> readTrackedText(
+    String repoPath,
+    String absPath,
+  ) async {
+    readCalls++;
+    final id = head;
+    final text = blobs[absPath];
+    if (id == null || text == null) return null;
+    return GitHeadBaseline(headIdentity: id, content: text);
+  }
+}
+
+void _flush(FakeAsync async) {
+  async.flushMicrotasks();
+  async.elapse(Duration.zero);
+  async.flushMicrotasks();
+}
+
+/// Mesma regra do VM: textual editável, não-scratch → attach uma vez.
+void ensureScmCoordinator(
+  FileViewerSession session, {
+  required ScmBaselineCache cache,
+  required String? Function(String path) resolveGitRoot,
+}) {
+  final editable =
+      session.view is FileViewText ||
+      session.view is FileViewMarkdown ||
+      session.view is FileViewSvg;
+  if (session.scratch || !editable) {
+    session.clearScmDecorations();
+    return;
+  }
+  if (session.scmCoordinator != null) return;
+  session.attachScmCoordinator(
+    ScmLineDecorationCoordinator(
+      session: session,
+      cache: cache,
+      calculator: const ScmLineDecorationCalculator(),
+      resolveGitRoot: resolveGitRoot,
+      debounce: Duration.zero,
+    ),
+  );
+}
+
+void main() {
+  test('abertura normal de arquivo textual anexa um coordenador', () {
+    fakeAsync((async) {
+      final fake = _FakeReader({'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = FileViewerSession(
+        id: 'v1',
+        projectId: 'p',
+        path: '/repo/a.txt',
+        view: const FileViewText('a\nb\n', language: 'txt'),
+      );
+
+      ensureScmCoordinator(
+        session,
+        cache: cache,
+        resolveGitRoot: (_) => '/repo',
+      );
+      expect(session.scmCoordinator, isNotNull);
+
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.scmCoordinator!.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      session.dispose();
+      ctrl.dispose();
+    });
+  });
+
+  test('arquivo já aberto: ensure não duplica o coordenador', () {
+    final fake = _FakeReader({'/repo/a.txt': 'a\n'});
+    final cache = ScmBaselineCache(fake);
+    final session = FileViewerSession(
+      id: 'v1',
+      projectId: 'p',
+      path: '/repo/a.txt',
+      view: const FileViewText('a\n', language: 'txt'),
+    );
+
+    ensureScmCoordinator(session, cache: cache, resolveGitRoot: (_) => '/repo');
+    final first = session.scmCoordinator;
+    ensureScmCoordinator(session, cache: cache, resolveGitRoot: (_) => '/repo');
+    expect(session.scmCoordinator, same(first));
+
+    session.dispose();
+  });
+
+  test(
+    'abertura via Source Control não injeta sets — só o coordenador publica',
+    () {
+      fakeAsync((async) {
+        final fake = _FakeReader({'/repo/a.txt': 'base\n'});
+        final cache = ScmBaselineCache(fake);
+        final session = FileViewerSession(
+          id: 'v1',
+          projectId: 'p',
+          path: '/repo/a.txt',
+          view: const FileViewText('base\nedit\n', language: 'txt'),
+          isPreview: false,
+        );
+
+        // openChangedFile → openFile(isPreview: false) → ensure + attach.
+        expect(session.scmDecorations, ScmLineDecorations.empty);
+        ensureScmCoordinator(
+          session,
+          cache: cache,
+          resolveGitRoot: (_) => '/repo',
+        );
+        final ctrl = CodeEditingController(
+          text: 'base\nedit\n',
+          language: 'txt',
+        );
+        session.scmCoordinator!.attachController(ctrl);
+        _flush(async);
+
+        expect(session.scmDecorations.addedLines, contains(2));
+        // Sem API de injeção pontual: só setScmDecorations do coordenador.
+        expect(session.scmDecorations.modifiedLines, isEmpty);
+
+        session.dispose();
+        ctrl.dispose();
+      });
+    },
+  );
+
+  test('múltiplas Git roots: resolveGitRoot escolhe a root dona', () {
+    fakeAsync((async) {
+      final fake = _FakeReader({
+        '/ws/a/f.txt': 'from-a\n',
+        '/ws/b/f.txt': 'from-b\n',
+      });
+      final cache = ScmBaselineCache(fake);
+      final session = FileViewerSession(
+        id: 'v1',
+        projectId: 'p',
+        path: '/ws/b/f.txt',
+        view: const FileViewText('from-b\nx\n', language: 'txt'),
+      );
+      final roots = <String>[];
+      ensureScmCoordinator(
+        session,
+        cache: cache,
+        resolveGitRoot: (path) {
+          final root = path.startsWith('/ws/a')
+              ? '/ws/a'
+              : path.startsWith('/ws/b')
+              ? '/ws/b'
+              : null;
+          if (root != null) roots.add(root);
+          return root;
+        },
+      );
+      final ctrl = CodeEditingController(text: 'from-b\nx\n', language: 'txt');
+      session.scmCoordinator!.attachController(ctrl);
+      _flush(async);
+
+      expect(roots, contains('/ws/b'));
+      expect(roots, isNot(contains('/ws/a')));
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      session.dispose();
+      ctrl.dispose();
+    });
+  });
+
+  test('arquivo fora de repositório permanece sem decorações', () {
+    fakeAsync((async) {
+      final fake = _FakeReader({'/tmp/x.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = FileViewerSession(
+        id: 'v1',
+        projectId: 'p',
+        path: '/tmp/x.txt',
+        view: const FileViewText('a\nb\n', language: 'txt'),
+      );
+      ensureScmCoordinator(session, cache: cache, resolveGitRoot: (_) => null);
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.scmCoordinator!.attachController(ctrl);
+      _flush(async);
+
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+      expect(fake.readCalls, 0);
+
+      session.dispose();
+      ctrl.dispose();
+    });
+  });
+
+  test('preview reuse limpa decorações antes de recarregar o path novo', () {
+    fakeAsync((async) {
+      final fake = _FakeReader({
+        '/repo/old.txt': 'old\n',
+        '/repo/new.txt': 'new\n',
+      });
+      final cache = ScmBaselineCache(fake);
+      final session = FileViewerSession(
+        id: 'v1',
+        projectId: 'p',
+        path: '/repo/old.txt',
+        view: const FileViewText('old\nx\n', language: 'txt'),
+        isPreview: true,
+      );
+      ensureScmCoordinator(
+        session,
+        cache: cache,
+        resolveGitRoot: (_) => '/repo',
+      );
+      final ctrl = CodeEditingController(text: 'old\nx\n', language: 'txt');
+      session.scmCoordinator!.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.isEmpty, isFalse);
+
+      // Espelha openFile preview reuse.
+      session.path = '/repo/new.txt';
+      session.view = const FileViewText('new\n', language: 'txt');
+      session.setScmDecorations(ScmLineDecorations.empty);
+      ensureScmCoordinator(
+        session,
+        cache: cache,
+        resolveGitRoot: (_) => '/repo',
+      );
+      expect(session.scmCoordinator, isNotNull);
+      ctrl.text = 'new\n';
+      session.scmCoordinator!.onSessionPathChanged();
+      _flush(async);
+      expect(session.scmDecorations, ScmLineDecorations.empty);
+
+      session.dispose();
+      ctrl.dispose();
+    });
+  });
+
+  test('scratch / Untitled limpa coordenador e decorações', () {
+    final fake = _FakeReader({});
+    final cache = ScmBaselineCache(fake);
+    final session = FileViewerSession(
+      id: 'v1',
+      projectId: 'p',
+      path: '',
+      view: const FileViewText('x\n', language: 'dbq'),
+      scratch: true,
+      scratchTitle: 'Untitled-1.dbq',
+    );
+    session.setScmDecorations(
+      const ScmLineDecorations(
+        addedLines: {1},
+        modifiedLines: {},
+        removalBoundaries: {},
+      ),
+    );
+    ensureScmCoordinator(session, cache: cache, resolveGitRoot: (_) => '/repo');
+    expect(session.scmCoordinator, isNull);
+    expect(session.scmDecorations, ScmLineDecorations.empty);
+    session.dispose();
+  });
+}

--- a/cockpit/test/ui/scm_session_integration_test.dart
+++ b/cockpit/test/ui/scm_session_integration_test.dart
@@ -11,7 +11,8 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Espelha a política de `_ensureScmCoordinator` / `openFile` / `openChangedFile`
-/// do `CockpitViewModel` sem montar o VM inteiro (31 deps).
+/// / `_restoreSession(viewer)` do `CockpitViewModel` sem montar o VM inteiro
+/// (31 deps).
 class _FakeReader implements GitHeadBaselineReader {
   _FakeReader(this.blobs);
 
@@ -112,6 +113,70 @@ void main() {
     expect(session.scmCoordinator, same(first));
 
     session.dispose();
+  });
+
+  test('restauração de sessão: ensure anexa coordenador como na abertura', () {
+    fakeAsync((async) {
+      final fake = _FakeReader({'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      // Espelha `_restoreSession(viewer)`: cria a sessão e só depois ensure
+      // (antes do FileViewer montar / attachController).
+      final session = FileViewerSession(
+        id: 'v-restored',
+        projectId: 'p',
+        path: '/repo/a.txt',
+        view: const FileViewText('a\nb\n', language: 'txt'),
+      );
+      expect(session.scmCoordinator, isNull);
+
+      ensureScmCoordinator(
+        session,
+        cache: cache,
+        resolveGitRoot: (_) => '/repo',
+      );
+      expect(session.scmCoordinator, isNotNull);
+
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.scmCoordinator!.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      session.dispose();
+      ctrl.dispose();
+    });
+  });
+
+  test('attachScmCoordinator notifica para bind tardio do controller', () {
+    fakeAsync((async) {
+      final fake = _FakeReader({'/repo/a.txt': 'a\n'});
+      final cache = ScmBaselineCache(fake);
+      final session = FileViewerSession(
+        id: 'v1',
+        projectId: 'p',
+        path: '/repo/a.txt',
+        view: const FileViewText('a\nb\n', language: 'txt'),
+      );
+
+      var notified = 0;
+      session.addListener(() => notified++);
+
+      ensureScmCoordinator(
+        session,
+        cache: cache,
+        resolveGitRoot: (_) => '/repo',
+      );
+      expect(notified, greaterThan(0));
+      expect(session.scmCoordinator, isNotNull);
+
+      // Simula FileViewer que só liga o controller ao receber o notify.
+      final ctrl = CodeEditingController(text: 'a\nb\n', language: 'txt');
+      session.scmCoordinator!.attachController(ctrl);
+      _flush(async);
+      expect(session.scmDecorations.addedLines, contains(2));
+
+      session.dispose();
+      ctrl.dispose();
+    });
   });
 
   test(


### PR DESCRIPTION
## Summary

- Decorações de linha SCM no gutter do editor (adicionado / modificado / removido) comparando o buffer ao `HEAD`, em qualquer abertura de arquivo elegível — inclusive abas restauradas no boot.
- Overview ruler fino na faixa do scroll (coluna Git sob a scrollbar), com tap para saltar à alteração; API multi-coluna pronta para diagnostics no futuro.
- Coordenador reativo com debounce, cache de baseline e proteção contra reloads atrasados que limpavam decorações no boot.
- Indicadores do overview sincronizados com a geometria efetiva da scrollbar, inclusive em arquivos longos.

## Root cause and fix

O overview estimava a extensão do conteúdo e distribuía as marcas linearmente pela altura do widget. A scrollbar, porém, usa os `ScrollMetrics` reais, padding e margens da trilha, além de limitar o thumb a um tamanho mínimo. Essa diferença deslocava os indicadores em relação à posição visual do conteúdo.

O ruler agora usa as métricas do mesmo scroll vertical do editor e reproduz o percurso e o tamanho efetivos do thumb. O mapeamento inverso usado pelo clique no overview compartilha a mesma geometria.

## Validation

- `flutter test test/ui/code_editor_reveal_test.dart test/ui/code_editor_selection_scroll_test.dart test/ui/code_editor_bottom_scroll_test.dart` — 16 testes passaram.
- `flutter analyze lib/app/cockpit/ui/widgets/code_editor.dart lib/app/cockpit/ui/widgets/editor_overview_ruler.dart test/ui/code_editor_reveal_test.dart` — sem problemas.

## Preview

| Imagens |
| --- |
| <img width="1355" height="936" alt="image" src="https://github.com/user-attachments/assets/95948fe7-55ab-4f1d-a539-ab68ab3987f1" />|
