### PR TITLE
feat(config): relocatable state root (REMOTE_PI_DIR) + config.json follows PI_CODING_AGENT_DIR

### DIFF
--- a/pi-extension/README.md
+++ b/pi-extension/README.md
@@ -600,17 +600,28 @@ with a `[<cwd>]` prefix, so a single log stream shows every agent.
 | `~/.pi/remote/sessions/<name>/` | Per-session | Broker socket + `audit.jsonl` |
 | `~/.pi/remote/skills/agent-network/SKILL.md` | Per-user | Agent skill the LLM reads |
 
-All paths above derive from a single **state root** — by default `~/.pi/remote`.
-Two environment variables let you relocate it:
+Every path above **except the global `config.json`** derives from a single
+**state root** — by default `~/.pi/remote`. Two environment variables relocate
+that state root:
 
 | Variable | Behaviour |
 |---|---|
 | `REMOTE_PI_DIR` | Absolute path to the state root. No suffix appended — set this to an XDG-style location like `~/.config/pi/remote-pi`. Takes priority over every other variable. |
 | `REMOTE_PI_HOME` | Stand-in for `$HOME`; state lives at `<REMOTE_PI_HOME>/.pi/remote`. Kept for backward compatibility. |
 
-When both are set, `REMOTE_PI_DIR` wins. Use these to put remote-pi state on a
-specific disk, inside an XDG directory, or anywhere your system's conventions
-dictate — the entire state tree always stays under one root.
+When both are set, `REMOTE_PI_DIR` wins. Use these to put remote-pi **state**
+(sessions, daemon registries, cwd locks, paired identity) on a specific disk,
+inside an XDG directory, or anywhere your system's conventions dictate.
+
+The global `config.json` (relay URL + defaults) is resolved separately, so it
+can sit beside the coding agent's own settings rather than the state tree:
+
+| Variable | Behaviour |
+|---|---|
+| `PI_CODING_AGENT_DIR` | The Pi host's settings root (default `~/.pi`). `config.json` lives at `<PI_CODING_AGENT_DIR>/remote/config.json`, so with the default agent dir the path stays exactly `~/.pi/remote/config.json`. Takes priority for config. |
+
+When `PI_CODING_AGENT_DIR` is unset, `config.json` falls back to the state root
+above (so a pure `REMOTE_PI_DIR` relocation still keeps config beside the rest).
 
 Override the relay for a single run without persisting:
 

--- a/pi-extension/README.md
+++ b/pi-extension/README.md
@@ -600,6 +600,18 @@ with a `[<cwd>]` prefix, so a single log stream shows every agent.
 | `~/.pi/remote/sessions/<name>/` | Per-session | Broker socket + `audit.jsonl` |
 | `~/.pi/remote/skills/agent-network/SKILL.md` | Per-user | Agent skill the LLM reads |
 
+All paths above derive from a single **state root** — by default `~/.pi/remote`.
+Two environment variables let you relocate it:
+
+| Variable | Behaviour |
+|---|---|
+| `REMOTE_PI_DIR` | Absolute path to the state root. No suffix appended — set this to an XDG-style location like `~/.config/pi/remote-pi`. Takes priority over every other variable. |
+| `REMOTE_PI_HOME` | Stand-in for `$HOME`; state lives at `<REMOTE_PI_HOME>/.pi/remote`. Kept for backward compatibility. |
+
+When both are set, `REMOTE_PI_DIR` wins. Use these to put remote-pi state on a
+specific disk, inside an XDG directory, or anywhere your system's conventions
+dictate — the entire state tree always stays under one root.
+
 Override the relay for a single run without persisting:
 
 ```bash

--- a/pi-extension/src/config.ts
+++ b/pi-extension/src/config.ts
@@ -1,13 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
-import { remotePiHome } from "./paths.js";
+import { remotePiConfigHome } from "./paths.js";
 
-// Resolved at call time via the shared `remotePiHome()` (honours REMOTE_PI_DIR /
-// REMOTE_PI_HOME). Previously hardcoded to `os.homedir()`, which ignored the
-// override every other site honoured and split config.json off from the rest of
-// the state — see paths.ts.
-const configDir = (): string => remotePiHome();
-const configFile = (): string => path.join(remotePiHome(), "config.json");
+// Resolved at call time via `remotePiConfigHome()` — config.json follows the
+// coding-agent dir (`PI_CODING_AGENT_DIR`), falling back to the state root
+// (`remotePiHome()`, still settable via REMOTE_PI_DIR / REMOTE_PI_HOME). See
+// paths.ts. Previously hardcoded to `os.homedir()`, which ignored every
+// relocation knob and split config.json off from the rest of the install.
+const configDir = (): string => remotePiConfigHome();
+const configFile = (): string => path.join(remotePiConfigHome(), "config.json");
 
 /**
  * Default community relay. Stored in canonical http(s):// form — conversion

--- a/pi-extension/src/config.ts
+++ b/pi-extension/src/config.ts
@@ -1,9 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { remotePiHome } from "./paths.js";
 
-const CONFIG_DIR = path.join(os.homedir(), ".pi", "remote");
-const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
+// Resolved at call time via the shared `remotePiHome()` (honours REMOTE_PI_DIR /
+// REMOTE_PI_HOME). Previously hardcoded to `os.homedir()`, which ignored the
+// override every other site honoured and split config.json off from the rest of
+// the state — see paths.ts.
+const configDir = (): string => remotePiHome();
+const configFile = (): string => path.join(remotePiHome(), "config.json");
 
 /**
  * Default community relay. Stored in canonical http(s):// form — conversion
@@ -18,7 +22,7 @@ export type RemotePiConfig = { relay?: string };
 
 export function loadConfig(): RemotePiConfig {
   try {
-    const raw = fs.readFileSync(CONFIG_FILE, "utf8");
+    const raw = fs.readFileSync(configFile(), "utf8");
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return {};
     return parsed as RemotePiConfig;
@@ -28,10 +32,10 @@ export function loadConfig(): RemotePiConfig {
 }
 
 export function saveConfig(patch: Partial<RemotePiConfig>): void {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.mkdirSync(configDir(), { recursive: true });
   const current = loadConfig();
   const next = { ...current, ...patch };
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(next, null, 2));
+  fs.writeFileSync(configFile(), JSON.stringify(next, null, 2));
 }
 
 export type RelayResolution = { url: string; source: "env" | "config" | "default" };

--- a/pi-extension/src/daemon/cron_log.ts
+++ b/pi-extension/src/daemon/cron_log.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { remotePiHome } from "../paths.js";
 
 /**
  * Append-only audit trail for cron fires at `~/.pi/remote/cron.jsonl`.
@@ -36,8 +36,7 @@ export interface CronLogEntry {
 const PREVIEW_LEN = 80;
 
 function logPath(): string {
-  const root = process.env["REMOTE_PI_HOME"] || homedir();
-  return join(root, ".pi", "remote", "cron.jsonl");
+  return join(remotePiHome(), "cron.jsonl");
 }
 
 /** Test/diag-only: the on-disk path. */

--- a/pi-extension/src/daemon/cron_registry.ts
+++ b/pi-extension/src/daemon/cron_registry.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { randomBytes } from "node:crypto";
 import { dirname, join } from "node:path";
 import { Cron } from "croner";
+import { remotePiHome } from "../paths.js";
 
 /**
  * Cron registry: scheduled prompts for daemons, persisted at
@@ -51,8 +51,7 @@ export interface CronRegistry {
 }
 
 function cronPath(): string {
-  const root = process.env["REMOTE_PI_HOME"] || homedir();
-  return join(root, ".pi", "remote", "cron.json");
+  return join(remotePiHome(), "cron.json");
 }
 
 /** Test/diag-only: the on-disk path. */

--- a/pi-extension/src/daemon/registry.ts
+++ b/pi-extension/src/daemon/registry.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import { daemonIdForCwd } from "./id.js";
 import { defaultAgentName } from "../session/local_config.js";
+import { remotePiHome } from "../paths.js";
 
 /**
  * The global daemon registry: which working directories are promoted to
@@ -23,8 +24,7 @@ import { defaultAgentName } from "../session/local_config.js";
 /** Resolved at call time so tests can override via `REMOTE_PI_HOME`. The
  *  prod path is always `~/.pi/remote/daemons.json`. */
 function registryPathInternal(): string {
-  const root = process.env["REMOTE_PI_HOME"] || homedir();
-  return join(root, ".pi", "remote", "daemons.json");
+  return join(remotePiHome(), "daemons.json");
 }
 
 export interface DaemonEntry {

--- a/pi-extension/src/daemon/supervisor.ts
+++ b/pi-extension/src/daemon/supervisor.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { remotePiHome } from "../paths.js";
 import { addDaemon, listDaemons, migrateRegistryNames, removeDaemon } from "./registry.js";
 import { daemonIdForCwd } from "./id.js";
 import { defaultAgentName, type LocalConfig } from "../session/local_config.js";
@@ -58,9 +58,8 @@ const SUPERVISOR_SOCK_NAME = "supervisor.sock";
 const RESTART_BACKOFFS_MS = [1_000, 5_000, 30_000, 5 * 60_000];
 
 function supervisorSockPath(): string {
-  const root = process.env["REMOTE_PI_HOME"] || homedir();
   // POSIX → ~/.pi/remote/supervisor.sock; Windows → per-user named pipe (plan/40).
-  return ipcAddress("supervisor", join(root, ".pi", "remote", SUPERVISOR_SOCK_NAME));
+  return ipcAddress("supervisor", join(remotePiHome(), SUPERVISOR_SOCK_NAME));
 }
 
 /** Thrown by `start()` when another live supervisor already holds the UDS.

--- a/pi-extension/src/pairing/storage.ts
+++ b/pi-extension/src/pairing/storage.ts
@@ -1,9 +1,9 @@
 import { writeFileSync } from "node:fs";
 import { mkdir, readFile, writeFile, chmod, unlink } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { generateEd25519Keypair, type Ed25519Keypair } from "./crypto.js";
 import { canonicalizeEd25519PublicKey } from "../mesh/encoding.js";
+import { remotePiHome } from "../paths.js";
 
 /**
  * Pi-secret storage (plan/27 Wave E1).
@@ -76,7 +76,7 @@ export class PairedIdentityMissingError extends Error {
   }
 }
 
-const PI_DIR = join(homedir(), ".pi", "remote");
+const PI_DIR = remotePiHome();
 const IDENTITY_FILE = join(PI_DIR, "identity.json");
 const PEERS_PATH = join(PI_DIR, "peers.json");
 

--- a/pi-extension/src/paths.test.ts
+++ b/pi-extension/src/paths.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { remotePiHome } from "./paths.js";
+
+const SAVED_DIR = process.env["REMOTE_PI_DIR"];
+const SAVED_HOME = process.env["REMOTE_PI_HOME"];
+
+function restore(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+afterEach(() => {
+  restore("REMOTE_PI_DIR", SAVED_DIR);
+  restore("REMOTE_PI_HOME", SAVED_HOME);
+});
+
+describe("remotePiHome precedence", () => {
+  test("defaults to ~/.pi/remote when nothing is set", () => {
+    delete process.env["REMOTE_PI_DIR"];
+    delete process.env["REMOTE_PI_HOME"];
+    expect(remotePiHome()).toBe(join(homedir(), ".pi", "remote"));
+  });
+
+  test("REMOTE_PI_HOME is treated as a stand-in $HOME (appends .pi/remote)", () => {
+    delete process.env["REMOTE_PI_DIR"];
+    process.env["REMOTE_PI_HOME"] = "/tmp/fake-home";
+    expect(remotePiHome()).toBe(join("/tmp/fake-home", ".pi", "remote"));
+  });
+
+  test("REMOTE_PI_DIR is an absolute override with no .pi/remote suffix", () => {
+    process.env["REMOTE_PI_DIR"] = "/Users/x/.config/pi/remote-pi";
+    process.env["REMOTE_PI_HOME"] = "/tmp/fake-home"; // ignored when DIR is set
+    expect(remotePiHome()).toBe("/Users/x/.config/pi/remote-pi");
+  });
+
+  test("an empty REMOTE_PI_DIR falls through to REMOTE_PI_HOME", () => {
+    process.env["REMOTE_PI_DIR"] = "";
+    process.env["REMOTE_PI_HOME"] = "/tmp/fake-home";
+    expect(remotePiHome()).toBe(join("/tmp/fake-home", ".pi", "remote"));
+  });
+
+  test("resolved at call time (a later env change is picked up)", () => {
+    process.env["REMOTE_PI_DIR"] = "/first";
+    expect(remotePiHome()).toBe("/first");
+    process.env["REMOTE_PI_DIR"] = "/second";
+    expect(remotePiHome()).toBe("/second");
+  });
+});

--- a/pi-extension/src/paths.test.ts
+++ b/pi-extension/src/paths.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { remotePiHome } from "./paths.js";
+import { remotePiConfigHome, remotePiHome } from "./paths.js";
 
 const SAVED_DIR = process.env["REMOTE_PI_DIR"];
 const SAVED_HOME = process.env["REMOTE_PI_HOME"];
+const SAVED_AGENT_DIR = process.env["PI_CODING_AGENT_DIR"];
 
 function restore(key: string, value: string | undefined): void {
   if (value === undefined) delete process.env[key];
@@ -14,6 +15,7 @@ function restore(key: string, value: string | undefined): void {
 afterEach(() => {
   restore("REMOTE_PI_DIR", SAVED_DIR);
   restore("REMOTE_PI_HOME", SAVED_HOME);
+  restore("PI_CODING_AGENT_DIR", SAVED_AGENT_DIR);
 });
 
 describe("remotePiHome precedence", () => {
@@ -46,5 +48,40 @@ describe("remotePiHome precedence", () => {
     expect(remotePiHome()).toBe("/first");
     process.env["REMOTE_PI_DIR"] = "/second";
     expect(remotePiHome()).toBe("/second");
+  });
+});
+
+describe("remotePiConfigHome precedence", () => {
+  test("PI_CODING_AGENT_DIR unset → falls back to remotePiHome()", () => {
+    delete process.env["PI_CODING_AGENT_DIR"];
+    delete process.env["REMOTE_PI_DIR"];
+    delete process.env["REMOTE_PI_HOME"];
+    expect(remotePiConfigHome()).toBe(join(homedir(), ".pi", "remote"));
+    expect(remotePiConfigHome()).toBe(remotePiHome());
+  });
+
+  test("PI_CODING_AGENT_DIR set → <agentDir>/remote (default ~/.pi keeps historical path)", () => {
+    process.env["PI_CODING_AGENT_DIR"] = join(homedir(), ".pi");
+    expect(remotePiConfigHome()).toBe(join(homedir(), ".pi", "remote"));
+  });
+
+  test("PI_CODING_AGENT_DIR wins over the state resolver (REMOTE_PI_DIR)", () => {
+    process.env["PI_CODING_AGENT_DIR"] = "/agent/home";
+    process.env["REMOTE_PI_DIR"] = "/state/root"; // steers state, not config
+    expect(remotePiConfigHome()).toBe(join("/agent", "home", "remote"));
+    expect(remotePiHome()).toBe("/state/root");
+  });
+
+  test("an empty PI_CODING_AGENT_DIR falls through to remotePiHome()", () => {
+    process.env["PI_CODING_AGENT_DIR"] = "";
+    process.env["REMOTE_PI_DIR"] = "/state/root";
+    expect(remotePiConfigHome()).toBe("/state/root");
+  });
+
+  test("resolved at call time (a later env change is picked up)", () => {
+    process.env["PI_CODING_AGENT_DIR"] = "/first";
+    expect(remotePiConfigHome()).toBe(join("/first", "remote"));
+    process.env["PI_CODING_AGENT_DIR"] = "/second";
+    expect(remotePiConfigHome()).toBe(join("/second", "remote"));
   });
 });

--- a/pi-extension/src/paths.ts
+++ b/pi-extension/src/paths.ts
@@ -2,11 +2,15 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 /**
- * Absolute root for ALL remote-pi on-disk state: `config.json`, `sessions/`,
- * `skills/`, the paired-identity/`peers.json` store, the daemon registries
- * (`daemons.json`, `cron.json`), the cron/audit logs, the supervisor socket,
- * and the cwd lock dir. Every path in the codebase derives from this one
- * resolver so a relocated install can never split its state across two roots.
+ * Absolute root for remote-pi on-disk STATE: `sessions/`, `skills/`, the
+ * paired-identity/`peers.json` store, the daemon registries (`daemons.json`,
+ * `cron.json`), the cron/audit logs, the supervisor socket, and the cwd lock
+ * dir. Every state path in the codebase derives from this one resolver so a
+ * relocated install can never split its state across two roots.
+ *
+ * The GLOBAL `config.json` is the one exception — it follows the coding-agent
+ * dir via `remotePiConfigHome()` (below), not this resolver — though by default
+ * both land in the same place.
  *
  * Precedence (resolved at CALL time so tests — and a relocated deployment —
  * can override via env without re-importing):
@@ -22,11 +26,36 @@ import { join } from "node:path";
  *
  * Historically `config.ts` and `pairing/storage.ts` resolved this from
  * `os.homedir()` directly while seven other sites honoured `REMOTE_PI_HOME`, so
- * setting the override silently split `config.json`/`identity.json` away from
- * `sessions/` and the daemon state. Centralising here closes that hole.
+ * setting the override silently split `identity.json` away from `sessions/` and
+ * the daemon state. Centralising here closes that hole.
  */
 export function remotePiHome(): string {
   const dir = process.env["REMOTE_PI_DIR"];
   if (dir && dir.length > 0) return dir;
   return join(process.env["REMOTE_PI_HOME"] || homedir(), ".pi", "remote");
+}
+
+/**
+ * Root for remote-pi's global `config.json` specifically (the machine-wide
+ * relay URL + `defaults` block). Distinct from `remotePiHome()`: the Pi host
+ * keeps its own global settings under `PI_CODING_AGENT_DIR`, and remote-pi's
+ * config is a sibling of those, so it follows the agent dir when relocated
+ * rather than the state dir.
+ *
+ * Precedence (resolved at CALL time):
+ *
+ *   1. `PI_CODING_AGENT_DIR` — the Pi host's settings root (default `~/.pi`).
+ *      Config lives at `<PI_CODING_AGENT_DIR>/remote/config.json`, so with the
+ *      default agent dir the path stays exactly `~/.pi/remote/config.json`.
+ *   2. otherwise `remotePiHome()` — which itself stays settable via
+ *      `REMOTE_PI_DIR` / `REMOTE_PI_HOME`. So a pure state relocation (no agent
+ *      dir set) keeps config beside the rest of the state, as before.
+ *
+ * State (sessions, daemon registries, cwd locks, identity) is unaffected — only
+ * `config.json` honours `PI_CODING_AGENT_DIR`.
+ */
+export function remotePiConfigHome(): string {
+  const agentDir = process.env["PI_CODING_AGENT_DIR"];
+  if (agentDir && agentDir.length > 0) return join(agentDir, "remote");
+  return remotePiHome();
 }

--- a/pi-extension/src/paths.ts
+++ b/pi-extension/src/paths.ts
@@ -1,0 +1,32 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Absolute root for ALL remote-pi on-disk state: `config.json`, `sessions/`,
+ * `skills/`, the paired-identity/`peers.json` store, the daemon registries
+ * (`daemons.json`, `cron.json`), the cron/audit logs, the supervisor socket,
+ * and the cwd lock dir. Every path in the codebase derives from this one
+ * resolver so a relocated install can never split its state across two roots.
+ *
+ * Precedence (resolved at CALL time so tests — and a relocated deployment —
+ * can override via env without re-importing):
+ *
+ *   1. `REMOTE_PI_DIR`  — an ABSOLUTE override of the state dir itself. Lets the
+ *      state live at an arbitrary path (e.g. an XDG-style
+ *      `~/.config/pi/remote-pi`) with no forced `.pi/remote` suffix. This is the
+ *      knob to reach for when relocating; `REMOTE_PI_HOME` cannot express it.
+ *   2. `REMOTE_PI_HOME` — a stand-in `$HOME`; state lives at
+ *      `<REMOTE_PI_HOME>/.pi/remote`. Long-standing test/override knob, kept for
+ *      backward compatibility.
+ *   3. `os.homedir()`   — the default, `~/.pi/remote`.
+ *
+ * Historically `config.ts` and `pairing/storage.ts` resolved this from
+ * `os.homedir()` directly while seven other sites honoured `REMOTE_PI_HOME`, so
+ * setting the override silently split `config.json`/`identity.json` away from
+ * `sessions/` and the daemon state. Centralising here closes that hole.
+ */
+export function remotePiHome(): string {
+  const dir = process.env["REMOTE_PI_DIR"];
+  if (dir && dir.length > 0) return dir;
+  return join(process.env["REMOTE_PI_HOME"] || homedir(), ".pi", "remote");
+}

--- a/pi-extension/src/session/cwd_lock.ts
+++ b/pi-extension/src/session/cwd_lock.ts
@@ -1,10 +1,10 @@
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { Server } from "node:net";
 import { roomIdFor } from "../rooms.js";
 import { removeStaleSock, tryBind, tryConnect } from "./leader_election.js";
 import { ipcAddress, usesNamedPipe } from "./ipc.js";
+import { remotePiHome } from "../paths.js";
 
 /**
  * Per-cwd singleton lock for `/remote-pi`. At most one Pi process per
@@ -34,10 +34,9 @@ import { ipcAddress, usesNamedPipe } from "./ipc.js";
 
 /** Resolved at call time (not module load) so tests can redirect the lock
  *  dir away from the developer's real `~/.pi/remote/locks` via
- *  `REMOTE_PI_HOME` — same override the daemon registry honors. */
+ *  `REMOTE_PI_DIR` / `REMOTE_PI_HOME` — the shared override every site honors. */
 function locksDir(): string {
-  const root = process.env["REMOTE_PI_HOME"] || homedir();
-  return join(root, ".pi", "remote", "locks");
+  return join(remotePiHome(), "locks");
 }
 
 export interface AcquiredLock {

--- a/pi-extension/src/session/global_config.ts
+++ b/pi-extension/src/session/global_config.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { ipcAddress, usesNamedPipe } from "./ipc.js";
+import { remotePiHome } from "../paths.js";
 
-const HOME_PI_REMOTE = join((process.env["REMOTE_PI_HOME"] || homedir()), ".pi", "remote");
+const HOME_PI_REMOTE = remotePiHome();
 const SESSIONS_DIR = join(HOME_PI_REMOTE, "sessions");
 const SKILLS_DIR = join(HOME_PI_REMOTE, "skills");
 /**


### PR DESCRIPTION
## What

Centralises remote-pi's on-disk path resolution into two small resolvers in a new `paths.ts`, and lets a relocated install move its state and/or config without splitting them apart.

**State root — `remotePiHome()`** (sessions, daemon registries, cron/audit logs, supervisor socket, cwd locks, paired identity):

| Variable | Behaviour |
|---|---|
| `REMOTE_PI_DIR` | Absolute override of the state dir itself — no `.pi/remote` suffix. XDG-style relocation (e.g. `~/.config/pi/remote-pi`). Highest priority. |
| `REMOTE_PI_HOME` | Stand-in `$HOME`; state lives at `<REMOTE_PI_HOME>/.pi/remote`. Kept for backward compatibility. |
| *(unset)* | Default `~/.pi/remote`. |

**Global `config.json` — `remotePiConfigHome()`** (relay URL + the `defaults` block):

| Variable | Behaviour |
|---|---|
| `PI_CODING_AGENT_DIR` | The Pi host's settings root (default `~/.pi`). config lives at `<PI_CODING_AGENT_DIR>/remote/config.json`. Highest priority for config. |
| *(unset)* | Falls back to `remotePiHome()` (so a pure `REMOTE_PI_DIR` relocation keeps config beside the state). |

## Why

Two problems in one fix:

1. **Split-state bug.** `config.ts` and `pairing/storage.ts` resolved paths from `os.homedir()` directly, while seven other sites already honoured `REMOTE_PI_HOME`. Setting the override silently split `config.json`/`identity.json` away from `sessions/` and the daemon state. Every consumer now derives from one resolver.
2. **Config belongs with the agent.** The global `config.json` is a sibling of the Pi host's own settings, so it follows `PI_CODING_AGENT_DIR` rather than the state dir.

## Backward compatibility

Fully inert by default. With no env vars set, every path stays exactly `~/.pi/remote/...`. With the default agent dir (`~/.pi`), `config.json` stays exactly `~/.pi/remote/config.json`.

## Testing

- New `paths.test.ts` — precedence for both resolvers (10 cases), resolved-at-call-time so tests/relocations override via env.
- `pnpm typecheck` clean.

## Note

This is the base of a two-PR stack. The global-defaults feature (#149) builds on this resolver and targets `main` as well; it collapses to its own 2 commits once this merges.
