### PR TITLE
feat: bridge OMP ask prompts to Remote Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,22 @@ Then in the Pi chat, run:
 The setup wizard walks you through agent name, session name, and relay choice,
 then prints a QR code. Scan it with the Remote Pi mobile app and you're paired.
 
-### Recommended companion: `@eko24ive/pi-ask`
+### Structured clarification prompts
 
-```bash
-pi install npm:@eko24ive/pi-ask
-```
+Remote Pi renders rich clarification prompts in the mobile app when the host
+exposes either:
 
-With pi-ask installed, the agent's `ask_user` clarification prompts (structured
-questions with options, multi-select, and previews) render natively in the
-mobile app — answer from your phone and the flow resolves on the desktop.
-Without it, the agent simply asks in plain chat text (also answerable from the
-phone, just unstructured). Remote Pi works either way; pi-ask is optional.
+- OMP's built-in `ask` tool; no additional package is required.
+- Pi's `ask_user` tool from `@eko24ive/pi-ask`:
+
+  ```bash
+  pi install npm:@eko24ive/pi-ask
+  ```
+
+Both paths support multiple questions, multi-select options, custom answers,
+descriptions, and previews. Remote Pi races the paired app against the local
+desktop dialog; the first answer wins. With no paired app, OMP falls back to
+its normal local UI.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -101,22 +101,20 @@ Then in the Pi chat, run:
 The setup wizard walks you through agent name, session name, and relay choice,
 then prints a QR code. Scan it with the Remote Pi mobile app and you're paired.
 
-### Structured clarification prompts
+### Recommended companion: `@eko24ive/pi-ask`
 
-Remote Pi renders rich clarification prompts in the mobile app when the host
-exposes either:
+```bash
+pi install npm:@eko24ive/pi-ask
+```
 
-- OMP's built-in `ask` tool; no additional package is required.
-- Pi's `ask_user` tool from `@eko24ive/pi-ask`:
+With pi-ask installed, the agent's `ask_user` clarification prompts (structured
+questions with options, multi-select, and previews) render natively in the
+mobile app — answer from your phone and the flow resolves on the desktop.
+Without it, the agent simply asks in plain chat text (also answerable from the
+phone, just unstructured). Remote Pi works either way; pi-ask is optional.
 
-  ```bash
-  pi install npm:@eko24ive/pi-ask
-  ```
-
-Both paths support multiple questions, multi-select options, custom answers,
-descriptions, and previews. Remote Pi races the paired app against the local
-desktop dialog; the first answer wins. With no paired app, OMP falls back to
-its normal local UI.
+OMP's built-in `ask` tool is also bridged to the same mobile prompt surface; it
+does not require installing `@eko24ive/pi-ask`.
 
 ## Status
 

--- a/app/lib/protocol/protocol.dart
+++ b/app/lib/protocol/protocol.dart
@@ -1383,10 +1383,15 @@ class Bye extends ServerMessage {
 
 // ---------------------------------------------------------------------------
 // Plan/57 — extension_ui_request bridge (mirror SDK RPC contract)
-// Interactive extension prompts are rendered natively instead of stranding
-// the mobile user. Pi's pi-ask `ask_user` flow and OMP's built-in `ask` flow
-// share this wire contract. Rich multi/preview questions ride in an optional
-// `ask` envelope; strict clients can ignore it.
+//
+// Interactive extension prompts (ask_user today, via @eko24ive/pi-ask) are
+// rendered natively instead of stranding the mobile user. The wire mirrors the
+// SDK's `pi --mode rpc` extension_ui_request / extension_ui_response contract
+// (RpcExtensionUIRequest/Response), so the app and the Cockpit share one
+// interactive-UI vocabulary. pi-ask's richer schema (multi/preview/notes) rides
+// in an optional `ask` envelope; strict handling ignores it. OMP's built-in
+// `ask` uses the same bridge when its rich UI is exposed by the host.
+// Inert when neither producer is available (no frames ever arrive).
 // ---------------------------------------------------------------------------
 
 /// `select` | `confirm` | `input` | `editor` | `notify` (SDK methods). `notify`
@@ -1409,7 +1414,7 @@ enum ExtensionUiMethod {
   }
 }
 
-/// Ask question type — `single` (one answer) | `multi` (several) |
+/// pi-ask AskQuestionType — `single` (one answer) | `multi` (several) |
 /// `preview` (options carry a preview pane).
 enum AskQuestionWireType {
   single('single'),
@@ -1494,9 +1499,9 @@ class AskQuestionWire {
       );
 }
 
-/// Optional rich enrichment on an `extension_ui_request`. When present, the
-/// app renders the full flow (multi/preview/notes) from [questions] instead of
-/// the degraded SDK method. One request carries the whole flow.
+/// Optional pi-ask/OMP enrichment on an `extension_ui_request`. When present,
+/// the app renders the full flow (multi/preview/notes) from [questions] instead
+/// of the degraded SDK method. One request carries the whole flow.
 class AskEnrichmentWire {
   final String flowId;
   final String? toolCallId;

--- a/app/lib/protocol/protocol.dart
+++ b/app/lib/protocol/protocol.dart
@@ -1383,14 +1383,10 @@ class Bye extends ServerMessage {
 
 // ---------------------------------------------------------------------------
 // Plan/57 — extension_ui_request bridge (mirror SDK RPC contract)
-//
-// Interactive extension prompts (ask_user today, via @eko24ive/pi-ask) are
-// rendered natively instead of stranding the mobile user. The wire mirrors the
-// SDK's `pi --mode rpc` extension_ui_request / extension_ui_response contract
-// (RpcExtensionUIRequest/Response), so the app and the Cockpit share one
-// interactive-UI vocabulary. pi-ask's richer schema (multi/preview/notes) rides
-// in an optional `ask` envelope; strict handling ignores it. Inert when pi-ask
-// is absent (the tool doesn't exist → no frames ever arrive).
+// Interactive extension prompts are rendered natively instead of stranding
+// the mobile user. Pi's pi-ask `ask_user` flow and OMP's built-in `ask` flow
+// share this wire contract. Rich multi/preview questions ride in an optional
+// `ask` envelope; strict clients can ignore it.
 // ---------------------------------------------------------------------------
 
 /// `select` | `confirm` | `input` | `editor` | `notify` (SDK methods). `notify`
@@ -1413,7 +1409,7 @@ enum ExtensionUiMethod {
   }
 }
 
-/// pi-ask AskQuestionType — `single` (one answer) | `multi` (several) |
+/// Ask question type — `single` (one answer) | `multi` (several) |
 /// `preview` (options carry a preview pane).
 enum AskQuestionWireType {
   single('single'),
@@ -1498,7 +1494,7 @@ class AskQuestionWire {
       );
 }
 
-/// Optional pi-ask enrichment on an `extension_ui_request`. When present, the
+/// Optional rich enrichment on an `extension_ui_request`. When present, the
 /// app renders the full flow (multi/preview/notes) from [questions] instead of
 /// the degraded SDK method. One request carries the whole flow.
 class AskEnrichmentWire {

--- a/pi-extension/src/extension_ui_bridge.test.ts
+++ b/pi-extension/src/extension_ui_bridge.test.ts
@@ -71,6 +71,105 @@ describe("extension_ui_bridge", () => {
     const pi = {} as unknown as ExtensionAPI;
     expect(createExtensionUiBridge(pi, () => {})).toBeNull();
   });
+  it("bridges OMP askDialog to the paired app and resolves a rich answer", async () => {
+    const bus = fakeBus();
+    const sent: ServerMessage[] = [];
+    const bridge = createExtensionUiBridge(fakePi(bus), (m) => sent.push(m), {
+      hasActivePeer: () => true,
+    })!;
+    let localAborted = false;
+    const ui = {
+      askDialog: (
+        _questions: unknown[],
+        options?: { signal?: AbortSignal },
+      ) =>
+        new Promise<unknown>((resolve) => {
+          options?.signal?.addEventListener("abort", () => {
+            localAborted = true;
+            resolve(undefined);
+          });
+        }),
+    };
+
+    bridge.attachOmpAskDialog(ui);
+    const pending = ui.askDialog([
+      {
+        id: "goal",
+        question: "What is the goal?",
+        header: "Goal",
+        options: [
+          { label: "Ship it", description: "Finish the change" },
+          { label: "Pause" },
+        ],
+        multi: true,
+      },
+    ]);
+
+    expect(sent).toHaveLength(1);
+    const request = sent[0];
+    expect(request?.type).toBe("extension_ui_request");
+    if (!request || request.type !== "extension_ui_request") return;
+    expect(request.id).toMatch(/^omp:ask:/);
+    expect(request.method).toBe("select");
+    expect(request.ask?.source).toBe("omp-ask");
+    expect(request.ask?.questions[0]?.type).toBe("multi");
+    const option = request.ask?.questions[0]?.options[0]?.value;
+    expect(option).toBe("goal:0");
+
+    bridge.respond({
+      type: "extension_ui_response",
+      id: request.id,
+      ask: {
+        flow_id: request.id,
+        kind: "answer",
+        mode: "submit",
+        answers: { goal: { values: [option!] } },
+      },
+    });
+
+    await expect(pending).resolves.toEqual({
+      kind: "submit",
+      results: [
+        {
+          id: "goal",
+          question: "What is the goal?",
+          options: ["Ship it", "Pause"],
+          multi: true,
+          selectedOptions: ["Ship it"],
+          customInput: undefined,
+          note: undefined,
+        },
+      ],
+    });
+    expect(localAborted).toBe(true);
+    expect(sent.at(-1)).toMatchObject({
+      type: "extension_ui_request",
+      id: request.id,
+      method: "notify",
+    });
+    bridge.dispose();
+  });
+
+  it("falls back to OMP's local askDialog when no app is paired", async () => {
+    const bus = fakeBus();
+    const sent: ServerMessage[] = [];
+    const bridge = createExtensionUiBridge(fakePi(bus), (m) => sent.push(m), {
+      hasActivePeer: () => false,
+    })!;
+    const localResult = {
+      kind: "submit" as const,
+      results: [],
+    };
+    const askDialog = vi.fn(async () => localResult);
+    const ui = { askDialog };
+
+    bridge.attachOmpAskDialog(ui);
+    await expect(ui.askDialog([])).resolves.toEqual(localResult);
+    expect(askDialog).toHaveBeenCalledTimes(1);
+    expect(sent).toHaveLength(0);
+    bridge.dispose();
+  });
+
 
   it("translates a pi-ask `started` event into one extension_ui_request", () => {
     const bus = fakeBus();

--- a/pi-extension/src/extension_ui_bridge.ts
+++ b/pi-extension/src/extension_ui_bridge.ts
@@ -1,24 +1,19 @@
-// Plan/57 — Bridge @eko24ive/pi-ask clarification flows to the paired app over
-// the extension_ui_request/response contract.
+// Plan/57 — Bridge interactive clarification flows to the paired app over the
+// extension_ui_request/response contract.
 //
-// pi-ask (when installed) runs ask_user in the Pi TUI on the desktop AND emits
-// a same-process event contract on `pi.events` (docs/remote-events.md):
+// Two producers are supported:
 //
-//   @eko24ive/pi-ask:started      { flowId, toolCallId?, source, title?, questions[] }
-//   @eko24ive/pi-ask:submit       { requestId, flowId, response }   // we emit this
-//   @eko24ive/pi-ask:submit-result{ requestId, flowId, ok, error? } // pi-ask emits
-//   @eko24ive/pi-ask:completed    { flowId, result }
+//   @eko24ive/pi-ask events — Pi's ask_user extension emits a same-process
+//     event contract that this bridge forwards to the app.
+//   OMP's built-in ask tool — OMP exposes its rich askDialog through the
+//     ExtensionContext UI object. When present, this bridge wraps that method
+//     and races the desktop dialog against the paired app.
 //
-// This module subscribes to those events and translates them into the SDK's
-// extension_ui_request/response wire shapes (mirrored from
-// `pi --mode rpc`'s RpcExtensionUIRequest/Response) so the mobile app renders
-// ask_user natively. pi-ask's richer schema rides in an optional `ask` envelope.
-//
-// Inert when pi-ask is absent: no events fire, nothing breaks. ask_user without
-// pi-ask doesn't exist, so this bridge is strictly opt-in.
+// Both flows use the same wire envelope. The app already renders the envelope
+// as a native multi-question/multi-select surface; only the producer differs.
 
+import { randomUUID } from "node:crypto";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { PlainPeerChannel } from "./transport/peer_channel.js";
 import type {
   AskAnswerWire,
   AskEnrichmentWire,
@@ -34,16 +29,78 @@ const PI_ASK_STARTED = "@eko24ive/pi-ask:started";
 const PI_ASK_COMPLETED = "@eko24ive/pi-ask:completed";
 const PI_ASK_SUBMIT = "@eko24ive/pi-ask:submit";
 const PI_ASK_SUBMIT_RESULT = "@eko24ive/pi-ask:submit-result";
+const OMP_ASK_FLOW_PREFIX = "omp:ask:";
 
-/** Drop a flow from `activeFlows` if pi-ask never resolves it (e.g. a flow
- *  disposed on session_shutdown — pi-ask does not emit `completed` for those).
- *  Bounds memory; generous vs. a human answer time. */
+/** Drop an unanswered flow after ten minutes. */
 const FLOW_TTL_MS = 10 * 60 * 1000;
 
 /** Minimal view of `pi.events` this bridge needs. */
 type EventBus = ExtensionAPI["events"];
 
-/** One ask_user flow we've surfaced to the app and are awaiting an answer for. */
+/** Structural copy of OMP's rich ask UI types.
+ *
+ * Remote Pi is compiled against Pi's public extension types, while OMP loads
+ * legacy Pi extensions through its compatibility layer. Keeping these types
+ * structural avoids a hard dependency on OMP.
+ */
+export interface OmpAskDialogOption {
+  label: string;
+  description?: string;
+  preview?: string;
+}
+
+export interface OmpAskDialogQuestion {
+  id: string;
+  question: string;
+  header?: string;
+  options: OmpAskDialogOption[];
+  multi?: boolean;
+  recommended?: number;
+}
+
+export interface OmpAskDialogResultItem {
+  id: string;
+  question: string;
+  options: string[];
+  multi: boolean;
+  selectedOptions: string[];
+  customInput?: string;
+  note?: string;
+  timedOut?: boolean;
+}
+
+export type OmpAskDialogResult =
+  | { kind: "submit"; results: OmpAskDialogResultItem[] }
+  | { kind: "chat" };
+
+interface OmpDialogOptions {
+  signal?: AbortSignal;
+  timeout?: number;
+  onTimeout?: () => void;
+  [key: string]: unknown;
+}
+
+type OmpAskDialog = (
+  questions: OmpAskDialogQuestion[],
+  options?: OmpDialogOptions,
+) => Promise<OmpAskDialogResult | undefined>;
+
+type RemoteOmpResult =
+  | { kind: "answer"; value: OmpAskDialogResult | undefined }
+  | { kind: "unavailable" };
+
+interface OmpDialogWinner {
+  source: "local" | "remote";
+  value: OmpAskDialogResult | undefined;
+}
+interface ActiveOmpFlow {
+  flowId: string;
+  title: string | null;
+  questions: AskQuestionWire[];
+  resolve: (result: RemoteOmpResult) => void;
+}
+
+/** One pi-ask flow we've surfaced to the app and are awaiting an answer for. */
 interface ActiveFlow {
   flowId: string;
   toolCallId: string | null;
@@ -52,33 +109,38 @@ interface ActiveFlow {
   questions: AskQuestionWire[];
 }
 
+export interface ExtensionUiBridgeOptions {
+  /** Return true when at least one paired app can receive a prompt. */
+  hasActivePeer?: () => boolean;
+}
+
 export interface ExtensionUiBridge {
-  /** Route an inbound `extension_ui_response` from a peer back to pi-ask. */
+  /** Route an inbound extension_ui_response from a peer. */
   respond(msg: ExtensionUiResponseWire): void;
+  /** Wrap OMP's optional rich askDialog UI method when the host provides it. */
+  attachOmpAskDialog(ui: unknown): void;
   /**
-   * Requests for flows still awaiting an answer, for `session_sync` to replay.
+   * Requests for flows still awaiting an answer, for session_sync to replay.
    *
-   * The `started` broadcast fires exactly once. A peer that connects *after*
-   * a flow opened never saw it: history replayed, but the interactive frame
-   * did not, so the phone showed the ask_user tool call as plain text while
-   * the desktop sat blocked on the TUI dialog. Replaying on sync closes that
-   * hole — the common real-world case is the agent asking while the app is
-   * closed.
+   * The started broadcast fires exactly once. A peer that connects after a
+   * flow opened never saw it, so replay the interactive frame after history.
    */
   pendingRequests(): ServerMessage[];
-  /** Drop all subscriptions + state (best-effort teardown). */
+  /** Drop all subscriptions, wrappers, timers, and pending state. */
   dispose(): void;
 }
 
 /**
- * Wire pi-ask's event contract to the relay's extension_ui_request/response
- * frames. Returns `null` only if the SDK exposes no usable `events` bus (defensive
- * — modern Pi always has one); callers stay null-safe.
+ * Wire Pi ask_user events and OMP's built-in ask dialog to the relay's
+ * extension_ui_request/response frames. Returns null only when the SDK exposes
+ * no usable events bus.
  */
 export function createExtensionUiBridge(
   pi: ExtensionAPI,
   broadcast: (msg: ServerMessage) => void,
+  options: ExtensionUiBridgeOptions = {},
 ): ExtensionUiBridge | null {
+
   const eventsRaw = (pi as { events?: EventBus }).events;
   if (
     !eventsRaw ||
@@ -95,10 +157,14 @@ export function createExtensionUiBridge(
   // option value, and so completed/submit-result can be tolerated if they arrive
   // after the app already answered.
   const activeFlows = new Map<string, ActiveFlow>();
+  const activeOmpFlows = new Map<string, ActiveOmpFlow>();
+  const ompFlowTimers = new Map<string, NodeJS.Timeout>();
+  let restoreOmpAskDialog: (() => void) | null = null;
+  const hasActivePeer = options.hasActivePeer ?? (() => true);
   // Per-flow TTL timers (FLOW_TTL_MS). pi-ask disposes flows on session_shutdown
   // WITHOUT emitting `completed`, so without this the `activeFlows` map would
   // leak one entry per abandoned flow. Bounded, defensive.
-  const flowTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const flowTimers = new Map<string, NodeJS.Timeout>();
 
   function clearFlowTtl(flowId: string): void {
     const t = flowTimers.get(flowId);
@@ -129,6 +195,150 @@ export function createExtensionUiBridge(
         });
       }, FLOW_TTL_MS),
     );
+  }
+  function clearOmpFlowTtl(flowId: string): void {
+    const timer = ompFlowTimers.get(flowId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      ompFlowTimers.delete(flowId);
+    }
+  }
+
+  function settleOmpFlow(
+    flowId: string,
+    result: RemoteOmpResult,
+    notify = true,
+  ): void {
+    const flow = activeOmpFlows.get(flowId);
+    if (!flow) return;
+    activeOmpFlows.delete(flowId);
+    clearOmpFlowTtl(flowId);
+    flow.resolve(result);
+    if (notify) {
+      broadcast({
+        type: "extension_ui_request",
+        id: flowId,
+        method: "notify",
+        message: "Clarification resolved.",
+      });
+    }
+  }
+
+  function armOmpFlowTtl(flowId: string): void {
+    clearOmpFlowTtl(flowId);
+    ompFlowTimers.set(
+      flowId,
+      setTimeout(() => {
+        settleOmpFlow(flowId, { kind: "unavailable" });
+      }, FLOW_TTL_MS),
+    );
+  }
+
+  function requestOmpAskDialog(
+    questions: OmpAskDialogQuestion[],
+    dialogOptions?: OmpDialogOptions,
+  ): Promise<RemoteOmpResult> {
+    if (dialogOptions?.signal?.aborted) {
+      return Promise.resolve({ kind: "unavailable" });
+    }
+
+    const flowId = `${OMP_ASK_FLOW_PREFIX}${randomUUID()}`;
+    const flow: ActiveOmpFlow = {
+      flowId,
+      title: null,
+      questions: toOmpWireQuestions(questions),
+      resolve: () => {},
+    };
+    let resolveResult: (result: RemoteOmpResult) => void = () => {};
+    const result = new Promise<RemoteOmpResult>((resolve) => {
+      resolveResult = resolve;
+    });
+    flow.resolve = resolveResult;
+    activeOmpFlows.set(flowId, flow);
+    armOmpFlowTtl(flowId);
+
+    const onAbort = (): void => {
+      settleOmpFlow(flowId, { kind: "unavailable" });
+    };
+    dialogOptions?.signal?.addEventListener("abort", onAbort, { once: true });
+
+    try {
+      broadcast(requestForOmpFlow(flow));
+    } catch {
+      onAbort();
+    }
+
+    return result.finally(() => {
+      dialogOptions?.signal?.removeEventListener("abort", onAbort);
+    });
+  }
+
+  function attachOmpAskDialog(ui: unknown): void {
+    restoreOmpAskDialog?.();
+    restoreOmpAskDialog = null;
+    if (!ui || typeof ui !== "object") return;
+
+    const candidate = ui as { askDialog?: OmpAskDialog };
+    const original = candidate.askDialog;
+    if (typeof original !== "function") return;
+
+    const wrapped: OmpAskDialog = async (questions, dialogOptions) => {
+      let remoteAvailable = false;
+      try {
+        remoteAvailable = hasActivePeer();
+      } catch {
+        remoteAvailable = false;
+      }
+      if (!remoteAvailable) return original(questions, dialogOptions);
+
+      const localAbort = new AbortController();
+      const remoteAbort = new AbortController();
+      const parentSignal = dialogOptions?.signal;
+      const localSignal = parentSignal
+        ? AbortSignal.any([parentSignal, localAbort.signal])
+        : localAbort.signal;
+      const remoteSignal = parentSignal
+        ? AbortSignal.any([parentSignal, remoteAbort.signal])
+        : remoteAbort.signal;
+
+      const localPromise = Promise.resolve().then(() =>
+        original(questions, { ...dialogOptions, signal: localSignal }),
+      );
+      const localWinner: Promise<OmpDialogWinner> = localPromise.then(
+        (value): OmpDialogWinner => ({
+          source: "local",
+          value,
+        }),
+      );
+      const remoteWinner: Promise<OmpDialogWinner> = requestOmpAskDialog(
+        questions,
+        {
+          ...dialogOptions,
+          signal: remoteSignal,
+        },
+      ).then((outcome): OmpDialogWinner | PromiseLike<OmpDialogWinner> =>
+        outcome.kind === "unavailable"
+          ? localWinner
+          : { source: "remote", value: outcome.value },
+      );
+
+      try {
+        const winner = await Promise.race([localWinner, remoteWinner]);
+        return winner.value;
+      } finally {
+        localAbort.abort();
+        remoteAbort.abort();
+      }
+    };
+
+    try {
+      candidate.askDialog = wrapped;
+    } catch {
+      return;
+    }
+    restoreOmpAskDialog = () => {
+      if (candidate.askDialog === wrapped) candidate.askDialog = original;
+    };
   }
 
   const unsubStarted = events.on(PI_ASK_STARTED, (raw: unknown) => {
@@ -206,7 +416,43 @@ export function createExtensionUiBridge(
     });
   });
 
+  function respondToOmpFlow(msg: ExtensionUiResponseWire): boolean {
+    const ask = msg.ask;
+    const flowId =
+      ask?.flow_id ?? (activeOmpFlows.has(msg.id) ? msg.id : undefined);
+    if (!flowId) return false;
+    const flow = activeOmpFlows.get(flowId);
+    if (!flow) return false;
+
+    if (
+      ("cancelled" in msg && msg.cancelled === true) ||
+      (ask !== undefined && ask.kind === "cancel")
+    ) {
+      settleOmpFlow(flowId, { kind: "answer", value: undefined });
+      return true;
+    }
+
+    if (ask !== undefined && ask.kind === "answer") {
+      settleOmpFlow(flowId, {
+        kind: "answer",
+        value: ompResultFromAnswer(flow, ask),
+      });
+      return true;
+    }
+
+    if ("value" in msg) {
+      settleOmpFlow(flowId, {
+        kind: "answer",
+        value: ompResultFromLabel(flow, String(msg.value)),
+      });
+      return true;
+    }
+
+    return true;
+  }
+
   function respond(msg: ExtensionUiResponseWire): void {
+    if (respondToOmpFlow(msg)) return;
     const ask = msg.ask;
 
     // Explicit cancel — with or without the ask envelope. A strict client
@@ -284,17 +530,26 @@ export function createExtensionUiBridge(
 
   return {
     respond,
-    // Insertion order = the order the flows opened, so a client replaying more
-    // than one renders them oldest-first. pi-ask resolves one flow at a time in
-    // practice, so this is a defensive detail rather than a live case.
-    pendingRequests: () => [...activeFlows.values()].map(requestForFlow),
+    attachOmpAskDialog,
+    pendingRequests: () => [
+      ...[...activeFlows.values()].map(requestForFlow),
+      ...[...activeOmpFlows.values()].map(requestForOmpFlow),
+    ],
     dispose() {
+      restoreOmpAskDialog?.();
+      restoreOmpAskDialog = null;
       unsubStarted();
       unsubCompleted();
       unsubResult();
       for (const t of flowTimers.values()) clearTimeout(t);
       flowTimers.clear();
+      for (const flowId of [...activeOmpFlows.keys()]) {
+        settleOmpFlow(flowId, { kind: "unavailable" }, false);
+      }
+      for (const t of ompFlowTimers.values()) clearTimeout(t);
+      ompFlowTimers.clear();
       activeFlows.clear();
+      activeOmpFlows.clear();
     },
   };
 }
@@ -336,6 +591,120 @@ function requestForFlow(flow: ActiveFlow): ServerMessage {
     ask,
   };
 }
+/** Build the same envelope for an OMP `ask` flow. */
+function requestForOmpFlow(flow: ActiveOmpFlow): ServerMessage {
+  const first = flow.questions[0];
+  const title = flow.title ?? first?.prompt ?? "Clarification";
+  const options = first ? first.options.map((o) => o.label) : [];
+  const ask: AskEnrichmentWire = {
+    flow_id: flow.flowId,
+    tool_call_id: null,
+    source: "omp-ask",
+    title: flow.title,
+    questions: flow.questions,
+  };
+  if (options.length === 0) {
+    return {
+      type: "extension_ui_request",
+      id: flow.flowId,
+      method: "input",
+      title,
+      placeholder: first?.prompt,
+      ask,
+    };
+  }
+  return {
+    type: "extension_ui_request",
+    id: flow.flowId,
+    method: "select",
+    title,
+    options,
+    ask,
+  };
+}
+
+function toOmpWireQuestions(
+  questions: OmpAskDialogQuestion[],
+): AskQuestionWire[] {
+  return questions.map((question) => {
+    const hasPreview = question.options.some(
+      (option) => typeof option.preview === "string" && option.preview.length > 0,
+    );
+    const isMulti = question.multi === true;
+    const type: AskQuestionWireType = hasPreview
+      ? "preview"
+      : isMulti
+        ? "multi"
+        : "single";
+    return {
+      id: question.id,
+      label: question.header ?? question.question,
+      prompt: question.question,
+      type,
+      required: false,
+      ...(isMulti && hasPreview ? { presentedType: "multi" as const } : {}),
+      requestedType: isMulti ? "multi" : type,
+      options: question.options.map((option, index) => ({
+        value: `${question.id}:${index}`,
+        label: option.label,
+        description: option.description,
+        preview: option.preview,
+      })),
+    };
+  });
+}
+function ompResultFromAnswer(
+  flow: ActiveOmpFlow,
+  answer: AskResponseEnrichmentWire & { kind: "answer" },
+): OmpAskDialogResult {
+  return {
+    kind: "submit",
+    results: flow.questions.map((question) => {
+      const response = answer.answers[question.id] ?? {};
+      const values = new Set(response.values ?? []);
+      const selectedOptions = question.options
+        .map((option, index) => ({
+          label: option.label,
+          value: `${question.id}:${index}`,
+        }))
+        .filter((option) => values.has(option.value) || values.has(option.label))
+        .map((option) => option.label);
+      return {
+        id: question.id,
+        question: question.prompt,
+        options: question.options.map((option) => option.label),
+        multi: question.type === "multi" || question.presentedType === "multi",
+        selectedOptions,
+        customInput: response.customText,
+        note: response.note,
+      };
+    }),
+  };
+}
+
+function ompResultFromLabel(
+  flow: ActiveOmpFlow,
+  label: string,
+): OmpAskDialogResult {
+  return {
+    kind: "submit",
+    results: flow.questions.map((question, index) => {
+      const selected =
+        index === 0
+          ? question.options.find((option) => option.label === label)?.label
+          : undefined;
+      return {
+        id: question.id,
+        question: question.prompt,
+        options: question.options.map((option) => option.label),
+        multi: question.type === "multi" || question.presentedType === "multi",
+        selectedOptions: selected ? [selected] : [],
+        customInput: index === 0 && !selected && label ? label : undefined,
+      };
+    }),
+  };
+}
+
 
 // ── pi-ask event parsing (defensive — shapes come from a third-party package) ──
 

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -2075,13 +2075,14 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
 
   _pi = pi;
 
-  // Plan/57 — bridge @eko24ive/pi-ask clarification flows to the paired app.
-  // Inert when pi-ask isn't installed (no events fire) or the SDK exposes no
-  // events bus. ask_user without pi-ask doesn't exist, so this never breaks a
-  // Pi that doesn't use the extension. Dispose any prior bridge first so a
-  // factory re-run (new pi session) can't leak subscriptions or double-send.
+  // Plan/57 — bridge Pi ask_user and OMP ask clarification flows to the
+  // paired app. Pi ask_user uses its event contract; OMP exposes askDialog on
+  // the ExtensionContext UI object. The bridge is inert for stock Pi hosts
+  // without either surface.
   _extensionUiBridge?.dispose();
-  _extensionUiBridge = createExtensionUiBridge(pi, _broadcastToActive);
+  _extensionUiBridge = createExtensionUiBridge(pi, _broadcastToActive, {
+    hasActivePeer: _anyPeerActive,
+  });
 
   // Plano 19: ensure ~/.pi/remote/{sessions,skills}/ exist and deploy the
   // agent-network skill on first load. resources_discover lets Pi find it.
@@ -2340,12 +2341,19 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // bound to the current session.
   pi.on("session_start", (_event, ctx) => {
     _lastEventCtx = ctx;
-    // session_shutdown disposes per-session pi-ask subscriptions. A host that
-    // reuses this module instance does NOT re-run the factory, so rebind the
-    // bridge here; fresh-module hosts already created theirs in the factory.
+    // session_shutdown disposes the bridge's per-session subscriptions and
+    // restores any OMP askDialog wrapper. Rebind it here when a host reuses
+    // this module instance across a session replacement; fresh-module hosts
+    // already created it in the factory.
     if (!_extensionUiBridge) {
-      _extensionUiBridge = createExtensionUiBridge(pi, _broadcastToActive);
+      _extensionUiBridge = createExtensionUiBridge(pi, _broadcastToActive, {
+        hasActivePeer: _anyPeerActive,
+      });
     }
+    // OMP exposes its built-in rich `ask` dialog on the ExtensionContext UI
+    // object. The bridge detects that optional method at runtime, so stock Pi
+    // remains unchanged while OMP prompts can race the paired app.
+    _extensionUiBridge?.attachOmpAskDialog(ctx.ui);
     // Rearm a reused-but-disposed instance. The session_shutdown teardown (below)
     // sets _disposed=true assuming the host re-evaluates THIS module fresh for the
     // replacement session, yielding a new instance with _disposed=false. Some hosts

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -2075,10 +2075,12 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
 
   _pi = pi;
 
-  // Plan/57 — bridge Pi ask_user and OMP ask clarification flows to the
-  // paired app. Pi ask_user uses its event contract; OMP exposes askDialog on
-  // the ExtensionContext UI object. The bridge is inert for stock Pi hosts
-  // without either surface.
+  // Plan/57 — bridge @eko24ive/pi-ask clarification flows to the paired app.
+  // Inert when pi-ask isn't installed (no events fire) or the SDK exposes no
+  // events bus. OMP's optional askDialog path is attached to the current
+  // session UI below. ask_user without pi-ask doesn't exist, so this never
+  // breaks a Pi that doesn't use the extension. Dispose any prior bridge first
+  // so a factory re-run (new pi session) can't leak subscriptions or double-send.
   _extensionUiBridge?.dispose();
   _extensionUiBridge = createExtensionUiBridge(pi, _broadcastToActive, {
     hasActivePeer: _anyPeerActive,
@@ -2341,10 +2343,10 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   // bound to the current session.
   pi.on("session_start", (_event, ctx) => {
     _lastEventCtx = ctx;
-    // session_shutdown disposes the bridge's per-session subscriptions and
-    // restores any OMP askDialog wrapper. Rebind it here when a host reuses
-    // this module instance across a session replacement; fresh-module hosts
-    // already created it in the factory.
+    // session_shutdown disposes per-session pi-ask subscriptions and restores
+    // any OMP askDialog wrapper. A host that reuses this module instance does
+    // NOT re-run the factory, so rebind the bridge here; fresh-module hosts
+    // already created theirs in the factory.
     if (!_extensionUiBridge) {
       _extensionUiBridge = createExtensionUiBridge(pi, _broadcastToActive, {
         hasActivePeer: _anyPeerActive,

--- a/pi-extension/src/protocol/types.ts
+++ b/pi-extension/src/protocol/types.ts
@@ -14,14 +14,15 @@ export type QueuedMessageItem = {
 };
 
 // ── Plan/57 — extension_ui_request bridge (mirror SDK RPC contract) ───────
-// The paired app renders interactive extension prompts natively instead of
-// stranding the mobile user. Pi's pi-ask `ask_user` flow and OMP's built-in
-// `ask` flow both use this wire shape. The wire mirrors the SDK's
-// `pi --mode rpc` extension_ui_request/response contract (RpcExtensionUIRequest/
-// Response in dist/modes/rpc/rpc-types.d.ts) so the mobile app and Cockpit
-// share one interactive-UI vocabulary. Casing is snake_case to match the rest
-// of the relay protocol (mirror is semantic, not literal). Rich multi/preview
-// questions ride in the optional `ask` envelope; strict clients ignore it.
+// The paired app renders interactive extension prompts (ask_user today, via
+// @eko24ive/pi-ask) natively instead of stranding the mobile user. The wire
+// mirrors the SDK's `pi --mode rpc` extension_ui_request/response contract
+// (RpcExtensionUIRequest/Response in dist/modes/rpc/rpc-types.d.ts) so the
+// mobile app and the Cockpit share one interactive-UI vocabulary. Casing is
+// snake_case to match the rest of the relay protocol (mirror is semantic, not
+// literal). pi-ask's richer schema (multi/preview/notes) rides in an optional
+// `ask` envelope; strict clients ignore it. Inert when pi-ask is absent.
+// OMP's built-in `ask` uses the same envelope when its rich UI is exposed.
 
 export type ExtensionUiMethod =
   | "select"
@@ -38,7 +39,7 @@ export interface AskOptionWire {
   description?: string;
   /** Preview-pane content (preview questions only). */
   preview?: string;
-  /** Option permits a freeform custom entry in the originating UI. */
+  /** pi-ask addition: option allows freeform custom entry. */
   freeform?: boolean;
 }
 
@@ -55,21 +56,27 @@ export interface AskQuestionWire {
   options: AskOptionWire[];
 }
 
-/** Optional rich enrichment on an extension_ui_request — lets the app render
+/** Optional pi-ask enrichment on an extension_ui_request — lets the app render
  * the full flow (multi/preview/notes) instead of the degraded SDK select. A
  * flow maps to ONE request carrying every question; the app renders a
- * full-screen modal and submits ONE response with all answers. */
+ * full-screen modal and submits ONE response with all answers (pi-ask resolves
+ * a flow in a single submit). OMP uses the same one-submit shape. When `ask`
+ * is absent the SDK method/options drive rendering (future generic prompts). */
 export interface AskEnrichmentWire {
   flow_id: string;
   tool_call_id: string | null;
-  /** Producer identifier, e.g. "tool", "answer", or "omp-ask". */
+  /** pi-ask RemoteAskSource; OMP uses `"omp-ask"`. */
   source: string;
   title: string | null;
   questions: AskQuestionWire[];
 }
-
-/** Remote answer parts. Keys mirror the originating ask implementation inside
- * the envelope (camelCase); frame fields remain snake_case. */
+/** pi-ask RemoteAskAnswer — one question's answered parts.
+ *
+ *  CASING EXCEPTION: inside the `ask` envelope the keys mirror pi-ask's own
+ *  schema VERBATIM (camelCase: `presentedType`, `requestedType`, `customText`,
+ *  `optionNotes`) so the bridge can forward the response to pi-ask's submit
+ *  event without a remap pass. The snake_case convention of this protocol
+ *  applies at the frame level (`flow_id`, `tool_call_id`, `notify_type`). */
 export interface AskAnswerWire {
   values?: string[];
   customText?: string;
@@ -77,8 +84,9 @@ export interface AskAnswerWire {
   optionNotes?: Record<string, string>;
 }
 
-/** Optional rich answer on an extension_ui_response — carries structured
- * multi-question answers through the round-trip. */
+/** Optional pi-ask enrichment on an extension_ui_response — carries the
+ * structured answer so multi/preview/notes survive the round-trip. OMP ask
+ * uses the same envelope. */
 export type AskResponseEnrichmentWire =
   | {
       flow_id: string;
@@ -87,10 +95,10 @@ export type AskResponseEnrichmentWire =
       answers: Record<string, AskAnswerWire>;
     }
   | { flow_id: string; kind: "cancel" };
-
-/** ServerMessage: interactive extension prompt. Mirrors the SDK's
- * extension_ui_request contract. The optional `ask` envelope carries the
- * full rich question schema. */
+/** ServerMessage: interactive extension prompt. Mirrors RpcExtensionUIRequest
+ * (select/confirm/input/editor/notify). The `ask` envelope is present when the
+ * prompt originates from a pi-ask or OMP ask flow, carrying the full question
+ * schema. */
 export type ExtensionUiRequestWire =
   | {
       type: "extension_ui_request";
@@ -191,9 +199,10 @@ export type ClientMessage =
   | { type: "model_set"; id: string; provider: string; model_id: string }
   | { type: "thinking_set"; id: string; level: ThinkingLevel }
   | { type: "list_models"; id: string }
-  // Plan/57 — interactive extension prompt response. Mirrors
-  // RpcExtensionUIResponse; the optional `ask` envelope carries the rich
-  // multi-question answer for both pi-ask and OMP ask flows.
+  // Plan/57 — interactive extension prompt response (ask_user via pi-ask).
+  // Mirrors RpcExtensionUIResponse; the optional `ask` envelope carries
+  // pi-ask's structured answer so multi/preview/notes survive the round-trip.
+  // OMP ask uses the same envelope and routing.
   | ExtensionUiResponseWire;
 
 /**

--- a/pi-extension/src/protocol/types.ts
+++ b/pi-extension/src/protocol/types.ts
@@ -14,14 +14,14 @@ export type QueuedMessageItem = {
 };
 
 // ── Plan/57 — extension_ui_request bridge (mirror SDK RPC contract) ───────
-// The paired app renders interactive extension prompts (ask_user today, via
-// @eko24ive/pi-ask) natively instead of stranding the mobile user. The wire
-// mirrors the SDK's `pi --mode rpc` extension_ui_request/response contract
-// (RpcExtensionUIRequest/Response in dist/modes/rpc/rpc-types.d.ts) so the
-// mobile app and the Cockpit share one interactive-UI vocabulary. Casing is
-// snake_case to match the rest of the relay protocol (mirror is semantic, not
-// literal). pi-ask's richer schema (multi/preview/notes) rides in an optional
-// `ask` envelope; strict clients ignore it. Inert when pi-ask is absent.
+// The paired app renders interactive extension prompts natively instead of
+// stranding the mobile user. Pi's pi-ask `ask_user` flow and OMP's built-in
+// `ask` flow both use this wire shape. The wire mirrors the SDK's
+// `pi --mode rpc` extension_ui_request/response contract (RpcExtensionUIRequest/
+// Response in dist/modes/rpc/rpc-types.d.ts) so the mobile app and Cockpit
+// share one interactive-UI vocabulary. Casing is snake_case to match the rest
+// of the relay protocol (mirror is semantic, not literal). Rich multi/preview
+// questions ride in the optional `ask` envelope; strict clients ignore it.
 
 export type ExtensionUiMethod =
   | "select"
@@ -38,7 +38,7 @@ export interface AskOptionWire {
   description?: string;
   /** Preview-pane content (preview questions only). */
   preview?: string;
-  /** pi-ask addition: option allows freeform custom entry. */
+  /** Option permits a freeform custom entry in the originating UI. */
   freeform?: boolean;
 }
 
@@ -55,28 +55,21 @@ export interface AskQuestionWire {
   options: AskOptionWire[];
 }
 
-/** Optional pi-ask enrichment on an extension_ui_request — lets the app render
- *  the full flow (multi/preview/notes) instead of the degraded SDK select. A
- *  flow maps to ONE request carrying every question; the app renders a
- *  full-screen modal and submits ONE response with all answers (pi-ask resolves
- *  a flow in a single submit). When `ask` is absent the SDK method/options
- *  drive rendering (future generic prompts). */
+/** Optional rich enrichment on an extension_ui_request — lets the app render
+ * the full flow (multi/preview/notes) instead of the degraded SDK select. A
+ * flow maps to ONE request carrying every question; the app renders a
+ * full-screen modal and submits ONE response with all answers. */
 export interface AskEnrichmentWire {
   flow_id: string;
   tool_call_id: string | null;
-  /** pi-ask RemoteAskSource: "tool" | "answer" | "answer:again" | "ask:replay". */
+  /** Producer identifier, e.g. "tool", "answer", or "omp-ask". */
   source: string;
   title: string | null;
   questions: AskQuestionWire[];
 }
 
-/** pi-ask RemoteAskAnswer — one question's answered parts.
- *
- *  CASING EXCEPTION: inside the `ask` envelope the keys mirror pi-ask's own
- *  schema VERBATIM (camelCase: `presentedType`, `requestedType`, `customText`,
- *  `optionNotes`) so the bridge can forward the response to pi-ask's submit
- *  event without a remap pass. The snake_case convention of this protocol
- *  applies at the frame level (`flow_id`, `tool_call_id`, `notify_type`). */
+/** Remote answer parts. Keys mirror the originating ask implementation inside
+ * the envelope (camelCase); frame fields remain snake_case. */
 export interface AskAnswerWire {
   values?: string[];
   customText?: string;
@@ -84,8 +77,8 @@ export interface AskAnswerWire {
   optionNotes?: Record<string, string>;
 }
 
-/** Optional pi-ask enrichment on an extension_ui_response — carries the
- *  structured answer so multi/preview/notes survive the round-trip. */
+/** Optional rich answer on an extension_ui_response — carries structured
+ * multi-question answers through the round-trip. */
 export type AskResponseEnrichmentWire =
   | {
       flow_id: string;
@@ -95,9 +88,9 @@ export type AskResponseEnrichmentWire =
     }
   | { flow_id: string; kind: "cancel" };
 
-/** ServerMessage: interactive extension prompt. Mirrors RpcExtensionUIRequest
- *  (select/confirm/input/editor/notify). The `ask` envelope is present when the
- *  prompt originates from a pi-ask flow, carrying the full question schema. */
+/** ServerMessage: interactive extension prompt. Mirrors the SDK's
+ * extension_ui_request contract. The optional `ask` envelope carries the
+ * full rich question schema. */
 export type ExtensionUiRequestWire =
   | {
       type: "extension_ui_request";
@@ -198,9 +191,9 @@ export type ClientMessage =
   | { type: "model_set"; id: string; provider: string; model_id: string }
   | { type: "thinking_set"; id: string; level: ThinkingLevel }
   | { type: "list_models"; id: string }
-  // Plan/57 — interactive extension prompt response (ask_user via pi-ask).
-  // Mirrors RpcExtensionUIResponse; the optional `ask` envelope carries
-  // pi-ask's structured answer so multi/preview/notes survive the round-trip.
+  // Plan/57 — interactive extension prompt response. Mirrors
+  // RpcExtensionUIResponse; the optional `ask` envelope carries the rich
+  // multi-question answer for both pi-ask and OMP ask flows.
   | ExtensionUiResponseWire;
 
 /**


### PR DESCRIPTION
## Summary
Support for [OhMyPi's ](https://github.com/can1357/oh-my-pi) ask prompts


- bridge OMP's built-in `ctx.ui.askDialog()` to the Remote Pi mobile prompt surface
- preserve the existing `@eko24ive/pi-ask` event bridge and response routing
- race the local OMP dialog against the paired app; first answer wins
- carry rich multi-question, multi-select, descriptions, previews, and custom answers
- add regression coverage and document both prompt producers

## Verification

- `pnpm exec vitest run src/extension_ui_bridge.test.ts` — 25 passed
- `pnpm build` — passed
- `omp plugin doctor --json` — remote-pi healthy
