### PR TITLE
fix(cockpit): keep the app responsive under terminal output pressure

### DIFF
--- a/cockpit/packages/cockpit_server/lib/src/remote_server.dart
+++ b/cockpit/packages/cockpit_server/lib/src/remote_server.dart
@@ -10,6 +10,24 @@ class _RpcUnknown implements Exception {
   final String method;
 }
 
+/// Converts a wire-level PTY open request into the host-side spawn spec.
+/// Keeping the mapping in one function prevents flow-control options from
+/// being lost when the request crosses the server boundary.
+PtySpawnSpec ptySpawnSpecFromOpen(PtyOpen message, {String? statusSocketPath}) {
+  final environment = statusSocketPath == null
+      ? message.environment
+      : {...message.environment, 'COCKPIT_STATUS_SOCK': statusSocketPath};
+  return PtySpawnSpec(
+    executable: message.executable,
+    arguments: message.arguments,
+    workingDirectory: message.workingDirectory,
+    environment: environment,
+    rows: message.rows,
+    columns: message.columns,
+    flowControlled: message.flowControlled,
+  );
+}
+
 /// Servidor do protocolo Cockpit Remote sobre socket local (UDS).
 ///
 /// Sessões pertencem ao [TerminalService], não às conexões: um cliente que
@@ -185,21 +203,8 @@ class _Connection {
           // servidor, que reenvia o turno pelo protocolo (Wave G). O env do
           // cliente NÃO sobrescreve isto (o socket do cliente é inalcançável do
           // host).
-          final env = _statusSocketPath == null
-              ? message.environment
-              : {
-                  ...message.environment,
-                  'COCKPIT_STATUS_SOCK': _statusSocketPath!,
-                };
           final info = await _terminals.open(
-            PtySpawnSpec(
-              executable: message.executable,
-              arguments: message.arguments,
-              workingDirectory: message.workingDirectory,
-              environment: env,
-              rows: message.rows,
-              columns: message.columns,
-            ),
+            ptySpawnSpecFromOpen(message, statusSocketPath: _statusSocketPath),
           );
           // Ecoa o `rid`: é ele que diz ao cliente QUAL `pty.open` esta
           // resposta atende. Sem isso, dois opens simultâneos casavam com a

--- a/cockpit/packages/cockpit_server/test/remote_server_test.dart
+++ b/cockpit/packages/cockpit_server/test/remote_server_test.dart
@@ -1,0 +1,38 @@
+import 'package:cockpit_protocol/cockpit_protocol.dart';
+import 'package:cockpit_server/cockpit_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('preserves flow control when mapping a PTY open request', () {
+    final spec = ptySpawnSpecFromOpen(
+      const PtyOpen(
+        executable: 'powershell.exe',
+        arguments: ['-NoProfile'],
+        environment: {'COCKPIT_PANE_ID': 't1'},
+        rows: 40,
+        columns: 120,
+        flowControlled: true,
+      ),
+      statusSocketPath: r'C:\tmp\status.sock',
+    );
+
+    expect(spec.executable, 'powershell.exe');
+    expect(spec.arguments, ['-NoProfile']);
+    expect(spec.rows, 40);
+    expect(spec.columns, 120);
+    expect(spec.flowControlled, isTrue);
+    expect(spec.environment, {
+      'COCKPIT_PANE_ID': 't1',
+      'COCKPIT_STATUS_SOCK': r'C:\tmp\status.sock',
+    });
+  });
+
+  test('keeps an unthrottled request unthrottled', () {
+    final spec = ptySpawnSpecFromOpen(
+      const PtyOpen(executable: 'cmd.exe', flowControlled: false),
+    );
+
+    expect(spec.flowControlled, isFalse);
+    expect(spec.environment, isEmpty);
+  });
+}

--- a/cockpit/test/session/pty_output_coalescer_test.dart
+++ b/cockpit/test/session/pty_output_coalescer_test.dart
@@ -119,6 +119,51 @@ void main() {
     }
   });
 
+  test('cinco terminais concorrentes não monopolizam um frame', () {
+    final frames = _ManualFrames();
+    final scheduler = _scheduler(
+      frames,
+      maxCharsPerFrame: 20,
+      maxSliceChars: 4,
+    );
+    final outputs = List.generate(5, (_) => StringBuffer());
+    final workPerFrame = <int, int>{};
+    var frame = 0;
+    final sources = List.generate(
+      outputs.length,
+      (index) => PtyOutputCoalescer(
+        scheduler: scheduler,
+        onFlush: (slice) {
+          outputs[index].write(slice);
+          workPerFrame.update(
+            frame,
+            (value) => value + slice.length,
+            ifAbsent: () => slice.length,
+          );
+        },
+        onAcknowledge: () {},
+      )..add('abcdefghijkl'),
+    );
+
+    while (frames.callbacks.isNotEmpty) {
+      frame++;
+      frames.run();
+      expect(workPerFrame[frame], lessThanOrEqualTo(20));
+      if (frame == 1) {
+        expect(outputs.every((buffer) => buffer.length == 4), isTrue);
+      }
+    }
+
+    expect(
+      outputs.map((buffer) => buffer.toString()),
+      everyElement('abcdefghijkl'),
+    );
+    expect(scheduler.pendingChars, 0);
+    for (final source in sources) {
+      source.dispose();
+    }
+  });
+
   test('budget de tempo adia fontes restantes sem perder dados', () {
     final frames = _ManualFrames();
     var now = 0;


### PR DESCRIPTION
## Owner

@jacobaraujo7 — owner do projeto, para revisão.

## Problema

Quando um agente gera muita saída, especialmente com múltiplos subagentes, o terminal pode consumir o isolate principal do Flutter. O PTY precisa aplicar backpressure fim a fim para que a UI continue responsiva.

## Correção

- O servidor agora preserva `PtyOpen.flowControlled` ao criar o `PtySpawnSpec` do host.
- Adicionado teste de regressão para garantir que a janela de créditos não seja perdida no limite do servidor.
- Adicionado teste do scheduler com cinco fontes concorrentes, cobrindo o cenário de cinco subagentes.
- O PR não altera o navigation rail nem adiciona imagens ao projeto.

## Benchmarks

- Scheduler: cinco fontes respeitaram o budget global de 20 caracteres por frame e terminaram sem backlog.
- Harness Windows PTY: `T2 PASS` reproduziu o código antigo bloqueando (`0/50 writes em 5s`).
- Harness Windows PTY: `T3 PASS`, 500 escritas de 4 KB; total `0,9 ms`, pior chamada `0,09 ms`.
- Benchmark Windows resume: invariantes passaram; burst efetivo `1000 → 2` e pico de concorrência `1000 → 1`.

## Validação

- `dart test` em `packages/cockpit_server`: 2 testes passaram.
- `flutter test test/session/pty_output_coalescer_test.dart`: 9 testes passaram.
- `dart analyze` do `cockpit_server`: sem issues.
- `flutter analyze` do app: sem erros; apenas infos preexistentes.
- `flutter build windows --release --no-pub`: passou em 53,8s.

## Commit

`0f03de0 fix(cockpit): preserve terminal flow control`