### PR TITLE
fix(extension): make agent-network skill filterable

### DIFF
--- a/pi-extension/README.md
+++ b/pi-extension/README.md
@@ -177,9 +177,10 @@ Requirements: Node 20+, Pi (the host coding agent).
 pi install npm:remote-pi
 ```
 
-The extension self-registers the `/remote-pi` slash command and deploys an
+The extension self-registers the `/remote-pi` slash command and bundles an
 agent skill that teaches the LLM how to use `list_peers`, `agent_send`, and the
-event-driven inbox/reply flow.
+event-driven inbox/reply flow. The skill is declared as a Pi package resource,
+so it can be disabled independently with `pi config` or `pi --no-skills`.
 
 To verify:
 
@@ -598,7 +599,6 @@ with a `[<cwd>]` prefix, so a single log stream shows every agent.
 | `~/.pi/remote/config.json` | Per-user | `relay` URL |
 | `~/.pi/remote/peers.json` | Per-machine | Paired mobile devices |
 | `~/.pi/remote/sessions/<name>/` | Per-session | Broker socket + `audit.jsonl` |
-| `~/.pi/remote/skills/agent-network/SKILL.md` | Per-user | Agent skill the LLM reads |
 
 Override the relay for a single run without persisting:
 

--- a/pi-extension/package.json
+++ b/pi-extension/package.json
@@ -35,6 +35,9 @@
     "extensions": [
       "./dist"
     ],
+    "skills": [
+      "./skills"
+    ],
     "image": "https://raw.githubusercontent.com/jacobaraujo7/remote_pi/main/branding/banner.png"
   },
   "author": "Jacob Moura <jacobmoura7@gmail.com>",

--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -243,17 +243,18 @@ const { acquireCwdLock } = await import("./session/cwd_lock.js");
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeMockPi(): { pi: ExtensionAPI; registeredCommands: string[] } {
+function makeMockPi(): { pi: ExtensionAPI; registeredCommands: string[]; registeredEvents: string[] } {
   const registeredCommands: string[] = [];
+  const registeredEvents: string[] = [];
   const pi = {
-    on: () => undefined,
+    on(event: string) { registeredEvents.push(event); },
     registerCommand(name: string, _opts: unknown) { registeredCommands.push(name); },
     registerTool: () => undefined, registerShortcut: () => undefined,
     registerFlag: () => undefined, getFlag: () => undefined,
     registerMessageRenderer: () => undefined,
     sendMessage: () => undefined, sendUserMessage: () => undefined,
   } as unknown as ExtensionAPI;
-  return { pi, registeredCommands };
+  return { pi, registeredCommands, registeredEvents };
 }
 
 function makeMockCtx(cwd = "/home/user/projects/remote_pi") {
@@ -321,6 +322,19 @@ const OTHER_OWNER_STANDARD_FIXTURE = OTHER_OWNER_PUBLIC_FIXTURE.toString("base64
 describe("extension default export", () => {
   test("is an ExtensionFactory function", () => {
     expect(typeof extension).toBe("function");
+  });
+
+  test("declares the agent skill as a filterable Pi package resource", () => {
+    const packagePath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+    const packageJson = JSON.parse(readFileSync(packagePath, "utf8")) as {
+      pi?: { skills?: string[] };
+    };
+    const { pi, registeredEvents } = makeMockPi();
+
+    (extension as ExtensionFactory)(pi);
+
+    expect(packageJson.pi?.skills).toEqual(["./skills"]);
+    expect(registeredEvents).not.toContain("resources_discover");
   });
 
   test("registers the user-facing commands (post plan/26 W3: + install/uninstall)", () => {

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -110,7 +110,7 @@ import { runSetupWizard, type WizardUI } from "./session/setup_wizard.js";
 import { updateFooter, type FooterState } from "./ui/footer.js";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { chmodSync, mkdtempSync, mkdirSync, copyFileSync, existsSync, unlinkSync, readFileSync, writeFileSync, realpathSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, existsSync, unlinkSync, readFileSync, writeFileSync, realpathSync } from "node:fs";
 import { createInterface } from "node:readline";
 import { spawnSync } from "node:child_process";
 import { hostname, tmpdir } from "node:os";
@@ -2083,18 +2083,15 @@ const extension: ExtensionFactory = (pi: ExtensionAPI): void => {
   _extensionUiBridge?.dispose();
   _extensionUiBridge = createExtensionUiBridge(pi, _broadcastToActive);
 
-  // Plano 19: ensure ~/.pi/remote/{sessions,skills}/ exist and deploy the
-  // agent-network skill on first load. resources_discover lets Pi find it.
+  // Plano 19: ensure ~/.pi/remote/{sessions,skills}/ directories exist. Pi loads the
+  // packaged agent-network skill through the package manifest.
   try {
     ensureGlobalDirs();
-    _deployAgentNetworkSkill();
   } catch { /* best-effort init */ }
 
   // Seed the global-pairings cache from peers.json so the footer can show
   // 🟢/🟡 correctly the moment the relay is up (no race with first refresh).
   _refreshPairingsCache();
-
-  pi.on("resources_discover", () => ({ skillPaths: [skillsDir()] }));
 
   // Plano 20: agent_send + agent_request tools so the LLM can drive the
   // session network natively. Getter captures `_meshNode` live so the
@@ -3995,45 +3992,6 @@ function _cmdUninstall(ctx: Pick<ExtensionContext, "ui">, opts: { linkCli?: bool
 
 // ── Agent-network commands (plano 19) ─────────────────────────────────────────
 
-function _resolveExtensionDir(): string {
-  // dist/index.js → dist; skills sit at <extensionRoot>/skills/. When we run
-  // from src/ via tsx (dev), index.ts is in src/ and skills/ is sibling. We
-  // detect by checking both locations.
-  const here = fileURLToPath(import.meta.url);
-  // dist/index.js or src/index.ts → parent = <dist or src>; sibling = ../skills
-  const parent = here.replace(/\/[^/]+$/, "");
-  const candidateA = join(parent, "..", "skills"); // dist → ../skills
-  const candidateB = join(parent, "skills");        // src → skills
-  if (existsSync(candidateA)) return parent.replace(/\/dist$/, "");
-  if (existsSync(candidateB)) return parent;
-  return parent;
-}
-
-function _deployAgentNetworkSkill(): void {
-  // Pi SDK spec (core/skills.js): every skill must live at
-  //   <skillsRoot>/<skill-name>/SKILL.md
-  // The skill `name:` frontmatter must equal the parent directory name. We
-  // ship the source pre-arranged that way so deploy is a straight copy into
-  // ~/.pi/remote/skills/agent-network/SKILL.md.
-  const root = _resolveExtensionDir();
-  const src1 = join(root, "skills", "agent-network", "SKILL.md");
-  const src2 = join(root, "..", "skills", "agent-network", "SKILL.md");
-  const src = existsSync(src1) ? src1 : (existsSync(src2) ? src2 : null);
-  if (!src) return;
-  const dstDir = join(skillsDir(), "agent-network");
-  const dst = join(dstDir, "SKILL.md");
-  try {
-    mkdirSync(dstDir, { recursive: true });
-    copyFileSync(src, dst);
-    // Cleanup legacy deploy at ~/.pi/remote/skills/agent-network.md (flat
-    // layout, fails the Pi SDK's name-vs-parent-dir validation).
-    const legacy = join(skillsDir(), "agent-network.md");
-    if (existsSync(legacy)) {
-      try { unlinkSync(legacy); } catch { /* ignored */ }
-    }
-  } catch { /* best-effort */ }
-}
-
 /**
  * Inject text into the agent as a user message, waking a turn. The Pi SDK's
  * `ExtensionAPI.sendUserMessage` is fire-and-forget (returns `void`) and
@@ -5283,8 +5241,9 @@ if (_isDirectRun()) {
 /**
  * Resolve the packaged agent-network skill path
  * (`<pkgRoot>/skills/agent-network/SKILL.md`). Single source of truth shared
- * by both runtimes: Pi discovers it via `resources_discover`, and the Claude
- * launcher injects it as a system prompt (see `_cmdClaudeCli`). Returns null
+ * by both runtimes: Pi discovers it through the package manifest, and the
+ * Claude launcher injects it as a system prompt (see `_cmdClaudeCli`).
+ * Returns null
  * if the file is missing (e.g. running before `pnpm build`).
  */
 function _agentNetworkSkillPath(): string | null {


### PR DESCRIPTION
## Summary

- declare `agent-network` through the Pi package manifest
- remove runtime `resources_discover` injection and the copied `~/.pi/remote/skills` deployment
- document that the skill can be disabled with `pi config` or `pi --no-skills`
- add a regression test for the package-resource contract

## Problem

The extension currently returns `~/.pi/remote/skills` from a `resources_discover` handler. Pi adds extension-contributed paths after its normal package filtering, so both of these still load `agent-network`:

```json
{ "source": "npm:remote-pi", "skills": [] }
```

```bash
pi --no-skills
```

Declaring the shipped `skills/` directory in `package.json` routes it through Pi's normal package resource resolution instead. This also avoids copying a second copy into the user's home directory.

## Verification

- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test` — 799 passed, 3 skipped
- `corepack pnpm pack --dry-run` includes `skills/agent-network/SKILL.md`
