### PR TITLE
fix(cockpit): erro C1041 no build Windows (PDB concorrente) 

### DIFF
--- a/cockpit/windows/CMakeLists.txt
+++ b/cockpit/windows/CMakeLists.txt
@@ -38,6 +38,10 @@ add_definitions(-DUNICODE -D_UNICODE)
 # não passa.
 add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
 
+# Compilações paralelas do MSVC (cl /MP) escrevendo no mesmo .pdb estouram
+# C1041 no flutter_inappwebview_windows; /FS serializa o acesso ao PDB.
+add_compile_options(/FS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
## Problema

Build Windows do cockpit falhava com erro C1041: múltiplos processos do compilador escrevendo no mesmo arquivo PDB simultaneamente.

## Correção

Adicionada a flag `/FS` ao compilador MSVC, que serializa o acesso ao PDB via mspdbsrv, permitindo compilação paralela sem conflito.

## Teste

- `flutter build windows` na máquina Windows 11 — build completo sem C1041
- Rebuild incremental repetido 3x para confirmar que o erro não reaparece
