### PR TITLE
feat(cockpit): expand and collapse worktrees per workspace

### DIFF
--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -681,6 +681,8 @@ class _RailPanel extends StatelessWidget {
           width: width,
           projects: vm.rootProjects,
           worktreesOf: vm.worktreesOf,
+          worktreesExpanded: vm.worktreesExpanded,
+          onWorktreesExpanded: vm.setWorktreesExpanded,
           selectedId: vm.selectedProjectId,
           notificationCount: vm.notificationCount,
           gitInfo: vm.gitInfo,

--- a/cockpit/lib/app/cockpit/ui/states/pane_node.dart
+++ b/cockpit/lib/app/cockpit/ui/states/pane_node.dart
@@ -89,6 +89,18 @@ PaneNode paneNodeFromJson(Map<String, dynamic> json) {
   );
 }
 
+/// Chave do documento de layout que guarda se a lista de worktrees do workspace
+/// está expandida no rail (V37 — toggle no card).
+const String kWorktreesExpandedKey = 'worktreesExpanded';
+
+/// Lê [kWorktreesExpandedKey] de um documento de layout. Ausente ou de tipo
+/// errado (layout antigo, workspace nunca salvo, doc corrompido) = **expandida**
+/// — é o comportamento que o rail sempre teve.
+bool worktreesExpandedOf(Map<String, dynamic>? doc) {
+  final value = doc?[kWorktreesExpandedKey];
+  return value is bool ? value : true;
+}
+
 // ---- helpers puros (espelham os do design) ----------------------------------
 
 List<LeafPane> leaves(PaneNode node, [List<LeafPane>? acc]) {

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -407,6 +407,11 @@ class CockpitViewModel extends ChangeNotifier {
   /// Debounce de gravação por projeto (o resize é arrasto contínuo).
   final Map<String, Timer> _saveTimers = <String, Timer>{};
 
+  /// Override em memória do toggle de worktrees (V37), por workspace raiz. Só
+  /// ganha entrada quando o usuário alterna; a leitura cai no documento de
+  /// layout salvo (e daí no default expandido) enquanto não houver override.
+  final Map<String, bool> _worktreesExpanded = <String, bool>{};
+
   /// `true` enquanto reconstruímos um projeto — evita gravar layout meio-feito.
   bool _restoring = false;
 
@@ -582,6 +587,26 @@ class CockpitViewModel extends ChangeNotifier {
   /// Worktrees (forks) de um workspace raiz, na ordem do git (vazio se nenhuma).
   List<Project> worktreesOf(String rootId) =>
       _worktrees[rootId] ?? const <Project>[];
+
+  /// `true` se a lista de worktrees de [rootId] está expandida no rail (V37).
+  /// Sem override do usuário, vale o que o documento de layout salvo diz — e
+  /// layout antigo/inexistente vem expandido.
+  bool worktreesExpanded(String rootId) =>
+      _worktreesExpanded[rootId] ?? worktreesExpandedOf(_savedLayouts[rootId]);
+
+  /// Expande/recolhe a lista de worktrees de [rootId] e agenda a gravação no
+  /// **mesmo** documento de layout do workspace (sem storage paralelo).
+  void setWorktreesExpanded(String rootId, bool expanded) {
+    if (worktreesExpanded(rootId) == expanded) return;
+    _worktreesExpanded[rootId] = expanded;
+    final saved = _savedLayouts[rootId];
+    _savedLayouts[rootId] = <String, dynamic>{
+      ...?saved,
+      kWorktreesExpandedKey: expanded,
+    };
+    notifyListeners();
+    _scheduleSave(rootId);
+  }
 
   String? get selectedProjectId => _selectedProjectId;
   Project? get selectedProject => _projectById(_selectedProjectId);
@@ -2879,6 +2904,7 @@ class CockpitViewModel extends ChangeNotifier {
     }
     _focused.remove(id);
     _savedLayouts.remove(id);
+    _worktreesExpanded.remove(id);
     git.forget(id);
     _saveTimers.remove(id)?.cancel();
   }
@@ -5199,6 +5225,9 @@ class CockpitViewModel extends ChangeNotifier {
       'focused': _focused[projectId],
       'tree': paneNodeToJson(tree),
       'sessions': sessions,
+      // Toggle de worktrees do rail (V37) — mora no mesmo doc do layout, então
+      // sobrevive à sessão sem inventar outro store.
+      kWorktreesExpandedKey: worktreesExpanded(projectId),
     };
   }
 
@@ -5377,7 +5406,15 @@ class CockpitViewModel extends ChangeNotifier {
     _saveTimers[projectId] = Timer(const Duration(milliseconds: 500), () {
       _saveTimers.remove(projectId);
       final doc = _serializeLayout(projectId);
-      if (doc.isNotEmpty) unawaited(_layoutStore.save(projectId, doc));
+      if (doc.isNotEmpty) {
+        unawaited(_layoutStore.save(projectId, doc));
+      } else {
+        // A rail toggle can happen while an unselected workspace is still
+        // activating and has no pane tree yet. Persist its rail-only document
+        // instead of dropping the user's choice.
+        final saved = _savedLayouts[projectId];
+        if (saved != null) unawaited(_layoutStore.save(projectId, saved));
+      }
     });
   }
 

--- a/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
@@ -563,6 +563,30 @@ class _WorktreeChevron extends StatelessWidget {
   }
 }
 
+class _CardTrailingSlot extends StatelessWidget {
+  const _CardTrailingSlot({
+    required this.menu,
+    required this.hasWorktrees,
+    required this.expanded,
+  });
+
+  final Widget menu;
+  final bool hasWorktrees;
+  final bool expanded;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!hasWorktrees) return menu;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        menu,
+        _WorktreeChevron(expanded: expanded),
+      ],
+    );
+  }
+}
+
 /// Envolve um badge/chip informativo pra que o clique nele **pare** ali: sem
 /// isto o toque cairia no card e alternaria a lista de worktrees, que não é o
 /// que alguém mirando um indicador espera. Chips com ação própria
@@ -826,26 +850,23 @@ class _RemoteSlot extends StatelessWidget {
                     ),
                   ),
                 ),
-                if (hasWorktrees) ...[
-                  const SizedBox(width: 4),
-                  _WorktreeChevron(expanded: expanded),
-                ],
                 const SizedBox(width: 2),
-                // Builder: o menu ancora no RenderBox do context passado a
-                // showAppMenu. Sem isto, o context do slot inteiro faria o popup
-                // abrir na largura toda (aparecia "embaixo"); com o Builder o
-                // context é o do ícone, igual ao workspace local.
-                Builder(
-                  builder: (iconContext) => GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTapUp: (_) => _showMenu(iconContext),
-                    child: SizedBox(
-                      width: 22,
-                      height: 22,
-                      child: Icon(
-                        Icons.more_vert,
-                        size: 14,
-                        color: context.colors.text3,
+                _CardTrailingSlot(
+                  hasWorktrees: hasWorktrees,
+                  expanded: expanded,
+                  menu: Builder(
+                    // O menu ancora no RenderBox do ícone, não no slot inteiro.
+                    builder: (iconContext) => GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTapUp: (_) => _showMenu(iconContext),
+                      child: SizedBox(
+                        width: 22,
+                        height: 22,
+                        child: Icon(
+                          Icons.more_vert,
+                          size: 14,
+                          color: context.colors.text3,
+                        ),
                       ),
                     ),
                   ),
@@ -1005,22 +1026,22 @@ class _ProjectItem extends StatelessWidget {
                   ),
                   const SizedBox(width: 4),
                 ],
-                if (hasWorktrees) ...[
-                  _WorktreeChevron(expanded: expanded),
-                  const SizedBox(width: 2),
-                ],
-                _MenuButton(
-                  workspaceId: project.id,
-                  canCreateWorktree: canCreateWorktree,
-                  roots: roots,
-                  onConfigure: onConfigure,
-                  onDelete: onDelete,
-                  onCreateWorktree: onCreateWorktree,
-                  onSync: onSync,
-                  onPull: onPull,
-                  onPush: onPush,
-                  moveTargets: moveTargets,
-                  onMoveToRealm: onMoveToRealm,
+                _CardTrailingSlot(
+                  hasWorktrees: hasWorktrees,
+                  expanded: expanded,
+                  menu: _MenuButton(
+                    workspaceId: project.id,
+                    canCreateWorktree: canCreateWorktree,
+                    roots: roots,
+                    onConfigure: onConfigure,
+                    onDelete: onDelete,
+                    onCreateWorktree: onCreateWorktree,
+                    onSync: onSync,
+                    onPull: onPull,
+                    onPush: onPush,
+                    moveTargets: moveTargets,
+                    onMoveToRealm: onMoveToRealm,
+                  ),
                 ),
               ],
             ),

--- a/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
@@ -61,6 +61,10 @@ String? branchOfRoot(List<RailRoot> roots, String rootPath) {
 /// duração. Só esses dois animam — o card/cabeçalho não se move.
 const Duration _kToggleDuration = Duration(milliseconds: 150);
 
+@visibleForTesting
+IconData worktreeChevronIcon(bool expanded) =>
+    expanded ? Icons.keyboard_arrow_down : Icons.chevron_right;
+
 /// Rail esquerda (~252px): cabeçalho "Sessions", lista de projetos (avatar +
 /// nome + git + contador de notificações), rodapé com o seletor de realm.
 class ProjectsRail extends StatefulWidget {
@@ -529,9 +533,9 @@ class _WorktreeSummary extends StatelessWidget {
   }
 }
 
-/// Chevron do card: aponta pra direita recolhido e gira 90° ao expandir, na
-/// mesma duração da lista. Puramente indicativo — quem recebe o clique é o card
-/// inteiro, então ele não intercepta ponteiro nenhum.
+/// Chevron do card: usa glifos explícitos para garantir direita/recolhido e
+/// baixo/expandido em todas as plataformas. Puramente indicativo — quem recebe
+/// o clique é o card inteiro, então ele não intercepta ponteiro nenhum.
 class _WorktreeChevron extends StatelessWidget {
   const _WorktreeChevron({required this.expanded});
 
@@ -542,11 +546,18 @@ class _WorktreeChevron extends StatelessWidget {
     final tr = context.t.cockpit.projectsRail;
     return AppTooltip(
       message: expanded ? tr.collapseWorktrees : tr.expandWorktrees,
-      child: AnimatedRotation(
-        turns: expanded ? 0.25 : 0.0,
+      child: AnimatedSwitcher(
         duration: _kToggleDuration,
-        curve: Curves.easeOutCubic,
-        child: Icon(Icons.chevron_right, size: 16, color: context.colors.text3),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeInCubic,
+        transitionBuilder: (child, animation) =>
+            FadeTransition(opacity: animation, child: child),
+        child: Icon(
+          worktreeChevronIcon(expanded),
+          key: ValueKey(expanded),
+          size: 16,
+          color: context.colors.text3,
+        ),
       ),
     );
   }

--- a/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
@@ -39,6 +39,28 @@ String? branchOfRoot(List<RailRoot> roots, String rootPath) {
   return null;
 }
 
+/// O que um clique no **card** do workspace faz (V37). `select` = selecionar o
+/// workspace; `expand` = novo estado da lista de worktrees (`null` = não mexer,
+/// caso do workspace sem fork nenhum — não há lista a alternar).
+///
+/// Não selecionado → seleciona e já deixa a lista aberta (uma ação, dois
+/// resultados). Já selecionado → o clique só alterna a lista.
+@visibleForTesting
+({bool select, bool? expand}) workspaceCardTap({
+  required bool selected,
+  required bool expanded,
+  required bool hasWorktrees,
+}) {
+  if (!hasWorktrees) return (select: !selected, expand: null);
+  // Selecionar nunca recolhe: o clique que traz o workspace pra frente abre a
+  // lista junto. Já selecionado, esse mesmo clique passa a ser só o toggle.
+  return (select: !selected, expand: selected ? !expanded : true);
+}
+
+/// Tempo do toggle de worktrees: o chevron gira e a lista anima a altura nesta
+/// duração. Só esses dois animam — o card/cabeçalho não se move.
+const Duration _kToggleDuration = Duration(milliseconds: 150);
+
 /// Rail esquerda (~252px): cabeçalho "Sessions", lista de projetos (avatar +
 /// nome + git + contador de notificações), rodapé com o seletor de realm.
 class ProjectsRail extends StatefulWidget {
@@ -46,6 +68,8 @@ class ProjectsRail extends StatefulWidget {
     super.key,
     required this.projects,
     required this.worktreesOf,
+    required this.worktreesExpanded,
+    required this.onWorktreesExpanded,
     required this.selectedId,
     required this.notificationCount,
     required this.gitInfo,
@@ -116,6 +140,12 @@ class ProjectsRail extends StatefulWidget {
 
   /// Worktrees (forks) de um workspace raiz, na ordem do git.
   final List<Project> Function(String rootId) worktreesOf;
+
+  /// `true` se a lista de worktrees do workspace raiz está expandida (V37).
+  final bool Function(String rootId) worktreesExpanded;
+
+  /// Expande/recolhe a lista de worktrees de um workspace raiz.
+  final void Function(String rootId, bool expanded) onWorktreesExpanded;
 
   final String? selectedId;
   final int Function(String projectId) notificationCount;
@@ -189,6 +219,20 @@ class _ProjectsRailState extends State<ProjectsRail> {
   void dispose() {
     _scroll.dispose();
     super.dispose();
+  }
+
+  /// Clique no card do workspace [project] (V37): seleciona e/ou alterna a
+  /// lista de worktrees, conforme [workspaceCardTap]. [onSelect] varia entre
+  /// local e remoto — o resto da regra é o mesmo pros dois.
+  void _onCardTap(Project project, VoidCallback onSelect) {
+    final action = workspaceCardTap(
+      selected: project.id == widget.selectedId,
+      expanded: widget.worktreesExpanded(project.id),
+      hasWorktrees: widget.worktreesOf(project.id).isNotEmpty,
+    );
+    if (action.select) onSelect();
+    final expand = action.expand;
+    if (expand != null) widget.onWorktreesExpanded(project.id, expand);
   }
 
   /// Os forks de um workspace, com `isLast` marcado pra linha de árvore fechar
@@ -317,53 +361,88 @@ class _ProjectsRailState extends State<ProjectsRail> {
                                   selected: project.id == widget.selectedId,
                                   git: widget.remoteGitInfoOf(project.id),
                                   moveTargets: widget.moveTargetsOf(project.id),
-                                  onTap: () => widget.onSelectRemote(project.id),
-                                  onAction: (action) => widget
-                                      .onRemoteWorkspaceAction(project.id, action),
-                                  onRemove: () =>
-                                      widget.onRemoveRemoteWorkspace(project.id),
+                                  worktreeCount: widget
+                                      .worktreesOf(project.id)
+                                      .length,
+                                  hasWorktrees: widget
+                                      .worktreesOf(project.id)
+                                      .isNotEmpty,
+                                  expanded: widget.worktreesExpanded(
+                                    project.id,
+                                  ),
+                                  onTap: () => _onCardTap(
+                                    project,
+                                    () => widget.onSelectRemote(project.id),
+                                  ),
+                                  onAction: (action) =>
+                                      widget.onRemoteWorkspaceAction(
+                                        project.id,
+                                        action,
+                                      ),
+                                  onRemove: () => widget
+                                      .onRemoveRemoteWorkspace(project.id),
                                 ),
                               ),
-                              ..._remoteForks(project),
+                              _ForkList(
+                                expanded: widget.worktreesExpanded(project.id),
+                                children: _remoteForks(project),
+                              ),
                             ] else ...[
-                            _WorkspaceReorderable(
-                              projectId: project.id,
-                              title: project.name,
-                              colorValue: project.colorValue,
-                              initial: project.initial,
-                              imagePath: project.imagePath,
-                              onReorder: widget.onReorder,
-                              child: _ProjectItem(
-                                project: project,
-                                selected: project.id == widget.selectedId,
-                                notifications: widget.notificationCount(
-                                  project.id,
+                              _WorkspaceReorderable(
+                                projectId: project.id,
+                                title: project.name,
+                                colorValue: project.colorValue,
+                                initial: project.initial,
+                                imagePath: project.imagePath,
+                                onReorder: widget.onReorder,
+                                child: _ProjectItem(
+                                  project: project,
+                                  selected: project.id == widget.selectedId,
+                                  notifications: widget.notificationCount(
+                                    project.id,
+                                  ),
+                                  git: widget.gitInfo(project.id),
+                                  rootsSummary: widget.rootsSummary(project.id),
+                                  worktreeCount: widget
+                                      .worktreesOf(project.id)
+                                      .length,
+                                  // "Criar worktree" só faz sentido em repo git
+                                  // (single ou multi-root — na multi a page pede
+                                  // a root alvo antes).
+                                  canCreateWorktree:
+                                      widget.gitInfo(project.id) != null ||
+                                      widget.rootsSummary(project.id).$1 > 1,
+                                  hasWorktrees: widget
+                                      .worktreesOf(project.id)
+                                      .isNotEmpty,
+                                  expanded: widget.worktreesExpanded(
+                                    project.id,
+                                  ),
+                                  onTap: () => _onCardTap(
+                                    project,
+                                    () => widget.onSelect(project.id),
+                                  ),
+                                  onConfigure: () =>
+                                      widget.onConfigure(project),
+                                  onDelete: () => widget.onDelete(project),
+                                  roots: widget.rootsOf(project.id),
+                                  onCreateWorktree: (r) =>
+                                      widget.onCreateWorktree(project, r),
+                                  onSync: (r) => widget.onSync(project, r),
+                                  onPull: (r) => widget.onPull(project, r),
+                                  onPush: (r) => widget.onPush(project, r),
+                                  moveTargets: widget.moveTargetsOf(project.id),
+                                  onMoveToRealm: (realmId) =>
+                                      widget.onMoveToRealm(project.id, realmId),
                                 ),
-                                git: widget.gitInfo(project.id),
-                                rootsSummary: widget.rootsSummary(project.id),
-                                // "Criar worktree" só faz sentido em repo git
-                                // (single ou multi-root — na multi a page pede
-                                // a root alvo antes).
-                                canCreateWorktree:
-                                    widget.gitInfo(project.id) != null ||
-                                    widget.rootsSummary(project.id).$1 > 1,
-                                onTap: () => widget.onSelect(project.id),
-                                onConfigure: () => widget.onConfigure(project),
-                                onDelete: () => widget.onDelete(project),
-                                roots: widget.rootsOf(project.id),
-                                onCreateWorktree: (r) =>
-                                    widget.onCreateWorktree(project, r),
-                                onSync: (r) => widget.onSync(project, r),
-                                onPull: (r) => widget.onPull(project, r),
-                                onPush: (r) => widget.onPush(project, r),
-                                moveTargets: widget.moveTargetsOf(project.id),
-                                onMoveToRealm: (realmId) =>
-                                    widget.onMoveToRealm(project.id, realmId),
                               ),
-                            ),
-                            // Worktrees (forks) penduradas abaixo do workspace,
-                            // sempre expandidas (plan/42, decisões 5, 12).
-                            ..._forkItems(project),
+                              // Worktrees (forks) penduradas abaixo do workspace,
+                              // expandidas/recolhidas pelo toggle do card (V37;
+                              // antes eram sempre visíveis — plan/42, dec. 5, 12).
+                              _ForkList(
+                                expanded: widget.worktreesExpanded(project.id),
+                                children: _forkItems(project),
+                              ),
                             ],
                           ],
                         ],
@@ -403,6 +482,91 @@ class _ProjectsRailState extends State<ProjectsRail> {
       ),
     );
   }
+}
+
+/// Lista de worktrees de um workspace, animada em **altura** ao expandir e
+/// recolher (V37). Só ela anima: o card acima mantém a mesma altura o tempo
+/// todo, então nada se desloca além da lista. Recolhida por completo, os itens
+/// saem da árvore (não ficam com altura zero atrás de um clip).
+class _ForkList extends StatelessWidget {
+  const _ForkList({required this.expanded, required this.children});
+
+  final bool expanded;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    if (children.isEmpty) return const SizedBox.shrink();
+    return AnimatedSize(
+      duration: _kToggleDuration,
+      curve: Curves.easeOutCubic,
+      alignment: Alignment.topCenter,
+      child: expanded
+          ? Column(mainAxisSize: MainAxisSize.min, children: children)
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+class _WorktreeSummary extends StatelessWidget {
+  const _WorktreeSummary({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Row(
+      children: [
+        Icon(Icons.call_split, size: 12, color: colors.text3),
+        const SizedBox(width: 6),
+        Text(
+          context.t.cockpit.projectsRail.worktreeCount(n: count),
+          style: context.typo.label.copyWith(color: colors.text2),
+        ),
+      ],
+    );
+  }
+}
+
+/// Chevron do card: aponta pra direita recolhido e gira 90° ao expandir, na
+/// mesma duração da lista. Puramente indicativo — quem recebe o clique é o card
+/// inteiro, então ele não intercepta ponteiro nenhum.
+class _WorktreeChevron extends StatelessWidget {
+  const _WorktreeChevron({required this.expanded});
+
+  final bool expanded;
+
+  @override
+  Widget build(BuildContext context) {
+    final tr = context.t.cockpit.projectsRail;
+    return AppTooltip(
+      message: expanded ? tr.collapseWorktrees : tr.expandWorktrees,
+      child: AnimatedRotation(
+        turns: expanded ? 0.25 : 0.0,
+        duration: _kToggleDuration,
+        curve: Curves.easeOutCubic,
+        child: Icon(Icons.chevron_right, size: 16, color: context.colors.text3),
+      ),
+    );
+  }
+}
+
+/// Envolve um badge/chip informativo pra que o clique nele **pare** ali: sem
+/// isto o toque cairia no card e alternaria a lista de worktrees, que não é o
+/// que alguém mirando um indicador espera. Chips com ação própria
+/// ([_MultiRootBadge]) já têm o gesto deles e não passam por aqui.
+class _AbsorbCardTap extends StatelessWidget {
+  const _AbsorbCardTap({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => GestureDetector(
+    behavior: HitTestBehavior.opaque,
+    onTap: () {},
+    child: child,
+  );
 }
 
 /// Slot fixo do workspace de sistema "Cockpit": glifo de terminal + rótulo, sem
@@ -463,10 +627,19 @@ class _RemoteSlot extends StatelessWidget {
     required this.selected,
     required this.git,
     required this.moveTargets,
+    required this.worktreeCount,
+    required this.hasWorktrees,
+    required this.expanded,
     required this.onTap,
     required this.onAction,
     required this.onRemove,
   });
+
+  /// `true` se o host tem forks pendurados — só então o chevron aparece.
+  final bool hasWorktrees;
+
+  /// Estado atual da lista de forks (V37).
+  final bool expanded;
 
   final String workspaceId;
   final String name;
@@ -474,6 +647,8 @@ class _RemoteSlot extends StatelessWidget {
 
   /// Realms de destino do "Move to realm" (vazio esconde o item).
   final List<RealmTarget> moveTargets;
+
+  final int worktreeCount;
 
   /// Imagem de fundo do avatar (personalizada nas Configurações), ou `null`.
   final String? imagePath;
@@ -488,6 +663,7 @@ class _RemoteSlot extends StatelessWidget {
     final b = git?.branch;
     return (b == null || b.isEmpty) ? null : b;
   }
+
   final VoidCallback onTap;
 
   /// Ações roteadas pra página: 'pull' | 'push' | 'sync' | 'rename' | 'close'.
@@ -502,7 +678,11 @@ class _RemoteSlot extends StatelessWidget {
       items: [
         if (hasGit) ...[
           AppMenuItem(value: 'sync', label: tr.sync, icon: Icons.sync),
-          AppMenuItem(value: 'pull', label: tr.pull, icon: Icons.arrow_downward),
+          AppMenuItem(
+            value: 'pull',
+            label: tr.pull,
+            icon: Icons.arrow_downward,
+          ),
           AppMenuItem(value: 'push', label: tr.push, icon: Icons.arrow_upward),
           AppMenuItem(
             value: 'worktree',
@@ -574,75 +754,101 @@ class _RemoteSlot extends StatelessWidget {
         borderRadius: BorderRadius.circular(7),
         onTap: onTap,
         padding: const EdgeInsets.fromLTRB(9, 7, 9, 7),
-        child: Row(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            // Mesmo avatar do workspace local: imagem de fundo quando houver,
-            // senão a inicial sobre a cor. A afordância "remoto" fica no badge
-            // "SSH" à direita.
-            WorkspaceAvatar(
-              imagePath: imagePath,
-              colorValue: colorValue,
-              initial: name.isEmpty ? '?' : name.characters.first.toUpperCase(),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    name,
-                    overflow: TextOverflow.ellipsis,
-                    style: context.typo.body.copyWith(
-                      fontSize: 13.5,
-                      color: colors.text,
-                      fontWeight: selected ? FontWeight.w500 : FontWeight.w400,
+            Row(
+              children: [
+                // Mesmo avatar do workspace local: imagem de fundo quando houver,
+                // senão a inicial sobre a cor. A afordância "remoto" fica no badge
+                // "SSH" à direita.
+                WorkspaceAvatar(
+                  imagePath: imagePath,
+                  colorValue: colorValue,
+                  initial: name.isEmpty
+                      ? '?'
+                      : name.characters.first.toUpperCase(),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        name,
+                        overflow: TextOverflow.ellipsis,
+                        style: context.typo.body.copyWith(
+                          fontSize: 13.5,
+                          color: colors.text,
+                          fontWeight: selected
+                              ? FontWeight.w500
+                              : FontWeight.w400,
+                        ),
+                      ),
+                      // Mesmo badge do local: branch + contador de sujeira, quando
+                      // o git remoto já foi lido (lazy). Sem git → nada.
+                      if (git != null) ...[
+                        const SizedBox(height: 4),
+                        _AbsorbCardTap(child: _GitBadge(info: git!)),
+                      ],
+                    ],
+                  ),
+                ),
+                _AbsorbCardTap(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 5,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: accent.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Text(
+                      'SSH',
+                      style: context.typo.label.copyWith(
+                        fontSize: 9,
+                        color: accent,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
-                  // Mesmo badge do local: branch + contador de sujeira, quando
-                  // o git remoto já foi lido (lazy). Sem git → nada.
-                  if (git != null) ...[
-                    const SizedBox(height: 4),
-                    _GitBadge(info: git!),
-                  ],
-                ],
-              ),
-            ),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
-              decoration: BoxDecoration(
-                color: accent.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                'SSH',
-                style: context.typo.label.copyWith(
-                  fontSize: 9,
-                  color: accent,
-                  fontWeight: FontWeight.w600,
                 ),
-              ),
-            ),
-            const SizedBox(width: 2),
-            // Builder: o menu ancora no RenderBox do context passado a
-            // showAppMenu. Sem isto, o context do slot inteiro faria o popup
-            // abrir na largura toda (aparecia "embaixo"); com o Builder o
-            // context é o do ícone, igual ao workspace local.
-            Builder(
-              builder: (iconContext) => GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTapUp: (_) => _showMenu(iconContext),
-                child: SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: Icon(
-                    Icons.more_vert,
-                    size: 14,
-                    color: context.colors.text3,
+                if (hasWorktrees) ...[
+                  const SizedBox(width: 4),
+                  _WorktreeChevron(expanded: expanded),
+                ],
+                const SizedBox(width: 2),
+                // Builder: o menu ancora no RenderBox do context passado a
+                // showAppMenu. Sem isto, o context do slot inteiro faria o popup
+                // abrir na largura toda (aparecia "embaixo"); com o Builder o
+                // context é o do ícone, igual ao workspace local.
+                Builder(
+                  builder: (iconContext) => GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTapUp: (_) => _showMenu(iconContext),
+                    child: SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: Icon(
+                        Icons.more_vert,
+                        size: 14,
+                        color: context.colors.text3,
+                      ),
+                    ),
                   ),
                 ),
-              ),
+              ],
             ),
+            if (hasWorktrees)
+              Padding(
+                padding: const EdgeInsets.only(left: 38, top: 4),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: _WorktreeSummary(count: worktreeCount),
+                ),
+              ),
           ],
         ),
       ),
@@ -659,6 +865,9 @@ class _ProjectItem extends StatelessWidget {
     required this.rootsSummary,
     required this.roots,
     required this.canCreateWorktree,
+    required this.worktreeCount,
+    required this.hasWorktrees,
+    required this.expanded,
     required this.onTap,
     required this.onConfigure,
     required this.onDelete,
@@ -682,6 +891,15 @@ class _ProjectItem extends StatelessWidget {
   /// Roots do workspace (submenu das ações git em multi-root).
   final List<RailRoot> roots;
   final bool canCreateWorktree;
+
+  final int worktreeCount;
+
+  /// `true` se o workspace tem worktrees — só então o chevron aparece e o
+  /// clique no card alterna a lista (V37).
+  final bool hasWorktrees;
+
+  /// Estado atual da lista de worktrees (V37).
+  final bool expanded;
   final VoidCallback onTap;
   final VoidCallback onConfigure;
   final VoidCallback onDelete;
@@ -705,80 +923,104 @@ class _ProjectItem extends StatelessWidget {
         borderRadius: BorderRadius.circular(7),
         onTap: onTap,
         padding: const EdgeInsets.fromLTRB(9, 7, 5, 7),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            WorkspaceAvatar(
-              imagePath: project.imagePath,
-              colorValue: project.colorValue,
-              initial: project.initial,
-              size: 30,
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    project.name,
-                    overflow: TextOverflow.ellipsis,
-                    style: context.typo.body.copyWith(
-                      fontSize: 13.5,
-                      color: colors.text,
-                      fontWeight: selected ? FontWeight.w500 : FontWeight.w400,
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                WorkspaceAvatar(
+                  imagePath: project.imagePath,
+                  colorValue: project.colorValue,
+                  initial: project.initial,
+                  size: 30,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        project.name,
+                        overflow: TextOverflow.ellipsis,
+                        style: context.typo.body.copyWith(
+                          fontSize: 13.5,
+                          color: colors.text,
+                          fontWeight: selected
+                              ? FontWeight.w500
+                              : FontWeight.w400,
+                        ),
+                      ),
+                      // Linha do git — repo git (branch) ou multi-root (agregado);
+                      // pasta comum não mostra nada.
+                      if (gitInfo != null) ...[
+                        const SizedBox(height: 4),
+                        _AbsorbCardTap(child: _GitBadge(info: gitInfo)),
+                      ] else if (rootsSummary.$1 > 1) ...[
+                        const SizedBox(height: 4),
+                        _MultiRootBadge(
+                          roots: rootsSummary.$1,
+                          dirtyRoots: rootsSummary.$2,
+                          rootList: roots,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 6),
+                if (notifications > 0) ...[
+                  _AbsorbCardTap(
+                    child: Container(
+                      constraints: const BoxConstraints(minWidth: 18),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 6,
+                        vertical: 1,
+                      ),
+                      decoration: BoxDecoration(
+                        color: colors.accent,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        '$notifications',
+                        textAlign: TextAlign.center,
+                        style: context.typo.mono.copyWith(
+                          fontSize: 11,
+                          color: onColor(colors.accent),
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
                     ),
                   ),
-                  // Linha do git — repo git (branch) ou multi-root (agregado);
-                  // pasta comum não mostra nada.
-                  if (gitInfo != null) ...[
-                    const SizedBox(height: 4),
-                    _GitBadge(info: gitInfo),
-                  ] else if (rootsSummary.$1 > 1) ...[
-                    const SizedBox(height: 4),
-                    _MultiRootBadge(
-                      roots: rootsSummary.$1,
-                      dirtyRoots: rootsSummary.$2,
-                      rootList: roots,
-                    ),
-                  ],
+                  const SizedBox(width: 4),
                 ],
-              ),
-            ),
-            const SizedBox(width: 6),
-            if (notifications > 0) ...[
-              Container(
-                constraints: const BoxConstraints(minWidth: 18),
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-                decoration: BoxDecoration(
-                  color: colors.accent,
-                  borderRadius: BorderRadius.circular(20),
+                if (hasWorktrees) ...[
+                  _WorktreeChevron(expanded: expanded),
+                  const SizedBox(width: 2),
+                ],
+                _MenuButton(
+                  workspaceId: project.id,
+                  canCreateWorktree: canCreateWorktree,
+                  roots: roots,
+                  onConfigure: onConfigure,
+                  onDelete: onDelete,
+                  onCreateWorktree: onCreateWorktree,
+                  onSync: onSync,
+                  onPull: onPull,
+                  onPush: onPush,
+                  moveTargets: moveTargets,
+                  onMoveToRealm: onMoveToRealm,
                 ),
-                child: Text(
-                  '$notifications',
-                  textAlign: TextAlign.center,
-                  style: context.typo.mono.copyWith(
-                    fontSize: 11,
-                    color: onColor(colors.accent),
-                    fontWeight: FontWeight.w600,
-                  ),
+              ],
+            ),
+            if (hasWorktrees)
+              Padding(
+                padding: const EdgeInsets.only(left: 40, top: 4),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: _WorktreeSummary(count: worktreeCount),
                 ),
               ),
-              const SizedBox(width: 4),
-            ],
-            _MenuButton(
-              workspaceId: project.id,
-              canCreateWorktree: canCreateWorktree,
-              roots: roots,
-              onConfigure: onConfigure,
-              onDelete: onDelete,
-              onCreateWorktree: onCreateWorktree,
-              onSync: onSync,
-              onPull: onPull,
-              onPush: onPush,
-              moveTargets: moveTargets,
-              onMoveToRealm: onMoveToRealm,
-            ),
           ],
         ),
       ),

--- a/cockpit/lib/i18n/en.i18n.json
+++ b/cockpit/lib/i18n/en.i18n.json
@@ -549,7 +549,13 @@
 			"sync": "Sync",
 			"pull": "Pull",
 			"push": "Push",
-			"createWorktree": "Create worktree"
+			"createWorktree": "Create worktree",
+			"worktreeCount": {
+				"one": "1 worktree",
+				"other": "${n} worktrees"
+			},
+			"expandWorktrees": "Expand worktrees",
+			"collapseWorktrees": "Collapse worktrees"
 		},
 		"findBar": {
 			"find": "Find",

--- a/cockpit/lib/i18n/es.i18n.json
+++ b/cockpit/lib/i18n/es.i18n.json
@@ -549,7 +549,13 @@
 			"sync": "Sincronizar",
 			"pull": "Pull",
 			"push": "Push",
-			"createWorktree": "Crear worktree"
+			"createWorktree": "Crear worktree",
+			"worktreeCount": {
+				"one": "1 worktree",
+				"other": "${n} worktrees"
+			},
+			"expandWorktrees": "Expandir worktrees",
+			"collapseWorktrees": "Contraer worktrees"
 		},
 		"findBar": {
 			"find": "Buscar",

--- a/cockpit/lib/i18n/pt_BR.i18n.json
+++ b/cockpit/lib/i18n/pt_BR.i18n.json
@@ -549,7 +549,13 @@
 			"sync": "Sincronizar",
 			"pull": "Pull",
 			"push": "Push",
-			"createWorktree": "Criar worktree"
+			"createWorktree": "Criar worktree",
+			"worktreeCount": {
+				"one": "1 worktree",
+				"other": "${n} worktrees"
+			},
+			"expandWorktrees": "Expandir worktrees",
+			"collapseWorktrees": "Recolher worktrees"
 		},
 		"findBar": {
 			"find": "Buscar",

--- a/cockpit/lib/i18n/strings.g.dart
+++ b/cockpit/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 2730 (910 per locale)
+/// Strings: 2742 (914 per locale)
 ///
-/// Built on 2026-08-17 at 18:44 UTC
+/// Built on 2026-08-18 at 13:39 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/cockpit/lib/i18n/strings_en.g.dart
+++ b/cockpit/lib/i18n/strings_en.g.dart
@@ -1869,6 +1869,18 @@ class Translations$cockpit$projectsRail$en {
 
 	/// en: 'Create worktree'
 	String get createWorktree => 'Create worktree';
+
+	/// en: '(one) {1 worktree} (other) {${n} worktrees}'
+	String worktreeCount({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(n,
+		one: '1 worktree',
+		other: '${n} worktrees',
+	);
+
+	/// en: 'Expand worktrees'
+	String get expandWorktrees => 'Expand worktrees';
+
+	/// en: 'Collapse worktrees'
+	String get collapseWorktrees => 'Collapse worktrees';
 }
 
 // Path: cockpit.findBar
@@ -3964,6 +3976,9 @@ extension on Translations {
 			'cockpit.projectsRail.pull' => 'Pull',
 			'cockpit.projectsRail.push' => 'Push',
 			'cockpit.projectsRail.createWorktree' => 'Create worktree',
+			'cockpit.projectsRail.worktreeCount' => ({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(n, one: '1 worktree', other: '${n} worktrees', ), 
+			'cockpit.projectsRail.expandWorktrees' => 'Expand worktrees',
+			'cockpit.projectsRail.collapseWorktrees' => 'Collapse worktrees',
 			'cockpit.findBar.find' => 'Find',
 			'cockpit.findBar.matchCase' => 'Match case',
 			'cockpit.findBar.wholeWord' => 'Whole word',
@@ -4000,11 +4015,11 @@ extension on Translations {
 			'cockpit.tasks.toggleDebugPaint' => 'Toggle debug paint',
 			'cockpit.tasks.togglePlatform' => 'Toggle platform',
 			'cockpit.tasks.quit' => 'Quit',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.notifications.agentFinished' => 'Agent finished',
 			'cockpit.notifications.open' => 'Open',
 			'cockpit.notifications.agentNeedsAction' => 'Agent needs your input',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.notifications.agentCrashed' => 'Agent stopped unexpectedly',
 			'cockpit.terminal.cwdFallbackWarning' => ({required Object requested, required Object path}) => 'Warning: the folder "${requested}" does not exist. This terminal opened in "${path}".',
 			'cockpit.remoteHost.addHost' => 'Add remote host',

--- a/cockpit/lib/i18n/strings_es.g.dart
+++ b/cockpit/lib/i18n/strings_es.g.dart
@@ -922,6 +922,12 @@ class _Translations$cockpit$projectsRail$es extends Translations$cockpit$project
 	@override String get pull => 'Pull';
 	@override String get push => 'Push';
 	@override String get createWorktree => 'Crear worktree';
+	@override String worktreeCount({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('es'))(n,
+		one: '1 worktree',
+		other: '${n} worktrees',
+	);
+	@override String get expandWorktrees => 'Expandir worktrees';
+	@override String get collapseWorktrees => 'Contraer worktrees';
 }
 
 // Path: cockpit.findBar
@@ -2150,6 +2156,9 @@ extension on TranslationsEs {
 			'cockpit.projectsRail.pull' => 'Pull',
 			'cockpit.projectsRail.push' => 'Push',
 			'cockpit.projectsRail.createWorktree' => 'Crear worktree',
+			'cockpit.projectsRail.worktreeCount' => ({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('es'))(n, one: '1 worktree', other: '${n} worktrees', ), 
+			'cockpit.projectsRail.expandWorktrees' => 'Expandir worktrees',
+			'cockpit.projectsRail.collapseWorktrees' => 'Contraer worktrees',
 			'cockpit.findBar.find' => 'Buscar',
 			'cockpit.findBar.matchCase' => 'Coincidir mayúsculas',
 			'cockpit.findBar.wholeWord' => 'Palabra completa',
@@ -2186,11 +2195,11 @@ extension on TranslationsEs {
 			'cockpit.tasks.toggleDebugPaint' => 'Alternar debug paint',
 			'cockpit.tasks.togglePlatform' => 'Alternar plataforma',
 			'cockpit.tasks.quit' => 'Salir',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.notifications.agentFinished' => 'El agente terminó',
 			'cockpit.notifications.open' => 'Abrir',
 			'cockpit.notifications.agentNeedsAction' => 'El agente necesita tu acción',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.notifications.agentCrashed' => 'El agente se detuvo inesperadamente',
 			'cockpit.terminal.cwdFallbackWarning' => ({required Object requested, required Object path}) => 'Aviso: la carpeta "${requested}" no existe. Esta terminal se abrió en "${path}".',
 			'cockpit.remoteHost.addHost' => 'Añadir host remoto',

--- a/cockpit/lib/i18n/strings_pt_BR.g.dart
+++ b/cockpit/lib/i18n/strings_pt_BR.g.dart
@@ -922,6 +922,12 @@ class _Translations$cockpit$projectsRail$pt_BR extends Translations$cockpit$proj
 	@override String get pull => 'Pull';
 	@override String get push => 'Push';
 	@override String get createWorktree => 'Criar worktree';
+	@override String worktreeCount({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('pt'))(n,
+		one: '1 worktree',
+		other: '${n} worktrees',
+	);
+	@override String get expandWorktrees => 'Expandir worktrees';
+	@override String get collapseWorktrees => 'Recolher worktrees';
 }
 
 // Path: cockpit.findBar
@@ -2150,6 +2156,9 @@ extension on TranslationsPtBr {
 			'cockpit.projectsRail.pull' => 'Pull',
 			'cockpit.projectsRail.push' => 'Push',
 			'cockpit.projectsRail.createWorktree' => 'Criar worktree',
+			'cockpit.projectsRail.worktreeCount' => ({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('pt'))(n, one: '1 worktree', other: '${n} worktrees', ), 
+			'cockpit.projectsRail.expandWorktrees' => 'Expandir worktrees',
+			'cockpit.projectsRail.collapseWorktrees' => 'Recolher worktrees',
 			'cockpit.findBar.find' => 'Buscar',
 			'cockpit.findBar.matchCase' => 'Diferenciar maiúsculas',
 			'cockpit.findBar.wholeWord' => 'Palavra inteira',
@@ -2186,11 +2195,11 @@ extension on TranslationsPtBr {
 			'cockpit.tasks.toggleDebugPaint' => 'Alternar debug paint',
 			'cockpit.tasks.togglePlatform' => 'Alternar plataforma',
 			'cockpit.tasks.quit' => 'Sair',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.notifications.agentFinished' => 'Agente terminou',
 			'cockpit.notifications.open' => 'Abrir',
 			'cockpit.notifications.agentNeedsAction' => 'Agente precisa de você',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.notifications.agentCrashed' => 'Agente parou inesperadamente',
 			'cockpit.terminal.cwdFallbackWarning' => ({required Object requested, required Object path}) => 'Aviso: a pasta "${requested}" não existe. Este terminal abriu em "${path}".',
 			'cockpit.remoteHost.addHost' => 'Adicionar host remoto',

--- a/cockpit/test/ui/worktrees_toggle_test.dart
+++ b/cockpit/test/ui/worktrees_toggle_test.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:cockpit/app/cockpit/data/repositories/json_workspace_layout_store.dart';
+import 'package:cockpit/app/cockpit/ui/states/pane_node.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/projects_rail.dart';
+import 'package:cockpit/app/core/data/setup/json_state_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Toggle de worktrees no card do workspace (V37): a regra do clique e a
+/// persistência do estado dentro do **documento de layout** já existente.
+void main() {
+  group('worktreesExpandedOf', () {
+    test('workspace sem layout salvo nasce expandido', () {
+      // Default do rail desde sempre — recolher precisa ser escolha explícita.
+      expect(worktreesExpandedOf(null), isTrue);
+    });
+
+    test('layout antigo (sem a chave) continua expandido', () {
+      expect(worktreesExpandedOf(const {'v': 1, 'tree': {}}), isTrue);
+    });
+
+    test('valor de tipo errado cai no default em vez de estourar', () {
+      // Doc editado à mão / gravado por versão futura não pode quebrar o boot.
+      expect(worktreesExpandedOf(const {kWorktreesExpandedKey: 'no'}), isTrue);
+    });
+
+    test('lê o estado gravado', () {
+      expect(
+        worktreesExpandedOf(const {kWorktreesExpandedKey: false}),
+        isFalse,
+      );
+      expect(worktreesExpandedOf(const {kWorktreesExpandedKey: true}), isTrue);
+    });
+  });
+
+  group('round-trip no WorkspaceLayoutStore', () {
+    late Directory tmp;
+    late JsonStateStore store;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('worktrees_toggle_test');
+      store = await JsonStateStore.open(tmp.path, 'layouts');
+    });
+
+    tearDown(() async {
+      JsonStateStore.resetCacheForTesting();
+      await tmp.delete(recursive: true);
+    });
+
+    test('recolhido sobrevive ao save/load (sem storage paralelo)', () async {
+      final layouts = JsonWorkspaceLayoutStore(store);
+      await layouts.save('p1', <String, dynamic>{
+        'v': 1,
+        'tree': <String, dynamic>{
+          'k': 'leaf',
+          'id': 'l1',
+          'tabs': <String>[],
+          'active': 'l1',
+        },
+        'sessions': <String, dynamic>{},
+        kWorktreesExpandedKey: false,
+      });
+
+      final reloaded = await layouts.load('p1');
+      expect(worktreesExpandedOf(reloaded), isFalse);
+      // O doc segue sendo o layout — o toggle é só mais um campo dele.
+      expect(reloaded!['tree'], isA<Map<dynamic, dynamic>>());
+    });
+
+    test(
+      'expandido sobrevive e o workspace sem doc volta ao default',
+      () async {
+        final layouts = JsonWorkspaceLayoutStore(store);
+        await layouts.save('p1', <String, dynamic>{
+          'v': 1,
+          kWorktreesExpandedKey: true,
+        });
+        expect(worktreesExpandedOf(await layouts.load('p1')), isTrue);
+        expect(worktreesExpandedOf(await layouts.load('nunca-salvo')), isTrue);
+      },
+    );
+  });
+
+  group('workspaceCardTap', () {
+    test('não selecionado: seleciona e abre a lista', () {
+      final action = workspaceCardTap(
+        selected: false,
+        expanded: false,
+        hasWorktrees: true,
+      );
+      expect(action.select, isTrue);
+      expect(action.expand, isTrue);
+    });
+
+    test('não selecionado e já expandido: seleciona e mantém aberto', () {
+      // Selecionar nunca RECOLHE — seria perder a lista sem pedir.
+      final action = workspaceCardTap(
+        selected: false,
+        expanded: true,
+        hasWorktrees: true,
+      );
+      expect(action.select, isTrue);
+      expect(action.expand, isTrue);
+    });
+
+    test('já selecionado: o clique só alterna', () {
+      expect(
+        workspaceCardTap(selected: true, expanded: true, hasWorktrees: true),
+        (select: false, expand: false),
+      );
+      expect(
+        workspaceCardTap(selected: true, expanded: false, hasWorktrees: true),
+        (select: false, expand: true),
+      );
+    });
+
+    test('sem worktrees: nunca mexe no estado da lista', () {
+      // Sem fork não há chevron nem lista; gravar um estado aqui só sujaria o
+      // layout de workspaces que nunca vão mostrar nada.
+      expect(
+        workspaceCardTap(selected: false, expanded: true, hasWorktrees: false),
+        (select: true, expand: null),
+      );
+      expect(
+        workspaceCardTap(selected: true, expanded: true, hasWorktrees: false),
+        (select: false, expand: null),
+      );
+    });
+  });
+}

--- a/cockpit/test/ui/worktrees_toggle_test.dart
+++ b/cockpit/test/ui/worktrees_toggle_test.dart
@@ -5,6 +5,7 @@ import 'package:cockpit/app/cockpit/ui/states/pane_node.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/projects_rail.dart';
 import 'package:cockpit/app/core/data/setup/json_state_store.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
 
 /// Toggle de worktrees no card do workspace (V37): a regra do clique e a
 /// persistência do estado dentro do **documento de layout** já existente.
@@ -125,6 +126,16 @@ void main() {
         workspaceCardTap(selected: true, expanded: true, hasWorktrees: false),
         (select: false, expand: null),
       );
+    });
+  });
+
+  group('worktreeChevronIcon', () {
+    test('aponta para a direita quando recolhido', () {
+      expect(worktreeChevronIcon(false), Icons.chevron_right);
+    });
+
+    test('aponta para baixo quando expandido', () {
+      expect(worktreeChevronIcon(true), Icons.keyboard_arrow_down);
     });
   });
 }


### PR DESCRIPTION
## Owner

@jacobaraujo7 — owner do projeto, para revisão.

## Motivação

Workspaces com muitas worktrees ocupavam toda a altura do navigation rail. O rail agora permite controlar a densidade por workspace sem perder a seleção rápida nem as ações existentes.

## Antes x depois

Antes — worktrees sempre expandidas:
![Navigation rail antes](https://gist.githubusercontent.com/fabiojansenbr/c244b7b38be904d57f1a7ff215ffdbf4/raw/478bc63d7ce4aabb39d58e2593c431425c5db527/navigation-rail-before.jpg)

Depois — worktrees recolhíveis por workspace:
![Navigation rail depois](https://gist.githubusercontent.com/fabiojansenbr/c244b7b38be904d57f1a7ff215ffdbf4/raw/ab040a7ce5ae881d173b891c89c4f2c601dcbd65/navigation-rail-after.jpg)

- Cada workspace expande/recolhe suas worktrees independentemente.
- Clique em workspace não selecionado seleciona e expande.
- Clique em workspace já selecionado alterna a lista.
- Chevron aponta para a direita recolhido e para baixo expandido.
- Chevron e lista animam em 150ms.
- Quantidade de worktrees aparece no card.
- Kebab e badges não propagam o toggle.
- Estado persiste no layout existente por workspace.
- Workspaces locais e remotos são suportados.

## Validação

- `flutter build windows` passou em Release.
- Testes focados do toggle e do rail passaram.
- `flutter analyze lib ...` sem erros; apenas infos preexistentes.
- Suíte completa: 1023 passaram, 5 ignorados e 16 falhas preexistentes em terminal/xterm/menu.

## Commits

- `9eba8c1 feat(cockpit): toggle worktrees per workspace`
- `1dddd32 fix(cockpit): show downward worktree chevron`
- `d72eb3b` sincroniza a branch com `origin/main` e resolve os conflitos.