### PR TITLE
fix(cockpit): corrigir encoding de arquivos no editor

### DIFF
--- a/cockpit/lib/app/cockpit/data/filesystem/file_reader_impl.dart
+++ b/cockpit/lib/app/cockpit/data/filesystem/file_reader_impl.dart
@@ -71,21 +71,55 @@ class FileReaderImpl implements FileReader {
     // Banco sqlite (magic header) nunca é texto útil — não abre como viewer;
     // ele aparece como conexão "detected" no painel Database (plano 51).
     if (_isSqlite(bytes)) return const FileViewUnsupported();
-    // UTF-8 tolerante: bytes inválidos (latin-1, binário) viram U+FFFD em vez
-    // de barrar o arquivo. Decisão explícita — abrir qualquer coisa como texto.
-    final text = utf8.decode(bytes, allowMalformed: true);
 
-    if (_markdown.contains(ext)) return FileViewMarkdown(text);
+    // Detecta o encoding real: tenta UTF-8 estrito primeiro; se falhar (bytes
+    // inválidos em UTF-8), usa Latin-1 — que mapeia cada byte 1:1 a um
+    // codepoint Unicode, preservando todos os bytes sem perda.
+    //
+    // Não usamos allowMalformed: isso convertiria bytes inválidos para U+FFFD
+    // (3 bytes em UTF-8), e salvar de volta produziria um arquivo diferente
+    // mesmo sem nenhuma edição (diff artificial no Git).
+    final (text, encoding) = _decodeBytes(bytes);
+
+    if (_markdown.contains(ext)) {
+      return FileViewMarkdown(text, encoding: encoding);
+    }
     // SVG é texto (XML) que também renderiza — fonte editável + preview.
-    if (ext == 'svg') return FileViewSvg(path, text);
-    return FileViewText(text, language: ext.isEmpty ? null : ext);
+    if (ext == 'svg') return FileViewSvg(path, text, encoding: encoding);
+    return FileViewText(text, language: ext.isEmpty ? null : ext, encoding: encoding);
+  }
+
+  /// Decodifica [bytes] detectando o encoding:
+  /// - UTF-8 estrito → retorna `(text, utf8)`
+  /// - Falhou (bytes inválidos) → Latin-1 → retorna `(text, latin1)`
+  ///
+  /// Latin-1 é escolhido porque mapeia cada byte `b` ao codepoint `b`
+  /// (identidade para 0–255), garantindo roundtrip perfeito ao gravar de volta.
+  static (String, Encoding) _decodeBytes(List<int> bytes) {
+    try {
+      return (utf8.decode(bytes), utf8);
+    } on FormatException {
+      return (latin1.decode(bytes), latin1);
+    }
   }
 
   @override
-  Future<bool> write(String path, String content) async {
+  Future<bool> write(String path, String content, {Encoding encoding = utf8}) async {
     try {
-      await File(path).writeAsString(content);
+      // Tenta gravar com o encoding original do arquivo.
+      // Se o conteúdo tiver caracteres fora do alcance do encoding (ex.:
+      // usuário digitou emojis num arquivo Latin-1), faz upgrade para UTF-8.
+      await File(path).writeAsString(content, encoding: encoding);
       return true;
+    } on ArgumentError {
+      // Encoding (ex.: Latin-1) não suporta todos os codepoints do conteúdo
+      // editado — faz upgrade silencioso para UTF-8.
+      try {
+        await File(path).writeAsString(content);
+        return true;
+      } on FileSystemException {
+        return false;
+      }
     } on FileSystemException {
       return false;
     }

--- a/cockpit/lib/app/cockpit/data/filesystem/git_diff_reader_impl.dart
+++ b/cockpit/lib/app/cockpit/data/filesystem/git_diff_reader_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:cockpit/app/cockpit/data/filesystem/git_binary.dart';
@@ -20,27 +21,21 @@ class GitDiffReaderImpl implements GitDiffReader {
 
       // Untracked? `git diff HEAD` não mostra arquivo não rastreado — detecta via
       // status e lê o arquivo inteiro como adicionado.
-      final status = await Process.run(git, [
-        '-C',
-        repoPath,
-        'status',
-        '--porcelain',
-        '--',
-        rel,
-      ]);
+      final status = await Process.run(
+        git,
+        ['-C', repoPath, 'status', '--porcelain', '--', rel],
+        stdoutEncoding: utf8,
+      );
       final statusOut = status.exitCode == 0 ? (status.stdout as String) : '';
       if (statusOut.startsWith('??')) {
         return _untrackedDiff(absPath);
       }
 
-      final diff = await Process.run(git, [
-        '-C',
-        repoPath,
-        'diff',
-        'HEAD',
-        '--',
-        rel,
-      ]);
+      final diff = await Process.run(
+        git,
+        ['-C', repoPath, 'diff', 'HEAD', '--', rel],
+        stdoutEncoding: utf8,
+      );
       if (diff.exitCode != 0) return FileDiff.unchanged(absPath);
       final out = diff.stdout as String;
       if (out.trim().isEmpty) return FileDiff.unchanged(absPath);
@@ -65,14 +60,11 @@ class GitDiffReaderImpl implements GitDiffReader {
         '${repoPath.endsWith('/') ? repoPath.substring(0, repoPath.length - 1) : repoPath}/$relativePath';
     try {
       final git = await _gitBinary.resolve();
-      final parentResult = await Process.run(git, [
-        '-C',
-        repoPath,
-        'show',
-        '--format=%P',
-        '--no-patch',
-        commitHash,
-      ]);
+      final parentResult = await Process.run(
+        git,
+        ['-C', repoPath, 'show', '--format=%P', '--no-patch', commitHash],
+        stdoutEncoding: utf8,
+      );
       if (parentResult.exitCode != 0) return FileDiff.unchanged(absPath);
       final parentLine = (parentResult.stdout as String).trim();
       final beforeRevision = parentLine.isEmpty
@@ -84,24 +76,32 @@ class GitDiffReaderImpl implements GitDiffReader {
           // `git show <commit> -- old new` separa rename com mudancas em
           // delete + add. Comparar os blobs diretamente preserva o conteudo
           // original e modificado como um unico diff.
-          ? await Process.run(git, [
-              '-C',
-              repoPath,
-              'diff',
-              '$beforeRevision:$previousRelativePath',
-              '$commitHash:$relativePath',
-            ])
-          : await Process.run(git, [
-              '-C',
-              repoPath,
-              'show',
-              '--format=',
-              '--first-parent',
-              '--find-renames',
-              commitHash,
-              '--',
-              relativePath,
-            ]);
+          ? await Process.run(
+              git,
+              [
+                '-C',
+                repoPath,
+                'diff',
+                '$beforeRevision:$previousRelativePath',
+                '$commitHash:$relativePath',
+              ],
+              stdoutEncoding: utf8,
+            )
+          : await Process.run(
+              git,
+              [
+                '-C',
+                repoPath,
+                'show',
+                '--format=',
+                '--first-parent',
+                '--find-renames',
+                commitHash,
+                '--',
+                relativePath,
+              ],
+              stdoutEncoding: utf8,
+            );
       if (result.exitCode != 0) return FileDiff.unchanged(absPath);
       final out = result.stdout as String;
       if (unifiedDiffLooksBinary(out)) {
@@ -140,7 +140,7 @@ class GitDiffReaderImpl implements GitDiffReader {
       final file = File(absPath);
       final bytes = await file.readAsBytes();
       if (_looksBinary(bytes)) return FileDiff.binary(absPath);
-      final content = String.fromCharCodes(bytes);
+      final content = utf8.decode(bytes, allowMalformed: true);
       final lines = content.split('\n');
       // split deixa uma string vazia no fim quando o arquivo termina em '\n'.
       if (lines.isNotEmpty && lines.last.isEmpty) lines.removeLast();

--- a/cockpit/lib/app/cockpit/domain/contracts/file_reader.dart
+++ b/cockpit/lib/app/cockpit/domain/contracts/file_reader.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
 
 /// Lê e classifica um arquivo para o viewer (markdown / texto / imagem /
@@ -5,10 +7,15 @@ import 'package:cockpit/app/cockpit/domain/entities/file_view.dart';
 abstract class FileReader {
   Future<FileView> read(String path);
 
-  /// Grava [content] (utf8) em [path], sobrescrevendo. Retorna `true` no sucesso,
-  /// `false` se o IO falhar (sem permissão, disco cheio, path sumiu). Não há
-  /// merge nem trava: escrita simultânea do agente é last-write-wins (escopo MVP).
-  Future<bool> write(String path, String content);
+  /// Grava [content] em [path] com o [encoding] informado, sobrescrevendo.
+  /// Retorna `true` no sucesso, `false` se o IO falhar (sem permissão, disco
+  /// cheio, path sumiu). Não há merge nem trava: escrita simultânea do agente
+  /// é last-write-wins (escopo MVP).
+  ///
+  /// Passe o [encoding] da [FileView] original para preservar o encoding do
+  /// arquivo no disco (evita diffs artificiais em arquivos não-UTF-8).
+  /// Arquivos novos (scratch) usam [utf8] como padrão.
+  Future<bool> write(String path, String content, {Encoding encoding = utf8});
 
   /// Emite (`void`) sempre que [path] muda no disco (modify/delete), pra o viewer
   /// reler o conteúdo ao vivo. Stream de longa duração — o consumidor cancela ao

--- a/cockpit/lib/app/cockpit/domain/entities/file_view.dart
+++ b/cockpit/lib/app/cockpit/domain/entities/file_view.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// O conteúdo de um arquivo aberto no viewer, já classificado.
 sealed class FileView {
   const FileView();
@@ -5,17 +7,25 @@ sealed class FileView {
 
 /// Markdown (.md/.mdx) — renderizado com gpt_markdown.
 final class FileViewMarkdown extends FileView {
-  const FileViewMarkdown(this.text);
+  const FileViewMarkdown(this.text, {this.encoding = utf8});
   final String text;
+
+  /// Encoding original do arquivo no disco — preservado no save para evitar
+  /// diffs artificiais em arquivos não-UTF-8 (ex.: Latin-1).
+  final Encoding encoding;
 }
 
 /// Texto legível (.js/.json/…) — texto puro por enquanto (highlight depois).
 final class FileViewText extends FileView {
-  const FileViewText(this.text, {this.language});
+  const FileViewText(this.text, {this.language, this.encoding = utf8});
   final String text;
 
   /// Dica de linguagem (extensão), para highlight futuro.
   final String? language;
+
+  /// Encoding original do arquivo no disco — preservado no save para evitar
+  /// diffs artificiais em arquivos não-UTF-8 (ex.: Latin-1).
+  final Encoding encoding;
 }
 
 /// Imagem raster (PNG/JPEG/…) — só o caminho; o widget carrega.
@@ -27,9 +37,13 @@ final class FileViewImage extends FileView {
 /// SVG — texto (XML) **e** imagem ao mesmo tempo: editável na fonte e
 /// renderizável no preview. Carrega [text] (fonte) e [path] (origem do render).
 final class FileViewSvg extends FileView {
-  const FileViewSvg(this.path, this.text);
+  const FileViewSvg(this.path, this.text, {this.encoding = utf8});
   final String path;
   final String text;
+
+  /// Encoding original do arquivo no disco — preservado no save para evitar
+  /// diffs artificiais em arquivos não-UTF-8 (ex.: Latin-1).
+  final Encoding encoding;
 }
 
 /// Áudio (mp3/wav/flac/…) — só o caminho; o player (media_kit) carrega. Plano 46.

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -1920,7 +1920,10 @@ class CockpitViewModel extends ChangeNotifier {
         return false; // fs.write falhou (permissão, conexão) → não salvou.
       }
     } else {
-      final ok = await _fileReader.write(s.path, content);
+      // Preserva o encoding original do arquivo para evitar diffs artificiais
+      // no Git (ex.: arquivo Latin-1 aberto e salvo sem edição).
+      final encoding = _encodingOf(s.view);
+      final ok = await _fileReader.write(s.path, content, encoding: encoding);
       if (!ok) return false;
     }
     final fresh = await _readFile(s.path);
@@ -1931,6 +1934,15 @@ class CockpitViewModel extends ChangeNotifier {
     }
     return true;
   }
+
+  /// Extrai o [Encoding] original de uma [FileView] editável. Usado no save para
+  /// preservar o encoding do arquivo e não gerar diffs artificiais no Git.
+  static Encoding _encodingOf(FileView view) => switch (view) {
+    FileViewText(:final encoding) => encoding,
+    FileViewMarkdown(:final encoding) => encoding,
+    FileViewSvg(:final encoding) => encoding,
+    _ => utf8,
+  };
 
   // ---- LSP (diagnostics + formatação) ---------------------------------------
 

--- a/cockpit/lib/app/cockpit/ui/widgets/diff_viewer.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/diff_viewer.dart
@@ -83,44 +83,129 @@ class _Row {
   final DiffLine? right;
 }
 
-class _DiffBody extends StatelessWidget {
+// ---------------------------------------------------------------------------
+// Item list — union selada de hunk-header e diff-row para o ListView.builder
+// ---------------------------------------------------------------------------
+
+sealed class _Item {}
+
+final class _HunkHeaderItem extends _Item {
+  _HunkHeaderItem(this.header);
+  final String header;
+}
+
+final class _RowItem extends _Item {
+  _RowItem(this.row);
+  final _Row row;
+}
+
+/// Converte hunks em uma lista plana de [_Item]s (header + linhas pares).
+/// Separado do widget para poder ser computado uma única vez por diff,
+/// não a cada `build()`.
+List<_Item> _buildDiffItems(List<DiffHunk> hunks) {
+  final items = <_Item>[];
+  for (final hunk in hunks) {
+    items.add(_HunkHeaderItem(hunk.header));
+    for (final row in _rowsOf(hunk)) {
+      items.add(_RowItem(row));
+    }
+  }
+  return items;
+}
+
+/// Alinha as linhas de um hunk em pares esquerda/direita. Runs de removed são
+/// zipados com os added seguintes (removed→left, added→right); sobras viram
+/// linhas de um lado só; contexto aparece nos dois lados.
+List<_Row> _rowsOf(DiffHunk hunk) {
+  final rows = <_Row>[];
+  final removed = <DiffLine>[];
+  final added = <DiffLine>[];
+
+  void flush() {
+    final n = removed.length > added.length ? removed.length : added.length;
+    for (var i = 0; i < n; i++) {
+      rows.add(
+        _Row(
+          left: i < removed.length ? removed[i] : null,
+          right: i < added.length ? added[i] : null,
+        ),
+      );
+    }
+    removed.clear();
+    added.clear();
+  }
+
+  for (final line in hunk.lines) {
+    switch (line.kind) {
+      case DiffLineKind.removed:
+        removed.add(line);
+      case DiffLineKind.added:
+        added.add(line);
+      case DiffLineKind.context:
+        flush();
+        rows.add(_Row(left: line, right: line));
+    }
+  }
+  flush();
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// _DiffBody — StatefulWidget para cachear _items entre rebuilds
+// ---------------------------------------------------------------------------
+
+class _DiffBody extends StatefulWidget {
   const _DiffBody({required this.diff, required this.language});
 
   final FileDiff diff;
   final String? language;
 
   @override
+  State<_DiffBody> createState() => _DiffBodyState();
+}
+
+class _DiffBodyState extends State<_DiffBody> {
+  /// Lista plana de itens (hunk headers + rows). Recalculada só quando o diff
+  /// muda, não a cada `build()`.
+  late List<_Item> _items;
+
+  @override
+  void initState() {
+    super.initState();
+    _items = _buildDiffItems(widget.diff.hunks);
+  }
+
+  @override
+  void didUpdateWidget(_DiffBody old) {
+    super.didUpdateWidget(old);
+    if (!identical(old.diff, widget.diff)) {
+      _items = _buildDiffItems(widget.diff.hunks);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final diff = widget.diff;
+    final language = widget.language;
     final colors = context.colors;
+
     if (diff.kind == FileDiffKind.binary) {
       return _messageBody(
         context,
+        diff,
         context.t.cockpit.fileTreePanel.diffBinaryFile,
       );
     }
     if (diff.kind == FileDiffKind.unchanged || diff.hunks.isEmpty) {
       return _messageBody(
         context,
+        diff,
         context.t.cockpit.fileTreePanel.diffNoChanges,
       );
     }
 
-    final rows = <_Row>[];
-    final headers = <int>{}; // índices onde começa um hunk (pra pintar header)
-    final headerText = <int, String>{};
-    for (final hunk in diff.hunks) {
-      headers.add(rows.length);
-      headerText[rows.length] = hunk.header;
-      rows.addAll(_rowsOf(hunk));
-    }
-
     return ColoredBox(
       color: colors.bg,
-      // Seleção contínua entre linhas (copiar blocos de código do diff). Os
-      // números de linha ficam fora da seleção (SelectionContainer.disabled).
-      // A SelectionArea fica DENTRO dos dois scrolls de propósito: em volta
-      // deles a seleção escorrega ao rolar com Interface size != 14 — ver
-      // [SelectableScroll].
       child: LayoutBuilder(
         builder: (context, constraints) {
           // Cada coluna preenche metade da largura disponível, respeitando um
@@ -129,29 +214,33 @@ class _DiffBody extends StatelessWidget {
           final side = ((avail - 1) / 2).clamp(_minSideWidth, double.infinity);
           final total = side * 2 + 1;
 
-          final children = <Widget>[_revisionHeader(context, side)];
-          for (var i = 0; i < rows.length; i++) {
-            final hdr = headerText[i];
-            if (hdr != null) {
-              children.add(_HunkHeader(text: hdr, width: total));
-            }
-            children.add(
-              _DiffRow(row: rows[i], sideWidth: side, language: language),
-            );
-          }
-
+          // Seleção contínua entre linhas (copiar blocos de código do diff).
+          // Os números de linha ficam fora da seleção (SelectionContainer.disabled
+          // em _Side). A SelectionArea fica DENTRO do scroll horizontal de
+          // propósito: em volta dele a seleção escorrega ao rolar com Interface
+          // size != 14 — ver [SelectableScroll].
+          //
+          // O scroll vertical é feito pelo ListView.builder, que virtualiza:
+          // só os widgets visíveis (~30) são construídos, em vez de todos os N
+          // do diff. Isso elimina a lentidão na abertura de diffs grandes.
           return SingleChildScrollView(
-            scrollDirection: Axis.vertical,
-            child: SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
+            scrollDirection: Axis.horizontal,
+            child: SizedBox(
+              width: total,
               child: SelectionArea(
-                child: SizedBox(
-                  width: total,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    mainAxisSize: MainAxisSize.min,
-                    children: children,
-                  ),
+                child: ListView.builder(
+                  // item 0 = revision header; restantes = _items
+                  itemCount: _items.length + 1,
+                  itemBuilder: (context, i) {
+                    if (i == 0) return _revisionHeader(context, diff, side);
+                    final item = _items[i - 1];
+                    return switch (item) {
+                      _HunkHeaderItem(:final header) =>
+                        _HunkHeader(text: header, width: total),
+                      _RowItem(:final row) =>
+                        _DiffRow(row: row, sideWidth: side, language: language),
+                    };
+                  },
                 ),
               ),
             ),
@@ -161,7 +250,7 @@ class _DiffBody extends StatelessWidget {
     );
   }
 
-  Widget _messageBody(BuildContext context, String text) {
+  Widget _messageBody(BuildContext context, FileDiff diff, String text) {
     if (diff.afterRevision == null) return _centered(context, text);
     return ColoredBox(
       color: context.colors.bg,
@@ -177,7 +266,7 @@ class _DiffBody extends StatelessWidget {
                 scrollDirection: Axis.horizontal,
                 child: SizedBox(
                   width: side * 2 + 1,
-                  child: _revisionHeader(context, side),
+                  child: _revisionHeader(context, diff, side),
                 ),
               ),
               Expanded(child: _centered(context, text)),
@@ -188,7 +277,11 @@ class _DiffBody extends StatelessWidget {
     );
   }
 
-  Widget _revisionHeader(BuildContext context, double sideWidth) {
+  static Widget _revisionHeader(
+    BuildContext context,
+    FileDiff diff,
+    double sideWidth,
+  ) {
     final tr = context.t.cockpit.fileTreePanel;
     final historical = diff.afterRevision != null;
     return _RevisionHeader(
@@ -204,49 +297,12 @@ class _DiffBody extends StatelessWidget {
     );
   }
 
-  Widget _centered(BuildContext context, String text) => Center(
+  static Widget _centered(BuildContext context, String text) => Center(
     child: Text(
       text,
       style: context.typo.label.copyWith(color: context.colors.text3),
     ),
   );
-
-  /// Alinha as linhas de um hunk em pares esquerda/direita. Runs de removed são
-  /// zipados com os added seguintes (removed→left, added→right); sobras viram
-  /// linhas de um lado só; contexto aparece nos dois lados.
-  List<_Row> _rowsOf(DiffHunk hunk) {
-    final rows = <_Row>[];
-    final removed = <DiffLine>[];
-    final added = <DiffLine>[];
-
-    void flush() {
-      final n = removed.length > added.length ? removed.length : added.length;
-      for (var i = 0; i < n; i++) {
-        rows.add(
-          _Row(
-            left: i < removed.length ? removed[i] : null,
-            right: i < added.length ? added[i] : null,
-          ),
-        );
-      }
-      removed.clear();
-      added.clear();
-    }
-
-    for (final line in hunk.lines) {
-      switch (line.kind) {
-        case DiffLineKind.removed:
-          removed.add(line);
-        case DiffLineKind.added:
-          added.add(line);
-        case DiffLineKind.context:
-          flush();
-          rows.add(_Row(left: line, right: line));
-      }
-    }
-    flush();
-    return rows;
-  }
 }
 
 String _shortRef(String ref) => ref.length <= 8 ? ref : ref.substring(0, 8);

--- a/cockpit/test/data/file_reader_impl_test.dart
+++ b/cockpit/test/data/file_reader_impl_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:cockpit/app/cockpit/data/filesystem/file_reader_impl.dart';
@@ -83,17 +84,57 @@ void main() {
     );
 
     test(
-      'bytes não-utf8 (latin-1) → FileViewText tolerante (U+FFFD)',
+      'bytes não-utf8 (latin-1) → FileViewText com texto correto e encoding Latin-1',
       () async {
         final dir = await Directory.systemTemp.createTemp('ck_fr_l1');
         addTearDown(() => dir.delete(recursive: true));
-        // 0xE9 = 'é' em latin-1, byte inválido em utf-8 → vira U+FFFD.
+        // 0xE9 = 'é' em Latin-1; byte inválido em UTF-8 estrito.
         final f = File('${dir.path}/cafe.txt')
           ..writeAsBytesSync([0x63, 0x61, 0x66, 0xe9]);
         final view = await reader.read(f.path);
         expect(view, isA<FileViewText>());
-        expect((view as FileViewText).text, contains('caf'));
-        expect(view.text, contains('�'));
+        // Deve decodificar como Latin-1 e mostrar 'é', NÃO U+FFFD.
+        expect((view as FileViewText).text, 'café');
+        // O encoding detectado deve ser Latin-1.
+        expect(view.encoding, latin1);
+      },
+    );
+
+    test(
+      'roundtrip Latin-1: ler + salvar sem edição não muda os bytes no disco',
+      () async {
+        final dir = await Directory.systemTemp.createTemp('ck_fr_rt_l1');
+        addTearDown(() => dir.delete(recursive: true));
+        // Arquivo Latin-1 com "ação" (bytes inválidos em UTF-8).
+        final original = [0x61, 0xe7, 0xe3, 0x6f]; // "ação" em Latin-1
+        final f = File('${dir.path}/acao.txt')..writeAsBytesSync(original);
+
+        final view = await reader.read(f.path) as FileViewText;
+        // Salva sem alterar o conteúdo, usando o encoding original.
+        final ok = await reader.write(f.path, view.text, encoding: view.encoding);
+
+        expect(ok, isTrue);
+        // Os bytes no disco devem ser idênticos aos originais.
+        expect(f.readAsBytesSync(), original);
+      },
+    );
+
+    test(
+      'roundtrip UTF-8: ler + salvar sem edição não muda os bytes no disco',
+      () async {
+        final dir = await Directory.systemTemp.createTemp('ck_fr_rt_utf8');
+        addTearDown(() => dir.delete(recursive: true));
+        // Arquivo UTF-8 com acentos.
+        const content = 'Olá, ação!\n';
+        final original = utf8.encode(content);
+        final f = File('${dir.path}/utf8.txt')..writeAsBytesSync(original);
+
+        final view = await reader.read(f.path) as FileViewText;
+        final ok = await reader.write(f.path, view.text, encoding: view.encoding);
+
+        expect(ok, isTrue);
+        expect(f.readAsBytesSync(), original);
+        expect(view.encoding, utf8);
       },
     );
 

--- a/cockpit/test/data/git_diff_reader_impl_test.dart
+++ b/cockpit/test/data/git_diff_reader_impl_test.dart
@@ -157,6 +157,35 @@ void main() {
     expect(diff.hunks, isEmpty);
   });
 
+  test('untracked com acentos UTF-8 → texto preservado sem corrupção', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    const accentedContent = 'ação\ntambém\nvocê\ninformação\n';
+    await write('accents.txt', accentedContent);
+    final diff = await reader.read(repo.path, '${repo.path}/accents.txt');
+    expect(diff.kind, FileDiffKind.added);
+    final lines = diff.hunks.expand((h) => h.lines).map((l) => l.text).toList();
+    expect(lines, ['ação', 'também', 'você', 'informação']);
+  });
+
+  test('modificado com acentos UTF-8 → diff preserva acentos', () async {
+    if (!await gitAvailable()) {
+      markTestSkipped('git não disponível');
+      return;
+    }
+    await write('a.txt', 'line1\nação\nline3\n');
+    final diff = await reader.read(repo.path, '${repo.path}/a.txt');
+    expect(diff.kind, FileDiffKind.modified);
+    final addedLines = diff.hunks
+        .expand((h) => h.lines)
+        .where((l) => l.kind == DiffLineKind.added)
+        .map((l) => l.text)
+        .toList();
+    expect(addedLines.any((t) => t == 'ação'), isTrue);
+  });
+
   test('binário → FileDiffKind.binary', () async {
     if (!await gitAvailable()) {
       markTestSkipped('git não disponível');


### PR DESCRIPTION
## Problema

Dois comportamentos incorretos relacionados ao encoding de arquivos no Cockpit:

1. **Diff com caracteres corrompidos** — ao abrir o diff de um arquivo não rastreado pelo Git com conteúdo em português (acentos, cedilha), os caracteres apareciam corrompidos (`ação` virava `Ã§Ã£o`).

2. **Arquivo modificado sem edição** — abrir qualquer arquivo com encoding não-UTF-8 (ex.: Latin-1) e salvar sem alterar nada fazia o arquivo aparecer como modificado no Git, gerando diffs artificiais.

---

## Causa raiz

### Bug 1 — diff
`GitDiffReaderImpl._untrackedDiff` usava `String.fromCharCodes(bytes)` para ler o conteúdo de arquivos não rastreados. Esse método interpreta cada byte como um codepoint Latin-1 isolado. Bytes UTF-8 multi-byte (ex.: `0xC3 0xA7` = `ç`) viravam dois caracteres separados.

### Bug 2 — encoding no save
`FileReaderImpl.read()` decodificava com `utf8.decode(bytes, allowMalformed: true)`: bytes inválidos em UTF-8 eram substituídos por U+FFFD (`0xEF 0xBF 0xBD`, 3 bytes). `FileReaderImpl.write()` gravava de volta como UTF-8, transformando cada byte original em até 3 bytes — arquivo diferente no disco sem nenhuma edição.

---

## Solução

### Fix 1 — diff ([`fed03ef`](fed03ef))
- Substituído `String.fromCharCodes(bytes)` por `utf8.decode(bytes, allowMalformed: true)` em `_untrackedDiff`
- Adicionado `stdoutEncoding: utf8` explícito em todos os `Process.run` do arquivo (consistência independente do locale do SO)

### Fix 2 — encoding roundtrip ([`c563a32`](c563a32))
- `FileReaderImpl.read()` agora tenta UTF-8 estrito; se falhar, usa Latin-1 (mapeamento 1:1 byte→codepoint, sem perda)
- `FileViewText`, `FileViewMarkdown` e `FileViewSvg` carregam o `Encoding` detectado
- `FileReader.write()` recebe o encoding como parâmetro (`{Encoding encoding = utf8}`)
- `CockpitViewModel.saveFile()` extrai o encoding da view e o passa ao gravar
- Se o usuário editar um arquivo Latin-1 e digitar caracteres fora do alcance, o encoding faz upgrade silencioso para UTF-8

### Perf — diff viewer ([`3863632`](3863632))
Enquanto o diff estava sendo analisado, foi identificado que `_DiffBody.build()` construía **todos** os widgets do diff de uma vez (ex.: diff de 300 linhas = ~900 widgets criados na abertura). Substituído `Column` eager por `ListView.builder` (virtualizado): só os ~30 widgets visíveis são construídos; o restante é criado conforme o usuário rola.

---

## Testes

- **`git_diff_reader_impl_test.dart`**: 2 novos casos — untracked e modified com conteúdo acentuado
- **`file_reader_impl_test.dart`**: 2 novos casos de roundtrip (Latin-1 e UTF-8) + atualização do teste existente de Latin-1 (agora espera `é` em vez de `U+FFFD`)