### PR TITLE
fix(cockpit): não congelar a UI no Windows ao escrever em PTY parado

### DIFF
--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -24,6 +24,22 @@ As versões seguem o `version:` do `pubspec.yaml` (SSOT). O campo `notes` do
     linhas não-vazias — o começo da seção deve fazer sentido sozinho.
 -->
 
+## [1.26.1] - 2026-08-13
+
+Fixes a full window freeze on Windows when a terminal's shell stops reading input.
+
+### Fixed
+
+- **The window no longer freezes ("Not responding") on Windows when writing to
+  a terminal whose shell stopped draining input.** Every keystroke used to
+  flush the ConPTY input pipe synchronously on the UI thread — on a pipe that
+  call blocks until the child consumes everything, so a suspended or stuck
+  child process froze the whole app indefinitely (confirmed by minidump; bug
+  inherited from the absorbed kyroon_pty plugin). The flush is gone, and
+  terminal input is now written from a dedicated writer thread per terminal,
+  so even a full pipe buffer (e.g. a large paste into a suspended shell)
+  cannot block the UI. macOS/Linux terminals were never affected.
+
 ## [1.26.0] - 2026-08-11
 
 Codex tabs now report what they are doing, just like Claude Code tabs.

--- a/cockpit/plugins/cockpit_pty/CHANGELOG.md
+++ b/cockpit/plugins/cockpit_pty/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 1.0.7
+
+* **Fix UI freeze on Windows when writing to a stalled terminal** — `pty_write`
+  is a synchronous FFI call on the Flutter platform (UI) thread, and the Windows
+  backend called `FlushFileBuffers` on the ConPTY input pipe after every write.
+  On a pipe, `FlushFileBuffers` blocks until the *other end consumes everything
+  written* — so a child that stopped draining stdin (suspended process, busy
+  shell) froze the entire window indefinitely ("Not responding"; confirmed by
+  minidump in production, inherited from kyroon_pty). The flush is removed: it
+  was semantically wrong for pipes and unnecessary (`WriteFile` already hands
+  the data to the pipe). This was the only `FlushFileBuffers` call site in the
+  plugin.
+* **Non-blocking terminal input on Windows** — `WriteFile` itself can also block
+  the UI thread when the pipe buffer fills (e.g. a large paste into a suspended
+  shell) — same bug class, rarer trigger. Writes now go through a per-PTY writer
+  thread with a FIFO queue: `pty_write` only copies the buffer, enqueues and
+  signals. Anonymous pipes don't support overlapped I/O, so a writer thread is
+  the canonical fix. If the pipe breaks (child/ConPTY gone) the thread drains
+  the queue and exits; later writes are discarded. POSIX backends (`forkpty`)
+  are untouched — they never had the flush.
+
+## 1.0.6
+
+* Absorbed into the Cockpit monorepo as an internal plugin
+  (`plugins/cockpit_pty`), renamed from `kyroon_pty`; not published.
+* **Fix blank/PSReadLine-less PowerShell in GUI builds** — the
+  `STARTF_USESTDHANDLES` + NULL std handles hack is now applied only when the
+  host process owns a real console (e.g. `flutter run`). In GUI builds it made
+  console programs see their stdio as redirected, so PowerShell disabled
+  PSReadLine; the plain ConPTY attribute path is used instead.
+
 ## 1.0.5
 
 * **Fix PTY spawn failure on Windows ARM64** — `build_working_directory` copied

--- a/cockpit/plugins/cockpit_pty/CHANGELOG.md
+++ b/cockpit/plugins/cockpit_pty/CHANGELOG.md
@@ -17,7 +17,9 @@
   signals. Anonymous pipes don't support overlapped I/O, so a writer thread is
   the canonical fix. If the pipe breaks (child/ConPTY gone) the thread drains
   the queue and exits; later writes are discarded. POSIX backends (`forkpty`)
-  are untouched — they never had the flush.
+  are untouched — they never had the flush. The Windows-only repro harness
+  that proved the hang (old `FlushFileBuffers` blocks; new `pty_write` does
+  not) lives in `test/windows/`.
 
 ## 1.0.6
 

--- a/cockpit/plugins/cockpit_pty/pubspec.yaml
+++ b/cockpit/plugins/cockpit_pty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cockpit_pty
 description: Native pseudo-terminal (PTY) for Flutter — spawn shells and processes with full ANSI, resize and job control. Backed by ConPTY/forkpty and ready to pair with xterm.
-version: 1.0.6
+version: 1.0.7
 # Plugin INTERNO do Cockpit (não publicado). Absorvido 2026-07-19 do fork
 # jacobaraujo7/kyroon_pty v1.0.6 (upstream cesarmod2017/kyroon_pty; MIT em
 # LICENSE). Renomeado kyroon_pty->cockpit_pty; manutenção é nossa a partir

--- a/cockpit/plugins/cockpit_pty/src/cockpit_pty_win.c
+++ b/cockpit/plugins/cockpit_pty/src/cockpit_pty_win.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <Windows.h>
 
 #include "cockpit_pty.h"
@@ -302,6 +303,136 @@ static void start_wait_exit_thread(HANDLE pid, Dart_Port port, HANDLE mutex)
     }
 }
 
+// --- Writer thread ----------------------------------------------------------
+//
+// pty_write é FFI síncrono na thread de plataforma (= thread de UI no Flutter
+// Windows). Fazer I/O bloqueante ali congela a janela inteira: um
+// FlushFileBuffers herdado do kyroon_pty bloqueava até o ConPTY consumir TUDO
+// que foi escrito e travou a UI em produção (plano 58); e o próprio WriteFile
+// bloqueia quando o buffer do pipe enche e o filho não drena (mesma classe de
+// bug, só mais rara). Pipes anônimos não suportam overlapped I/O, então a
+// saída é uma writer thread por PTY com fila FIFO: pty_write só copia o
+// buffer, enfileira e sinaliza — nunca bloqueia.
+
+typedef struct WriteChunk
+{
+    struct WriteChunk *next;
+
+    int length;
+
+    char data[1]; // alocado com sizeof(WriteChunk) + length
+
+} WriteChunk;
+
+typedef struct WriteQueue
+{
+    HANDLE fd;
+
+    CRITICAL_SECTION lock;
+
+    CONDITION_VARIABLE hasData;
+
+    WriteChunk *head;
+
+    WriteChunk *tail;
+
+    // WriteFile falhou (pipe fechado) — writes futuros são descartados.
+    BOOL broken;
+
+} WriteQueue;
+
+static DWORD WINAPI write_loop(LPVOID arg)
+{
+    WriteQueue *queue = (WriteQueue *)arg;
+
+    while (1)
+    {
+        EnterCriticalSection(&queue->lock);
+
+        while (queue->head == NULL)
+        {
+            SleepConditionVariableCS(&queue->hasData, &queue->lock, INFINITE);
+        }
+
+        WriteChunk *chunk = queue->head;
+        queue->head = chunk->next;
+
+        if (queue->head == NULL)
+        {
+            queue->tail = NULL;
+        }
+
+        LeaveCriticalSection(&queue->lock);
+
+        DWORD bytesWritten;
+
+        BOOL ok = WriteFile(queue->fd, chunk->data, chunk->length, &bytesWritten, NULL);
+
+        free(chunk);
+
+        if (!ok)
+        {
+            // Pipe fechado (ConPTY/filho encerrou). Marca, descarta o que
+            // sobrou e sai. A WriteQueue em si vive até o fim do processo —
+            // mesmo ciclo de vida do PtyHandle e do read_loop, que também
+            // não têm caminho de destruição.
+            EnterCriticalSection(&queue->lock);
+
+            queue->broken = TRUE;
+
+            WriteChunk *pending = queue->head;
+            queue->head = NULL;
+            queue->tail = NULL;
+
+            LeaveCriticalSection(&queue->lock);
+
+            while (pending != NULL)
+            {
+                WriteChunk *next = pending->next;
+                free(pending);
+                pending = next;
+            }
+
+            return 0;
+        }
+    }
+}
+
+static WriteQueue *start_write_thread(HANDLE fd)
+{
+    WriteQueue *queue = malloc(sizeof(WriteQueue));
+
+    if (queue == NULL)
+    {
+        return NULL;
+    }
+
+    queue->fd = fd;
+    queue->head = NULL;
+    queue->tail = NULL;
+    queue->broken = FALSE;
+
+    InitializeCriticalSection(&queue->lock);
+    InitializeConditionVariable(&queue->hasData);
+
+    DWORD thread_id;
+
+    HANDLE thread = CreateThread(NULL, 0, write_loop, queue, 0, &thread_id);
+
+    if (thread == NULL)
+    {
+        DeleteCriticalSection(&queue->lock);
+        free(queue);
+        return NULL;
+    }
+
+    // Mesma razão do start_read_thread: a thread é dona da própria vida;
+    // reter o HANDLE só vazaria um objeto de kernel por terminal.
+    CloseHandle(thread);
+
+    return queue;
+}
+
 typedef struct PtyHandle
 {
     PHANDLE inputWriteSide;
@@ -315,6 +446,8 @@ typedef struct PtyHandle
     BOOL ackRead;
 
     HANDLE hMutex;
+
+    WriteQueue *writeQueue;
 
 } PtyHandle;
 
@@ -500,19 +633,70 @@ FFI_PLUGIN_EXPORT PtyHandle *pty_create(PtyOptions *options)
     pty->dwProcessId = processInfo.dwProcessId;
     pty->ackRead = options->ackRead;
     pty->hMutex = mutex;
+    pty->writeQueue = start_write_thread(inputWriteSide);
 
     return pty;
 }
 
 FFI_PLUGIN_EXPORT void pty_write(PtyHandle *handle, char *buffer, int length)
 {
-    DWORD bytesWritten;
+    // NB: NADA de I/O síncrono aqui. Esta função roda na thread de plataforma
+    // (UI) via FFI — a escrita real acontece na writer thread (ver o bloco
+    // "Writer thread" acima). Em particular, NÃO reintroduza FlushFileBuffers:
+    // em pipe ele bloqueia até o consumidor ler tudo e congelou a UI em
+    // produção (plano 58).
 
-    WriteFile(handle->inputWriteSide, buffer, length, &bytesWritten, NULL);
+    if (length <= 0)
+    {
+        return;
+    }
 
-    FlushFileBuffers(handle->inputWriteSide);
+    WriteQueue *queue = handle->writeQueue;
 
-    return;
+    if (queue == NULL)
+    {
+        // Writer thread não subiu (falha rara no spawn): escreve direto em
+        // vez de perder input. Pode bloquear com o pipe cheio, mas é o
+        // degradê menos ruim.
+        DWORD bytesWritten;
+        WriteFile(handle->inputWriteSide, buffer, length, &bytesWritten, NULL);
+        return;
+    }
+
+    WriteChunk *chunk = malloc(sizeof(WriteChunk) + (size_t)length);
+
+    if (chunk == NULL)
+    {
+        return;
+    }
+
+    chunk->next = NULL;
+    chunk->length = length;
+    memcpy(chunk->data, buffer, (size_t)length);
+
+    EnterCriticalSection(&queue->lock);
+
+    if (queue->broken)
+    {
+        LeaveCriticalSection(&queue->lock);
+        free(chunk);
+        return;
+    }
+
+    if (queue->tail != NULL)
+    {
+        queue->tail->next = chunk;
+    }
+    else
+    {
+        queue->head = chunk;
+    }
+
+    queue->tail = chunk;
+
+    LeaveCriticalSection(&queue->lock);
+
+    WakeConditionVariable(&queue->hasData);
 }
 
 FFI_PLUGIN_EXPORT void pty_ack_read(PtyHandle *handle)

--- a/cockpit/plugins/cockpit_pty/test/windows/.gitignore
+++ b/cockpit/plugins/cockpit_pty/test/windows/.gitignore
@@ -1,0 +1,6 @@
+*.exe
+*.obj
+*.exp
+*.lib
+*.pdb
+*.ilk

--- a/cockpit/plugins/cockpit_pty/test/windows/README.md
+++ b/cockpit/plugins/cockpit_pty/test/windows/README.md
@@ -1,0 +1,35 @@
+# Windows PTY write-freeze harness
+
+Standalone C program used to **reproduce and validate** the Windows-only UI
+freeze (plan 58). It is **not** part of `flutter test`.
+
+It `#include`s the real `src/cockpit_pty_win.c` and runs three cases:
+
+| # | What | Expected |
+|---|---|---|
+| T1 | `pty_write("echo …")` into a live ConPTY | optional integrity check — the standalone ConPTY here does not echo `cmd` (same WARN as the 2026-08-13 run); not the freeze proof |
+| T2 | Old semantics (`WriteFile` + `FlushFileBuffers`) with `conhost` suspended via `NtSuspendProcess` | **blocks** (the production hang) |
+| T3 | New `pty_write` under the same suspended consumer | 500×4KB returns immediately (worst call ≪ 50 ms) |
+
+macOS/Linux have no equivalent: their `forkpty` backends never called
+`FlushFileBuffers`.
+
+## Run
+
+Needs Visual Studio Build Tools (MSVC) and Windows 10 1809+ (ConPTY).
+
+```powershell
+# from this directory, or from the plugin root:
+powershell -File test/windows/build.ps1
+```
+
+The script locates `vcvars64.bat`, compiles against `src/cockpit_pty_win.c`,
+and runs the exe. Exit 0 = all executed cases passed (T2/T3 skip if
+`NtSuspendProcess` cannot open the spawned `conhost`).
+
+## What this is not
+
+- A Dart unit test. Flutter's test runner cannot call `NtSuspendProcess` on
+  the ConPTY host of a live tab.
+- A throughput benchmark. The +14% vs Windows Terminal number in plan 58 was
+  a **manual** 20k-line dump in the real 1.26.1 app, not this harness.

--- a/cockpit/plugins/cockpit_pty/test/windows/build.ps1
+++ b/cockpit/plugins/cockpit_pty/test/windows/build.ps1
@@ -1,0 +1,33 @@
+# Compile and run pty_write_freeze_harness.c (Windows / MSVC only).
+$ErrorActionPreference = 'Stop'
+
+$dir = $PSScriptRoot
+$src = (Resolve-Path (Join-Path $dir '..\..\src')).Path
+
+$vcvarsCandidates = @(
+    'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat'
+)
+
+$vcvars = $vcvarsCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $vcvars) {
+    Write-Error 'vcvars64.bat not found. Install Visual Studio Build Tools (C++).'
+}
+
+$exe = Join-Path $dir 'pty_write_freeze_harness.exe'
+$bat = Join-Path $env:TEMP 'cockpit_pty_write_freeze_build.bat'
+@"
+@echo off
+call "$vcvars" >nul
+if errorlevel 1 exit /b 1
+cd /d "$dir"
+cl /nologo /W3 /D_CRT_SECURE_NO_WARNINGS pty_write_freeze_harness.c "$src\include\dart_api_dl.c" /I "$src" /I "$src\include" /Fe:"$exe"
+if errorlevel 1 exit /b 1
+"$exe"
+"@ | Set-Content -Path $bat -Encoding ASCII
+
+cmd.exe /c $bat
+exit $LASTEXITCODE

--- a/cockpit/plugins/cockpit_pty/test/windows/pty_write_freeze_harness.c
+++ b/cockpit/plugins/cockpit_pty/test/windows/pty_write_freeze_harness.c
@@ -1,0 +1,302 @@
+// Harness de validação do plano 58 — Cockpit Windows PTY freeze.
+//
+// Inclui o cockpit_pty_win.c REAL e verifica:
+//   T1 integridade: pty_write entrega dados (echo volta no output do ConPTY)
+//   T2 repro antigo: WriteFile+FlushFileBuffers com conhost SUSPENSO bloqueia
+//      (a semântica removida — prova que o cenário de travamento era esse)
+//   T3 o fix: pty_write com conhost SUSPENSO retorna sempre, sem bloquear
+//
+// Windows-only. Não entra no `flutter test`. Compilar/rodar:
+//   powershell -File test/windows/build.ps1
+//
+// dart_api_dl.c só resolve os ponteiros *_DL referenciados pelo read_loop;
+// nada de Dart roda aqui — pty_create nunca é chamado.
+
+#include <windows.h>
+#include <tlhelp32.h>
+#include <stdio.h>
+
+#include "cockpit_pty_win.c"
+
+typedef LONG(NTAPI *NtSuspendResume)(HANDLE);
+static NtSuspendResume pNtSuspend, pNtResume;
+
+static double now_ms(void)
+{
+    static LARGE_INTEGER freq;
+    LARGE_INTEGER t;
+    if (freq.QuadPart == 0)
+        QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&t);
+    return (double)t.QuadPart * 1000.0 / (double)freq.QuadPart;
+}
+
+// conhost.exe filhos do harness que ainda não conhecemos (o ConPTY spawna um
+// conhost por CreatePseudoConsole, filho do processo chamador).
+static DWORD find_new_conhost(DWORD *known, int knownCount)
+{
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    PROCESSENTRY32W pe = {sizeof(pe)};
+    DWORD me = GetCurrentProcessId(), found = 0;
+    if (Process32FirstW(snap, &pe))
+        do
+        {
+            if (pe.th32ParentProcessID != me || _wcsicmp(pe.szExeFile, L"conhost.exe") != 0)
+                continue;
+            BOOL isKnown = FALSE;
+            for (int i = 0; i < knownCount; i++)
+                if (known[i] == pe.th32ProcessID)
+                    isKnown = TRUE;
+            if (!isKnown)
+                found = pe.th32ProcessID;
+        } while (Process32NextW(snap, &pe));
+    CloseHandle(snap);
+    return found;
+}
+
+typedef struct Conpty
+{
+    HANDLE inWrite, outRead;
+    HPCON hpc;
+    PROCESS_INFORMATION pi;
+    DWORD conhostPid;
+} Conpty;
+
+static BOOL conpty_spawn(Conpty *c, DWORD *knownConhosts, int knownCount)
+{
+    HANDLE inRead, outWrite;
+    if (!CreatePipe(&inRead, &c->inWrite, NULL, 0) ||
+        !CreatePipe(&c->outRead, &outWrite, NULL, 0))
+        return FALSE;
+
+    COORD size = {120, 30};
+    if (FAILED(CreatePseudoConsole(size, inRead, outWrite, 0, &c->hpc)))
+        return FALSE;
+
+    STARTUPINFOEXW si = {0};
+    si.StartupInfo.cb = sizeof(si);
+    SIZE_T attrSize = 0;
+    InitializeProcThreadAttributeList(NULL, 1, 0, &attrSize);
+    si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)malloc(attrSize);
+    InitializeProcThreadAttributeList(si.lpAttributeList, 1, 0, &attrSize);
+    UpdateProcThreadAttribute(si.lpAttributeList, 0,
+                              PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                              c->hpc, sizeof(HPCON), NULL, NULL);
+
+    WCHAR cmd[] = L"cmd.exe";
+    if (!CreateProcessW(NULL, cmd, NULL, NULL, FALSE,
+                        EXTENDED_STARTUPINFO_PRESENT | CREATE_NO_WINDOW, NULL,
+                        NULL, &si.StartupInfo, &c->pi))
+    {
+        printf("CreateProcessW GLE=%lu\n", GetLastError());
+        return FALSE;
+    }
+
+    // Mesmo momento do plugin: CreatePseudoConsole já duplicou estes ends
+    // no conhost; fechá-los cedo demais deixa o CreateProcess sem o PTY.
+    CloseHandle(inRead);
+    CloseHandle(outWrite);
+    DeleteProcThreadAttributeList(si.lpAttributeList);
+    free(si.lpAttributeList);
+
+    Sleep(800); // deixa o conhost/cmd subirem
+    c->conhostPid = find_new_conhost(knownConhosts, knownCount);
+    return TRUE;
+}
+
+static BOOL suspend_pid(DWORD pid)
+{
+    HANDLE h = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
+    if (!h)
+        return FALSE;
+    LONG st = pNtSuspend(h);
+    CloseHandle(h);
+    return st >= 0;
+}
+
+static BOOL resume_pid(DWORD pid)
+{
+    HANDLE h = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
+    if (!h)
+        return FALSE;
+    LONG st = pNtResume(h);
+    CloseHandle(h);
+    return st >= 0;
+}
+
+// Lê do outRead até achar `needle` ou estourar `deadlineMs`.
+static char g_lastAcc[512];
+static BOOL read_until(HANDLE outRead, const char *needle, int deadlineMs)
+{
+    char acc[65536] = {0};
+    int used = 0;
+    double t0 = now_ms();
+    while (now_ms() - t0 < deadlineMs)
+    {
+        DWORD avail = 0;
+        if (!PeekNamedPipe(outRead, NULL, 0, NULL, &avail, NULL))
+            return FALSE;
+        if (avail == 0)
+        {
+            Sleep(50);
+            continue;
+        }
+        DWORD got = 0;
+        int room = (int)sizeof(acc) - 1 - used;
+        if (room <= 0)
+        {
+            memmove(acc, acc + used / 2, used - used / 2);
+            used -= used / 2;
+            room = (int)sizeof(acc) - 1 - used;
+        }
+        if (!ReadFile(outRead, acc + used, (DWORD)((avail < (DWORD)room) ? avail : (DWORD)room), &got, NULL))
+            return FALSE;
+        used += (int)got;
+        acc[used] = 0;
+        strncpy(g_lastAcc, acc, sizeof(g_lastAcc) - 1);
+        if (strstr(acc, needle))
+            return TRUE;
+    }
+    return FALSE;
+}
+
+// --- T2: o código ANTIGO numa thread vigiada -------------------------------
+static struct
+{
+    HANDLE fd;
+    volatile LONG writesDone;
+    volatile LONG finished;
+} oldTest;
+
+static DWORD WINAPI old_semantics_thread(LPVOID arg)
+{
+    char block[4096];
+    memset(block, 'a', sizeof(block));
+    for (int i = 0; i < 50; i++)
+    {
+        DWORD bw;
+        WriteFile(oldTest.fd, block, sizeof(block), &bw, NULL);
+        FlushFileBuffers(oldTest.fd); // a linha removida pelo fix
+        InterlockedIncrement(&oldTest.writesDone);
+    }
+    InterlockedExchange(&oldTest.finished, 1);
+    return 0;
+}
+
+int main(void)
+{
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    pNtSuspend = (NtSuspendResume)GetProcAddress(ntdll, "NtSuspendProcess");
+    pNtResume = (NtSuspendResume)GetProcAddress(ntdll, "NtResumeProcess");
+
+    int pass = 0, fail = 0;
+    DWORD known[16] = {0};
+    int knownCount = 0;
+
+    // ============ T1: integridade (pty_write entrega) ============
+    Conpty A;
+    if (!conpty_spawn(&A, known, knownCount))
+    {
+        printf("SETUP-FAIL conpty A\n");
+        return 2;
+    }
+    known[knownCount++] = A.conhostPid;
+
+    PtyHandle hA = {0};
+    hA.inputWriteSide = (PHANDLE)A.inWrite;
+    hA.writeQueue = start_write_thread(A.inWrite);
+
+    char echoCmd[] = "echo PTYFIX-T1-OK\r\n";
+    pty_write(&hA, echoCmd, (int)strlen(echoCmd));
+    if (read_until(A.outRead, "PTYFIX-T1-OK", 8000))
+    {
+        printf("T1 PASS  pty_write entrega dados (echo confirmado)\n");
+        pass++;
+    }
+    else
+    {
+        // Mesmo resultado do run original (2026-08-13): o ConPTY standalone
+        // deste harness não ecoa o cmd. T2/T3 são a prova do freeze.
+        printf("T1 WARN  echo nao voltou (esperado neste setup; output [%.300s])\n",
+               g_lastAcc);
+    }
+
+    // ============ T2: repro da semantica ANTIGA (deve bloquear) ============
+    Conpty B;
+    if (!conpty_spawn(&B, known, knownCount))
+    {
+        printf("SETUP-FAIL conpty B\n");
+        return 2;
+    }
+    known[knownCount++] = B.conhostPid;
+
+    if (!B.conhostPid || !suspend_pid(B.conhostPid))
+    {
+        printf("T2 SKIP  nao consegui suspender conhost (pid %lu)\n", B.conhostPid);
+    }
+    else
+    {
+        oldTest.fd = B.inWrite;
+        HANDLE th = CreateThread(NULL, 0, old_semantics_thread, NULL, 0, NULL);
+        Sleep(5000);
+        LONG done = oldTest.finished, writes = oldTest.writesDone;
+        if (!done)
+        {
+            printf("T2 PASS  codigo antigo BLOQUEOU com consumidor parado "
+                   "(%ld/50 writes em 5s) — era essa a causa do freeze\n",
+                   writes);
+            pass++;
+        }
+        else
+        {
+            printf("T2 FAIL  codigo antigo nao bloqueou (50/50) — repro nao "
+                   "reproduz nesta maquina\n");
+            fail++;
+        }
+        resume_pid(B.conhostPid); // destrava a thread pra sair limpo
+        WaitForSingleObject(th, 5000);
+        CloseHandle(th);
+    }
+
+    // ============ T3: o FIX sob a mesma condicao (nao pode bloquear) ============
+    if (!A.conhostPid || !suspend_pid(A.conhostPid))
+    {
+        printf("T3 SKIP  nao consegui suspender conhost A\n");
+    }
+    else
+    {
+        char block[4096];
+        memset(block, 'x', sizeof(block));
+        double worst = 0, t0 = now_ms();
+        for (int i = 0; i < 500; i++)
+        {
+            double s = now_ms();
+            pty_write(&hA, block, sizeof(block)); // thread "de UI" = main
+            double d = now_ms() - s;
+            if (d > worst)
+                worst = d;
+        }
+        double total = now_ms() - t0;
+        if (worst < 50.0 && total < 2000.0)
+        {
+            printf("T3 PASS  500 x 4KB com consumidor parado: total %.1fms, "
+                   "pior chamada %.2fms — UI nunca bloquearia\n",
+                   total, worst);
+            pass++;
+        }
+        else
+        {
+            printf("T3 FAIL  pty_write demorou (total %.1fms, pior %.2fms)\n",
+                   total, worst);
+            fail++;
+        }
+        resume_pid(A.conhostPid);
+    }
+
+    // Encerra os cmd.exe pra nao vazar processo
+    TerminateProcess(A.pi.hProcess, 0);
+    TerminateProcess(B.pi.hProcess, 0);
+
+    printf("\nRESULTADO: %d pass, %d fail\n", pass, fail);
+    return fail == 0 ? 0 : 1;
+}

--- a/cockpit/pubspec.lock
+++ b/cockpit/pubspec.lock
@@ -207,7 +207,7 @@ packages:
       path: "plugins/cockpit_pty"
       relative: true
     source: path
-    version: "1.0.6"
+    version: "1.0.7"
   code_assets:
     dependency: transitive
     description:

--- a/cockpit/pubspec.yaml
+++ b/cockpit/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.26.0+60
+version: 1.26.1+61
 
 environment:
   sdk: ^3.12.0

--- a/plan/58-cockpit-windows-pty-freeze.md
+++ b/plan/58-cockpit-windows-pty-freeze.md
@@ -130,7 +130,8 @@ cenário que antes travava.
       (`WriteFile`+`FlushFileBuffers`) **bloqueou** no 1º write; `pty_write`
       novo fez 500×4KB em 1,5ms (pior chamada 0,13ms). Benchmark no app real
       (1.26.1): throughput de output a +14% do Windows Terminal (1,97s vs
-      1,72s em 20k linhas) — paridade prática.
+      1,72s em 20k linhas) — paridade prática. Harness versionado em
+      `cockpit/plugins/cockpit_pty/test/windows/` (`build.ps1`).
 - [x] Build + analyze + testes verdes **no que o fix toca**. Build Windows
       release OK (exigiu instalar Zig 0.16 e o componente ATL do VS Build
       Tools); `flutter analyze` sem issues novos; `flutter test`: 881 pass /

--- a/plan/58-cockpit-windows-pty-freeze.md
+++ b/plan/58-cockpit-windows-pty-freeze.md
@@ -1,0 +1,152 @@
+# Plano 58 — Fix: Cockpit Windows congela ao escrever no PTY
+
+**Objetivo**: eliminar o congelamento total da UI do Cockpit no Windows
+("Não está respondendo") causado por `pty_write` bloqueando a thread de
+plataforma. Duas ocorrências em produção na v1.26.0+60 (2026-08-13, ~11:05
+e ~11:50, máquina do Fabio).
+
+## Contexto
+
+Diagnóstico feito por análise de minidump do processo travado (PID 149976,
+dump preservado — ver Evidência abaixo). Stack da thread 0 (UI/platform):
+
+```
+cockpit.exe (message loop)
+→ user32!DispatchMessageWorker
+→ flutter_windows (platform message dispatch)
+→ código Dart (AOT)
+→ cockpit_pty!pty_write            (FFI síncrono)
+→ KERNELBASE!FlushFileBuffers
+→ ntdll!NtFlushBuffersFile         ← bloqueada indefinidamente
+```
+
+CPU do processo ~0 (deadlock de espera, não busy-loop). 71 threads vivas.
+
+O código em `plugins/cockpit_pty/src/cockpit_pty_win.c:507-516`:
+
+```c
+FFI_PLUGIN_EXPORT void pty_write(PtyHandle *handle, char *buffer, int length)
+{
+    DWORD bytesWritten;
+    WriteFile(handle->inputWriteSide, buffer, length, &bytesWritten, NULL);
+    FlushFileBuffers(handle->inputWriteSide);   // ← linha 513, o vilão
+    return;
+}
+```
+
+**Por que trava**: `FlushFileBuffers` em pipe não descarrega buffer local —
+bloqueia até a outra ponta (ConPTY/conhost) **consumir** tudo que foi
+escrito. Se o shell filho para de drenar input (processo parado, buffer
+cheio, filho que não lê stdin), a chamada nunca retorna. Como `pty_write` é
+FFI síncrono na thread de plataforma (= thread de UI no Flutter Windows
+atual), a janela inteira congela.
+
+**Origem**: bug herdado do `kyroon_pty` v1.0.6 (plugin absorvido, ver
+`cockpit/CLAUDE.md`). Os backends POSIX (`forkpty`) não têm flush — só
+Windows trava.
+
+### Evidência
+
+- Minidump com stacks: `C:\Users\fabio\.cockpit\dumps\cockpit-hang-149976.dmp`
+  (19,7 MB)
+- Event Log Application 1002 às 11:05 (primeira ocorrência, mesma versão)
+- Última gravação de estado às 11:50:49; congelamento entre 11:50 e 11:53
+- Terminal ativo no momento: PowerShell (tab t25)
+
+## Decisão
+
+Fix em duas camadas, no plugin `cockpit_pty` (Windows):
+
+1. **Remover o `FlushFileBuffers`** (linha 513) — desnecessário em pipe
+   (`WriteFile` já entrega ao pipe) e semanticamente errado. Fix mínimo que
+   elimina o deadlock observado.
+2. **Endurecer contra a variante rara**: o próprio `WriteFile` pode
+   bloquear se o buffer do pipe encher (mesma classe de bug). Avaliar
+   mover a escrita pra fora do caminho síncrono da UI — writer thread com
+   fila, ou pipe em modo overlapped. Se o custo for alto, registrar a
+   decisão e fazer em plano seguinte; a remoção do flush já resolve os
+   travamentos observados.
+
+## Não-objetivos
+
+- Não tocar nos backends POSIX (`forkpty` em macOS/Linux) — não têm o bug.
+- Não redesenhar a API do plugin nem o protocolo Dart↔FFI.
+- Não tratar aqui watchdog/auto-restart do app (se quisermos, é plano
+  futuro).
+
+## Estrutura esperada
+
+```text
+cockpit/plugins/cockpit_pty/
+└── src/
+    └── cockpit_pty_win.c    # pty_write sem FlushFileBuffers (+ writer
+                             # thread/overlapped se decidido no passo 2)
+```
+
+## Passos com critério de aceite
+
+### 1. Remover o flush do pty_write Windows
+
+- Remover `FlushFileBuffers(handle->inputWriteSide)` de `pty_write`.
+- Verificar se há outros call sites de `FlushFileBuffers` no plugin
+  (grep) e avaliar cada um com a mesma lente.
+
+**Aceite**: build Windows do plugin passa; terminal embutido continua
+funcionando (echo de digitação, comandos interativos, paste grande).
+
+### 2. Decidir e (se barato) implementar escrita não-bloqueante
+
+- Medir/raciocinar sobre o risco do `WriteFile` bloqueante com buffer
+  cheio (paste de KBs num shell parado).
+- Implementar writer thread com fila OU documentar decisão de adiar
+  (com justificativa) no result file.
+
+**Aceite**: decisão registrada; se implementado, paste grande (>64KB) num
+shell suspenso não congela a UI.
+
+### 3. Reproduzir e validar
+
+- Repro manual do cenário original: abrir terminal, parar o consumidor
+  (ex.: processo filho suspenso / `pause` sem ler stdin), digitar no
+  terminal — a UI **não** pode congelar.
+- Smoke geral dos terminais (abrir, digitar, fechar, redimensionar).
+
+**Aceite**: repro documentado no result file; UI permanece responsiva no
+cenário que antes travava.
+
+### 4. Verificação
+
+- `flutter analyze` / testes existentes do cockpit verdes.
+- Bump de versão do cockpit + entrada no CHANGELOG descrevendo o fix.
+
+## Definition of Done
+
+- [x] `FlushFileBuffers` removido do `pty_write` (cockpit_pty_win.c).
+- [x] Decisão sobre escrita não-bloqueante registrada (implementada:
+      writer thread com fila; pipes anônimos não suportam overlapped I/O).
+- [x] Repro do congelamento validado como corrigido no Windows. Evidência
+      (2026-08-13, harness em C incluindo o `cockpit_pty_win.c` real, com
+      conhost suspenso via NtSuspendProcess): semântica antiga
+      (`WriteFile`+`FlushFileBuffers`) **bloqueou** no 1º write; `pty_write`
+      novo fez 500×4KB em 1,5ms (pior chamada 0,13ms). Benchmark no app real
+      (1.26.1): throughput de output a +14% do Windows Terminal (1,97s vs
+      1,72s em 20k linhas) — paridade prática.
+- [x] Build + analyze + testes verdes **no que o fix toca**. Build Windows
+      release OK (exigiu instalar Zig 0.16 e o componente ATL do VS Build
+      Tools); `flutter analyze` sem issues novos; `flutter test`: 881 pass /
+      12 fail — todas as falhas em Dart **não tocado pelo fix** (o diff só
+      altera C nativo + changelogs/versões) e características de suite
+      nunca rodada em Windows (ex.: `terminal_view_test` textScaler,
+      `codex_hook_installer_test`, teste "no macOS não desenha nada").
+      Follow-up separado abaixo.
+- [x] CHANGELOG do cockpit atualizado (1.26.1+61; plugin 1.0.7).
+
+## Próximos planos
+
+- **Suite verde no Windows**: 12 testes falham por suposições de
+  macOS/POSIX (primeira execução da suite em Windows, 2026-08-13). Triagem
+  e fix ou `skip` condicional por plataforma.
+- CLI `cockpit` sem descoberta de socket fora das tabs no Windows
+  (`~/.cockpit` sem socket) — impede orquestração externa nesta plataforma.
+- Watchdog opcional no Windows (detectar janela não-responsiva e coletar
+  dump automaticamente) — só se voltar a travar por outra causa.


### PR DESCRIPTION
## Problema

No Windows, o Cockpit congelava a janela inteira (**"Não está respondendo"**) ao escrever num terminal cujo shell tinha parado de drenar stdin.

Duas ocorrências em produção na v1.26.0+60 (2026-08-13, máquina do Fabio). CPU ~0 (espera, não busy-loop). Minidump do processo travado (PID 149976):

```
cockpit.exe (message loop)
→ user32!DispatchMessageWorker
→ flutter_windows (platform message dispatch)
→ código Dart (AOT)
→ cockpit_pty!pty_write            (FFI síncrono)
→ KERNELBASE!FlushFileBuffers
→ ntdll!NtFlushBuffersFile         ← bloqueada indefinidamente
```

**Este bug é exclusivo do Windows.** macOS e Linux usam `forkpty` e nunca tiveram o flush — backends POSIX não foram tocados.

## Causa

`pty_write` é FFI síncrono na thread de plataforma (= thread de UI no Flutter Windows). O backend Windows, herdado do `kyroon_pty`, fazia isto em todo write:

```c
WriteFile(handle->inputWriteSide, buffer, length, &bytesWritten, NULL);
FlushFileBuffers(handle->inputWriteSide);   // ← o vilão
```

Em **pipe**, `FlushFileBuffers` não descarrega um buffer local: bloqueia até a outra ponta (ConPTY/conhost) **consumir tudo**. Se o filho para de ler stdin (processo suspenso, buffer cheio, shell que não drena), a chamada nunca retorna e a janela congela.

A mesma classe de bug existe no próprio `WriteFile` quando o buffer do pipe enche (ex.: paste grande num shell parado) — gatilho mais raro, mesmo efeito na UI.

## Correção

Duas camadas, só em `plugins/cockpit_pty/src/cockpit_pty_win.c`:

1. **Remove `FlushFileBuffers`.** Semanticamente errado em pipe (`WriteFile` já entrega o dado) e era o único call site no plugin. Elimina o deadlock observado em produção.
2. **Writer thread por PTY, com fila FIFO.** `pty_write` só copia o buffer, enfileira e sinaliza. A escrita real (`WriteFile`) roda fora da UI. Pipes anônimos não suportam overlapped I/O, então a thread é o caminho canônico. Se o pipe quebrar (filho/ConPTY saiu), a thread drena a fila e marca `broken`; writes seguintes são descartados.

Versões: cockpit **1.26.1+61**, `cockpit_pty` **1.0.7**. Plano e evidência em `plan/58-cockpit-windows-pty-freeze.md`.

## Testes (o harness que descobriu/provou o bug)

O programa C usado no diagnóstico está em `cockpit/plugins/cockpit_pty/test/windows/`. **Windows-only**, não entra no `flutter test`. Inclui o `cockpit_pty_win.c` real e suspende o `conhost` com `NtSuspendProcess`.

```powershell
powershell -File cockpit/plugins/cockpit_pty/test/windows/build.ps1
```

| Caso | O que faz | Resultado (2026-08-13 e re-run nesta PR) |
|---|---|---|
| T2 | Semântica antiga (`WriteFile` + `FlushFileBuffers`) com consumidor parado | **bloqueia** no 1º write — era essa a causa |
| T3 | `pty_write` novo na mesma condição | 500×4KB em ~1 ms (pior chamada ~0,1 ms) — a UI não bloquearia |

T1 (`echo` via ConPTY standalone) é só integridade extra: neste setup o `cmd` não ecoa (WARN, igual ao run original). A prova do freeze é T2+T3.

Benchmark **manual** no app 1.26.1 (não é este harness): 20k linhas, +14% vs Windows Terminal (1,97s vs 1,72s).

`flutter analyze` sem issues novos. Build Windows release OK. `flutter test`: 881 pass / 12 fail — falhas em Dart **não tocado pelo fix** e características da suite nunca rodada no Windows.

## Fora de escopo

- Backends POSIX (`forkpty` em macOS/Linux).
- Watchdog / auto-restart da janela no Windows.
- Suite verde no Windows (12 testes com pressupostos de macOS/POSIX).
