### PR TITLE
fix(cockpit): preservar alterações locais e arquivos não rastreados ao criar worktree

### DIFF
--- a/cockpit/lib/app/cockpit/data/filesystem/worktree_manager_impl.dart
+++ b/cockpit/lib/app/cockpit/data/filesystem/worktree_manager_impl.dart
@@ -234,12 +234,8 @@ class WorktreeManagerImpl implements WorktreeManager {
             }
           }
           if (copyUntracked) {
-            final untracked = await _listGitFiles(git, repoPath, [
-              'ls-files',
-              '--others',
-              '--exclude-standard',
-            ]);
-            for (final f in untracked) {
+            final changed = await _listUntrackedAndModifiedFiles(git, repoPath);
+            for (final f in changed) {
               if (!f.startsWith('$worktreesSubdir/') &&
                   !f.startsWith('.pi/remote/worktrees/') &&
                   !f.startsWith('.git/')) {
@@ -287,6 +283,47 @@ class WorktreeManagerImpl implements WorktreeManager {
       output: controller.stream,
       result: resultCompleter.future,
     );
+  }
+
+  Future<List<String>> _listUntrackedAndModifiedFiles(
+    String git,
+    String repoPath,
+  ) async {
+    try {
+      final res = await Process.run(git, [
+        '-C',
+        repoPath,
+        'status',
+        '--porcelain=v1',
+        '-z',
+        '-uall',
+      ]);
+      if (res.exitCode != 0) return const [];
+      final stdout = res.stdout as String;
+      if (stdout.isEmpty) return const [];
+      final tokens = stdout.split('\u0000');
+      final result = <String>[];
+      for (var i = 0; i < tokens.length; i++) {
+        final token = tokens[i];
+        if (token.length < 4) continue;
+        final x = token[0];
+        final y = token[1];
+        var path = token.substring(3);
+        // Rename/copy no index ou worktree tem o path anterior no próximo token NUL
+        if (x == 'R' || x == 'C' || y == 'R' || y == 'C') {
+          i++;
+        }
+        if (path.endsWith('/')) {
+          path = path.substring(0, path.length - 1);
+        }
+        if (path.isNotEmpty) {
+          result.add(path);
+        }
+      }
+      return result;
+    } catch (_) {
+      return const [];
+    }
   }
 
   Future<List<String>> _listGitFiles(
@@ -337,6 +374,11 @@ class WorktreeManagerImpl implements WorktreeManager {
         if (await srcFile.exists()) {
           await srcFile.copy(dest);
           count++;
+        } else {
+          final destFile = File(dest);
+          if (await destFile.exists()) {
+            await destFile.delete();
+          }
         }
       } catch (e) {
         await _emit(controller, 'Warning: failed to copy $relPath: $e');

--- a/cockpit/test/data/worktree_manager_impl_test.dart
+++ b/cockpit/test/data/worktree_manager_impl_test.dart
@@ -216,7 +216,7 @@ void main() {
     );
   });
 
-  test('add com copyIgnored e copyUntracked copia os arquivos corretos', () async {
+  test('add com copyIgnored e copyUntracked copia os arquivos corretos e preserva alterações locais em rastreados', () async {
     if (!await gitAvailable()) {
       markTestSkipped('git não disponível no ambiente');
       return;
@@ -233,7 +233,17 @@ void main() {
     final untrackedFile = File('${repo.path}/untracked.txt');
     await untrackedFile.writeAsString('untracked content');
 
-    // 3. Cria worktree com cópia ativada
+    // 3. Modifica um arquivo já rastreado no git (alteração local não commitada)
+    await File('${repo.path}/README.md').writeAsString('hello modified locally');
+
+    // 4. Cria outro arquivo rastreado e adiciona ao stage (staged)
+    await File('${repo.path}/staged.txt').writeAsString('initial staged');
+    await git(['add', 'staged.txt']);
+    await git(['commit', '-m', 'add staged.txt']);
+    await File('${repo.path}/staged.txt').writeAsString('staged change');
+    await git(['add', 'staged.txt']);
+
+    // 5. Cria worktree com cópia ativada
     final run = manager.add(
       repo.path,
       'feat/copy-enabled',
@@ -252,8 +262,14 @@ void main() {
     expect(File('${wt.path}/.env').readAsStringSync(), 'SECRET=123');
     expect(File('${wt.path}/untracked.txt').existsSync(), isTrue);
     expect(File('${wt.path}/untracked.txt').readAsStringSync(), 'untracked content');
+    // Verifica que a alteração local do arquivo rastreado foi copiada para o novo worktree
+    expect(File('${wt.path}/README.md').existsSync(), isTrue);
+    expect(File('${wt.path}/README.md').readAsStringSync(), 'hello modified locally');
+    // Verifica que a alteração staged também foi copiada
+    expect(File('${wt.path}/staged.txt').existsSync(), isTrue);
+    expect(File('${wt.path}/staged.txt').readAsStringSync(), 'staged change');
 
-    // 4. Cria outra worktree com cópias desativadas
+    // 6. Cria outra worktree com cópias desativadas
     final runDisabled = manager.add(
       repo.path,
       'feat/copy-disabled',
@@ -270,5 +286,9 @@ void main() {
 
     expect(File('${wtDisabled.path}/.env').existsSync(), isFalse);
     expect(File('${wtDisabled.path}/untracked.txt').existsSync(), isFalse);
+    // Com cópia desativada, o arquivo rastreado mantém o conteúdo do commit base
+    expect(File('${wtDisabled.path}/README.md').existsSync(), isTrue);
+    expect(File('${wtDisabled.path}/README.md').readAsStringSync(), 'hello');
+    expect(File('${wtDisabled.path}/staged.txt').readAsStringSync(), 'initial staged');
   });
 }


### PR DESCRIPTION
## Descrição

Corrige o comportamento da opção de copiar arquivos não rastreados durante a criação de um novo worktree no Cockpit.

Anteriormente, ao habilitar essa opção nas configurações avançadas, apenas arquivos totalmente novos (*untracked*) eram copiados (`git ls-files --others`). Arquivos já rastreados pelo Git que possuíam alterações locais não commitadas (*staged* ou *unstaged*) eram ignorados, fazendo com que o novo worktree recebesse apenas o estado já commitado do arquivo.

## Alterações Realizadas

- **Listagem de alterações locais (`_listUntrackedAndModifiedFiles`)**: Atualizada a enumeração de arquivos para utilizar `git status --porcelain=v1 -z -uall`, cobrindo:
  - Arquivos não rastreados (*untracked*).
  - Arquivos rastreados com alterações locais (*modified*, *staged*, *added*, *renamed*).
  - Parsing seguro com separador NUL (`-z`) para evitar problemas com caminhos contendo caracteres especiais e espaços.
- **Sincronização do diretório de trabalho (`_copyFiles`)**:
  - Sobrescreve arquivos modificados no novo worktree com o conteúdo atual do diretório de trabalho de origem.
  - Remove arquivos no destino caso tenham sido deletados localmente na origem.
- **Testes automatizados**:
  - Atualizado teste em `cockpit/test/data/worktree_manager_impl_test.dart` cobrindo cenários com arquivos rastreados modificados (*unstaged* e *staged*), arquivos untracked e verificação de integridade quando a opção está desativada.