### PR TITLE
refactor(cockpit): simplificar o painel de workspaces e alinhar o menu ao resto do app

### DIFF
--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -696,7 +696,7 @@ class _RailPanel extends StatelessWidget {
           worktreesExpanded: vm.worktreesExpanded,
           onWorktreesExpanded: vm.setWorktreesExpanded,
           selectedId: vm.selectedProjectId,
-          notificationCount: vm.notificationCount,
+          notificationCounts: vm.notificationCounts,
           gitInfo: vm.gitInfo,
           rootsSummary: vm.rootsGitSummary,
           forkOriginName: vm.forkOriginName,

--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -744,8 +744,6 @@ class _RailPanel extends StatelessWidget {
             vm.selectProject(id);
             onDismiss();
           },
-          onRemoveRemoteWorkspace: (wsId) =>
-              unawaited(vm.removeRemoteWorkspace(wsId)),
           remoteGitInfoOf: vm.remoteGitInfoOf,
           onRemoteWorkspaceAction: (wsId, action) =>
               handleRemoteWorkspaceAction(context, wsId, action),

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -2148,11 +2148,22 @@ class CockpitViewModel extends ChangeNotifier {
     return null;
   }
 
-  /// Nº de agentes do workspace que terminaram um turno e ainda não foram
-  /// vistos (badge de notificações).
-  int notificationCount(String projectId) => _sessions.values
-      .where((s) => s.projectId == projectId && s.unseenFinish)
-      .length;
+  /// Nº de agentes que terminaram um turno e ainda não foram vistos, **por
+  /// workspace** (badge de notificações da rail).
+  ///
+  /// Mapa, e não uma consulta por id, de propósito: a rail pergunta isso uma
+  /// vez por workspace E por worktree a cada build, e a consulta por id varre
+  /// todas as sessões — o que dava O(itens × sessões) por frame. Uma varredura
+  /// só resolve a rail inteira. Ausente no mapa = zero.
+  Map<String, int> get notificationCounts {
+    final counts = <String, int>{};
+    for (final s in _sessions.values) {
+      if (s.unseenFinish) {
+        counts[s.projectId] = (counts[s.projectId] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }
 
   // ---- init -----------------------------------------------------------------
   Future<void> init() async {

--- a/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
@@ -57,7 +57,7 @@ class ProjectsRail extends StatefulWidget {
     required this.worktreesExpanded,
     required this.onWorktreesExpanded,
     required this.selectedId,
-    required this.notificationCount,
+    required this.notificationCounts,
     required this.gitInfo,
     required this.rootsSummary,
     required this.rootsOf,
@@ -130,7 +130,11 @@ class ProjectsRail extends StatefulWidget {
   final void Function(String rootId, bool expanded) onWorktreesExpanded;
 
   final String? selectedId;
-  final int Function(String projectId) notificationCount;
+
+  /// Notificações não vistas por workspace/worktree (ausente = 0). Mapa em vez
+  /// de callback por id: a rail lê isso uma vez por item a cada build, e no VM
+  /// a consulta por id varria todas as sessões — O(itens × sessões) por frame.
+  final Map<String, int> notificationCounts;
   final GitInfo? Function(String projectId) gitInfo;
 
   /// Agregado multi-root: (nº de roots, roots sujas). Só é lido quando
@@ -219,18 +223,121 @@ class _ProjectsRailState extends State<ProjectsRail> {
     );
   }
 
+  /// Um workspace da lista: o card (local ou remoto) + a lista de forks
+  /// pendurada abaixo.
+  ///
+  /// Todo dado por-workspace é resolvido **uma vez** aqui. Antes o `build`
+  /// perguntava as mesmas coisas ao VM várias vezes por item (`worktreesOf` 3x,
+  /// `gitInfo` 2x, `rootsSummary` 2x, `worktreesExpanded` 2x) — e cada uma
+  /// dessas, no `GitController`, realoca a lista de roots.
+  Widget _workspaceBlock(Project project) {
+    final id = project.id;
+    final forks = widget.worktreesOf(id);
+    final hasWorktrees = forks.isNotEmpty;
+    final expanded = widget.worktreesExpanded(id);
+    // Key pelo id: sem ela o estado do _WorkspaceReorderable (o caret de
+    // drop) escorrega pro vizinho quando um workspace sai do meio da lista.
+    final key = ValueKey(id);
+
+    if (project.isRemoteTerminal) {
+      return Column(
+        key: key,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _WorkspaceReorderable(
+            projectId: id,
+            title: project.name,
+            colorValue: project.colorValue,
+            initial: project.initial,
+            imagePath: project.imagePath,
+            onReorder: widget.onReorder,
+            child: _RemoteSlot(
+              workspaceId: id,
+              name: project.name,
+              colorValue: project.colorValue,
+              imagePath: project.imagePath,
+              selected: id == widget.selectedId,
+              git: widget.remoteGitInfoOf(id),
+              moveTargetsOf: () => widget.moveTargetsOf(id),
+              worktreeCount: forks.length,
+              hasWorktrees: hasWorktrees,
+              expanded: expanded,
+              onTap: () => _onCardTap(project, () => widget.onSelectRemote(id)),
+              onToggleExpanded: () => _toggleWorktrees(project),
+              onAction: (action) => widget.onRemoteWorkspaceAction(id, action),
+            ),
+          ),
+          _ForkList(
+            hasWorktrees: hasWorktrees,
+            expanded: expanded,
+            builder: () => _remoteForks(forks),
+          ),
+        ],
+      );
+    }
+
+    final git = widget.gitInfo(id);
+    final rootsSummary = widget.rootsSummary(id);
+    return Column(
+      key: key,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _WorkspaceReorderable(
+          projectId: id,
+          title: project.name,
+          colorValue: project.colorValue,
+          initial: project.initial,
+          imagePath: project.imagePath,
+          onReorder: widget.onReorder,
+          child: _ProjectItem(
+            project: project,
+            selected: id == widget.selectedId,
+            notifications: widget.notificationCounts[id] ?? 0,
+            git: git,
+            rootsSummary: rootsSummary,
+            worktreeCount: forks.length,
+            // "Criar worktree" só faz sentido em repo git (single ou multi-root
+            // — na multi a page pede a root alvo antes).
+            canCreateWorktree: git != null || rootsSummary.$1 > 1,
+            hasWorktrees: hasWorktrees,
+            expanded: expanded,
+            onTap: () => _onCardTap(project, () => widget.onSelect(id)),
+            onToggleExpanded: () => _toggleWorktrees(project),
+            onConfigure: () => widget.onConfigure(project),
+            onDelete: () => widget.onDelete(project),
+            rootsOf: () => widget.rootsOf(id),
+            onCreateWorktree: (r) => widget.onCreateWorktree(project, r),
+            onSync: (r) => widget.onSync(project, r),
+            onPull: (r) => widget.onPull(project, r),
+            onPush: (r) => widget.onPush(project, r),
+            moveTargetsOf: () => widget.moveTargetsOf(id),
+            onMoveToRealm: (realmId) => widget.onMoveToRealm(id, realmId),
+          ),
+        ),
+        // Worktrees (forks) penduradas abaixo do workspace, expandidas/
+        // recolhidas pelo chevron (V37; antes eram sempre visíveis — plan/42,
+        // dec. 5, 12).
+        _ForkList(
+          hasWorktrees: hasWorktrees,
+          expanded: expanded,
+          builder: () => _forkItems(forks),
+        ),
+      ],
+    );
+  }
+
   /// Os forks de um workspace, com `isLast` marcado pra linha de árvore fechar
   /// em "└" no último (a vertical dos demais segue até emendar com o próximo).
-  List<Widget> _forkItems(Project project) {
-    final forks = widget.worktreesOf(project.id);
+  List<Widget> _forkItems(List<Project> forks) {
     return [
       for (var i = 0; i < forks.length; i++)
         _WorktreeItem(
+          key: ValueKey(forks[i].id),
           worktree: forks[i],
           originName: widget.forkOriginName(forks[i].id),
           isLast: i == forks.length - 1,
           selected: forks[i].id == widget.selectedId,
-          notifications: widget.notificationCount(forks[i].id),
+          notifications: widget.notificationCounts[forks[i].id] ?? 0,
           git: widget.gitInfo(forks[i].id),
           onTap: () => widget.onSelect(forks[i].id),
           onRemove: () => widget.onRemoveWorktree(forks[i]),
@@ -244,16 +351,16 @@ class _ProjectsRailState extends State<ProjectsRail> {
   /// Forks (worktrees) de um workspace remoto — mesmo `_WorktreeItem` do local,
   /// mas o git vem do cache remoto (lazy) e as ações roteiam pros handlers que
   /// já ramificam por `isRemoteTerminal`.
-  List<Widget> _remoteForks(Project ws) {
-    final forks = widget.worktreesOf(ws.id);
+  List<Widget> _remoteForks(List<Project> forks) {
     return [
       for (var i = 0; i < forks.length; i++)
         _WorktreeItem(
+          key: ValueKey(forks[i].id),
           worktree: forks[i],
           originName: null,
           isLast: i == forks.length - 1,
           selected: forks[i].id == widget.selectedId,
-          notifications: widget.notificationCount(forks[i].id),
+          notifications: widget.notificationCounts[forks[i].id] ?? 0,
           git: widget.remoteGitInfoOf(forks[i].id),
           onTap: () => widget.onSelectRemote(forks[i].id),
           onRemove: () => widget.onRemoveWorktree(forks[i]),
@@ -319,118 +426,18 @@ class _ProjectsRailState extends State<ProjectsRail> {
                     controller: _scroll,
                     thumbVisibility: true,
                     child: ScrollConfiguration(
-                      behavior: ScrollConfiguration.of(context)
-                          .copyWith(scrollbars: false),
-                      child: ListView(
+                      behavior: ScrollConfiguration.of(
+                        context,
+                      ).copyWith(scrollbars: false),
+                      // .builder: só os workspaces visíveis são construídos.
+                      // Com `children:` a rail montava a lista inteira (card +
+                      // forks de cada um) a cada build, viewport ou não.
+                      child: ListView.builder(
                         controller: _scroll,
                         padding: const EdgeInsets.symmetric(horizontal: 8),
-                        children: [
-                          for (final project in projects) ...[
-                            // Remoto (plano 58): mesmo lugar/realm/reorder que o
-                            // local, mas com o slot SSH + forks remotos.
-                            if (project.isRemoteTerminal) ...[
-                              _WorkspaceReorderable(
-                                projectId: project.id,
-                                title: project.name,
-                                colorValue: project.colorValue,
-                                initial: project.initial,
-                                imagePath: project.imagePath,
-                                onReorder: widget.onReorder,
-                                child: _RemoteSlot(
-                                  workspaceId: project.id,
-                                  name: project.name,
-                                  colorValue: project.colorValue,
-                                  imagePath: project.imagePath,
-                                  selected: project.id == widget.selectedId,
-                                  git: widget.remoteGitInfoOf(project.id),
-                                  moveTargets: widget.moveTargetsOf(project.id),
-                                  worktreeCount: widget
-                                      .worktreesOf(project.id)
-                                      .length,
-                                  hasWorktrees: widget
-                                      .worktreesOf(project.id)
-                                      .isNotEmpty,
-                                  expanded: widget.worktreesExpanded(
-                                    project.id,
-                                  ),
-                                  onTap: () => _onCardTap(
-                                    project,
-                                    () => widget.onSelectRemote(project.id),
-                                  ),
-                                  onToggleExpanded: () =>
-                                      _toggleWorktrees(project),
-                                  onAction: (action) =>
-                                      widget.onRemoteWorkspaceAction(
-                                        project.id,
-                                        action,
-                                      ),
-                                ),
-                              ),
-                              _ForkList(
-                                expanded: widget.worktreesExpanded(project.id),
-                                children: _remoteForks(project),
-                              ),
-                            ] else ...[
-                              _WorkspaceReorderable(
-                                projectId: project.id,
-                                title: project.name,
-                                colorValue: project.colorValue,
-                                initial: project.initial,
-                                imagePath: project.imagePath,
-                                onReorder: widget.onReorder,
-                                child: _ProjectItem(
-                                  project: project,
-                                  selected: project.id == widget.selectedId,
-                                  notifications: widget.notificationCount(
-                                    project.id,
-                                  ),
-                                  git: widget.gitInfo(project.id),
-                                  rootsSummary: widget.rootsSummary(project.id),
-                                  worktreeCount: widget
-                                      .worktreesOf(project.id)
-                                      .length,
-                                  // "Criar worktree" só faz sentido em repo git
-                                  // (single ou multi-root — na multi a page pede
-                                  // a root alvo antes).
-                                  canCreateWorktree:
-                                      widget.gitInfo(project.id) != null ||
-                                      widget.rootsSummary(project.id).$1 > 1,
-                                  hasWorktrees: widget
-                                      .worktreesOf(project.id)
-                                      .isNotEmpty,
-                                  expanded: widget.worktreesExpanded(
-                                    project.id,
-                                  ),
-                                  onTap: () => _onCardTap(
-                                    project,
-                                    () => widget.onSelect(project.id),
-                                  ),
-                                  onToggleExpanded: () =>
-                                      _toggleWorktrees(project),
-                                  onConfigure: () =>
-                                      widget.onConfigure(project),
-                                  onDelete: () => widget.onDelete(project),
-                                  roots: widget.rootsOf(project.id),
-                                  onCreateWorktree: (r) =>
-                                      widget.onCreateWorktree(project, r),
-                                  onSync: (r) => widget.onSync(project, r),
-                                  onPull: (r) => widget.onPull(project, r),
-                                  onPush: (r) => widget.onPush(project, r),
-                                  moveTargets: widget.moveTargetsOf(project.id),
-                                  onMoveToRealm: (realmId) =>
-                                      widget.onMoveToRealm(project.id, realmId),
-                                ),
-                              ),
-                              // Worktrees (forks) penduradas abaixo do workspace,
-                              // expandidas/recolhidas pelo toggle do card (V37;
-                              // antes eram sempre visíveis — plan/42, dec. 5, 12).
-                              _ForkList(
-                                expanded: widget.worktreesExpanded(project.id),
-                                children: _forkItems(project),
-                              ),
-                            ],
-                          ],
-                        ],
+                        itemCount: projects.length,
+                        itemBuilder: (context, i) =>
+                            _workspaceBlock(projects[i]),
                       ),
                     ),
                   ),
@@ -474,20 +481,31 @@ class _ProjectsRailState extends State<ProjectsRail> {
 /// todo, então nada se desloca além da lista. Recolhida por completo, os itens
 /// saem da árvore (não ficam com altura zero atrás de um clip).
 class _ForkList extends StatelessWidget {
-  const _ForkList({required this.expanded, required this.children});
+  const _ForkList({
+    required this.hasWorktrees,
+    required this.expanded,
+    required this.builder,
+  });
 
+  /// `false` → nem o [AnimatedSize] é montado (workspace sem fork nenhum).
+  final bool hasWorktrees;
   final bool expanded;
-  final List<Widget> children;
+
+  /// As linhas das worktrees, construídas **sob demanda**: recolhido, o
+  /// [AnimatedSize] já descartava o conteúdo, mas o chamador montava os
+  /// `_WorktreeItem` assim mesmo — com um `forkOriginName` e um `gitInfo` por
+  /// fork, a cada build, para jogar tudo fora.
+  final List<Widget> Function() builder;
 
   @override
   Widget build(BuildContext context) {
-    if (children.isEmpty) return const SizedBox.shrink();
+    if (!hasWorktrees) return const SizedBox.shrink();
     return AnimatedSize(
       duration: _kToggleDuration,
       curve: Curves.easeOutCubic,
       alignment: Alignment.topCenter,
       child: expanded
-          ? Column(mainAxisSize: MainAxisSize.min, children: children)
+          ? Column(mainAxisSize: MainAxisSize.min, children: builder())
           : const SizedBox.shrink(),
     );
   }
@@ -622,7 +640,7 @@ class _RemoteSlot extends StatelessWidget {
     required this.imagePath,
     required this.selected,
     required this.git,
-    required this.moveTargets,
+    required this.moveTargetsOf,
     required this.worktreeCount,
     required this.hasWorktrees,
     required this.expanded,
@@ -641,8 +659,9 @@ class _RemoteSlot extends StatelessWidget {
   final String name;
   final int colorValue;
 
-  /// Realms de destino do "Move to realm" (vazio esconde o item).
-  final List<RealmTarget> moveTargets;
+  /// Realms de destino do "Move to realm" (vazio esconde o item). Thunk: varre
+  /// os workspaces por realm, e nada disso aparece no card — só no menu.
+  final List<RealmTarget> Function() moveTargetsOf;
 
   final int worktreeCount;
 
@@ -671,6 +690,7 @@ class _RemoteSlot extends StatelessWidget {
   Future<void> _showMenu(BuildContext context, Offset at) async {
     final tr = context.t.cockpit.projectsRail;
     final hasGit = branch != null;
+    final moveTargets = moveTargetsOf(); // resolvido no clique, não por build
     final pick = await showAppMenu<String>(
       context,
       globalPosition: at,
@@ -843,7 +863,7 @@ class _ProjectItem extends StatelessWidget {
     required this.notifications,
     required this.git,
     required this.rootsSummary,
-    required this.roots,
+    required this.rootsOf,
     required this.canCreateWorktree,
     required this.worktreeCount,
     required this.hasWorktrees,
@@ -856,7 +876,7 @@ class _ProjectItem extends StatelessWidget {
     required this.onSync,
     required this.onPull,
     required this.onPush,
-    required this.moveTargets,
+    required this.moveTargetsOf,
     required this.onMoveToRealm,
   });
 
@@ -869,8 +889,11 @@ class _ProjectItem extends StatelessWidget {
   /// [_GitBadge] quando [git] é `null` e há 2+ roots.
   final (int, int) rootsSummary;
 
-  /// Roots do workspace (submenu das ações git em multi-root).
-  final List<RailRoot> roots;
+  /// Roots do workspace (submenu das ações git em multi-root e popup do badge
+  /// multirepo). **Thunk**: resolver a lista custa um `split` e um lookup de
+  /// git por root, e nada disso é desenhado no card — só abre com o menu de
+  /// contexto ou o clique no badge. Antes era resolvido a cada build.
+  final List<RailRoot> Function() rootsOf;
   final bool canCreateWorktree;
 
   final int worktreeCount;
@@ -892,8 +915,10 @@ class _ProjectItem extends StatelessWidget {
   final void Function(String rootPath) onPull;
   final void Function(String rootPath) onPush;
 
-  /// Realms de destino do "Move to realm" (vazio esconde o item).
-  final List<RealmTarget> moveTargets;
+  /// Realms de destino do "Move to realm" (vazio esconde o item). Thunk pela
+  /// mesma razão de [rootsOf] — e este ainda varre a lista de workspaces por
+  /// realm, o que dava O(workspaces²) por build da rail.
+  final List<RealmTarget> Function() moveTargetsOf;
   final void Function(String realmId) onMoveToRealm;
 
   @override
@@ -903,14 +928,14 @@ class _ProjectItem extends StatelessWidget {
     final menu = _WorkspaceMenu(
       workspaceId: project.id,
       canCreateWorktree: canCreateWorktree,
-      roots: roots,
+      rootsOf: rootsOf,
       onConfigure: onConfigure,
       onDelete: onDelete,
       onCreateWorktree: onCreateWorktree,
       onSync: onSync,
       onPull: onPull,
       onPush: onPush,
-      moveTargets: moveTargets,
+      moveTargetsOf: moveTargetsOf,
       onMoveToRealm: onMoveToRealm,
     );
     return Padding(
@@ -964,7 +989,7 @@ class _ProjectItem extends StatelessWidget {
                           _MultiRootBadge(
                             roots: rootsSummary.$1,
                             dirtyRoots: rootsSummary.$2,
-                            rootList: roots,
+                            rootList: rootsOf,
                           ),
                         ],
                       ],
@@ -1029,6 +1054,7 @@ class _ProjectItem extends StatelessWidget {
 /// (ellipsis corta nomes longos). A linha fica **fora** do realce do item.
 class _WorktreeItem extends StatelessWidget {
   const _WorktreeItem({
+    super.key,
     required this.worktree,
     required this.originName,
     required this.isLast,
@@ -1327,9 +1353,13 @@ class _MultiRootBadge extends StatelessWidget {
   });
   final int roots;
   final int dirtyRoots;
-  final List<RailRoot> rootList;
+
+  /// Thunk: as roots só são lidas quando o popup abre — o chip mostra apenas os
+  /// contadores, que já vêm resolvidos em [roots]/[dirtyRoots].
+  final List<RailRoot> Function() rootList;
 
   void _showPopup(BuildContext context) {
+    final rootList = this.rootList();
     final overlay = showPopover<void>(
       context: context,
       alignment: Alignment.topLeft,
@@ -1587,14 +1617,14 @@ class _WorkspaceMenu {
   const _WorkspaceMenu({
     required this.workspaceId,
     required this.canCreateWorktree,
-    required this.roots,
+    required this.rootsOf,
     required this.onConfigure,
     required this.onDelete,
     required this.onCreateWorktree,
     required this.onSync,
     required this.onPull,
     required this.onPush,
-    required this.moveTargets,
+    required this.moveTargetsOf,
     required this.onMoveToRealm,
   });
 
@@ -1605,7 +1635,8 @@ class _WorkspaceMenu {
 
   /// Roots git do workspace. 2+ → as ações git viram **submenu** (escolhe a
   /// root ali mesmo); 1 → executam direto nela (comportamento histórico).
-  final List<RailRoot> roots;
+  /// Thunk: só é resolvido quando o menu abre.
+  final List<RailRoot> Function() rootsOf;
   final VoidCallback onConfigure;
   final VoidCallback onDelete;
   final void Function(String rootPath) onCreateWorktree;
@@ -1615,12 +1646,18 @@ class _WorkspaceMenu {
 
   /// Realms de destino do "Move to realm" (vazio = 0/1 realm → item oculto).
   /// Destino com o mesmo path já presente vem desabilitado (um path por realm).
-  final List<RealmTarget> moveTargets;
+  /// Thunk, como [rootsOf].
+  final List<RealmTarget> Function() moveTargetsOf;
   final void Function(String realmId) onMoveToRealm;
 
   /// Item de ação git: single-root executa direto (`<ação>|<root>`); multi-root
   /// abre submenu com uma entrada por root (roots sem git desabilitadas).
-  AppMenuItem<String> _gitItem(String action, String label, IconData icon) {
+  AppMenuItem<String> _gitItem(
+    List<RailRoot> roots,
+    String action,
+    String label,
+    IconData icon,
+  ) {
     final gitRoots = roots.where((r) => r.git != null).toList();
     if (roots.length <= 1) {
       final path = roots.isEmpty ? '' : roots.first.path;
@@ -1642,24 +1679,35 @@ class _WorkspaceMenu {
   }
 
   Future<void> show(BuildContext context, Offset at) async {
+    // Resolvidos aqui, no clique — não a cada build da rail.
+    final roots = rootsOf();
+    final moveTargets = moveTargetsOf();
     final pick = await showAppMenu<String>(
       context,
       globalPosition: at,
       items: [
         // Ações de sincronização só quando há git (single ou multi-root).
         if (canCreateWorktree) ...[
-          _gitItem('sync', context.t.cockpit.projectsRail.sync, Icons.sync),
           _gitItem(
+            roots,
+            'sync',
+            context.t.cockpit.projectsRail.sync,
+            Icons.sync,
+          ),
+          _gitItem(
+            roots,
             'pull',
             context.t.cockpit.projectsRail.pull,
             Icons.arrow_downward,
           ),
           _gitItem(
+            roots,
             'push',
             context.t.cockpit.projectsRail.push,
             Icons.arrow_upward,
           ),
           _gitItem(
+            roots,
             'worktree',
             context.t.cockpit.projectsRail.createWorktree,
             Icons.call_split,
@@ -1692,6 +1740,7 @@ class _WorkspaceMenu {
         // já tinha: é a mesma ação, só que na raiz.
         if (roots.any((r) => r.git != null))
           _gitItem(
+            roots,
             'copy-branch',
             context.t.cockpit.projectsRail.copyBranch,
             Icons.content_copy,

--- a/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/projects_rail.dart
@@ -39,24 +39,6 @@ String? branchOfRoot(List<RailRoot> roots, String rootPath) {
   return null;
 }
 
-/// O que um clique no **card** do workspace faz (V37). `select` = selecionar o
-/// workspace; `expand` = novo estado da lista de worktrees (`null` = não mexer,
-/// caso do workspace sem fork nenhum — não há lista a alternar).
-///
-/// Não selecionado → seleciona e já deixa a lista aberta (uma ação, dois
-/// resultados). Já selecionado → o clique só alterna a lista.
-@visibleForTesting
-({bool select, bool? expand}) workspaceCardTap({
-  required bool selected,
-  required bool expanded,
-  required bool hasWorktrees,
-}) {
-  if (!hasWorktrees) return (select: !selected, expand: null);
-  // Selecionar nunca recolhe: o clique que traz o workspace pra frente abre a
-  // lista junto. Já selecionado, esse mesmo clique passa a ser só o toggle.
-  return (select: !selected, expand: selected ? !expanded : true);
-}
-
 /// Tempo do toggle de worktrees: o chevron gira e a lista anima a altura nesta
 /// duração. Só esses dois animam — o card/cabeçalho não se move.
 const Duration _kToggleDuration = Duration(milliseconds: 150);
@@ -105,7 +87,6 @@ class ProjectsRail extends StatefulWidget {
     required this.onSelectCockpit,
     required this.onNewWorkspace,
     required this.onSelectRemote,
-    required this.onRemoveRemoteWorkspace,
     required this.remoteGitInfoOf,
     required this.onRemoteWorkspaceAction,
     this.width = 252,
@@ -129,9 +110,6 @@ class ProjectsRail extends StatefulWidget {
 
   /// "+": abre o menu Local vs Remoto, ancorado no [anchorContext] do botão.
   final void Function(BuildContext anchorContext) onNewWorkspace;
-
-  /// Remove um workspace remoto (pin) pelo id do workspace.
-  final void Function(String workspaceId) onRemoveRemoteWorkspace;
 
   /// Git status do workspace remoto (badge abaixo do nome + branch do menu);
   /// `null` = sem git ou ainda carregando (lazy).
@@ -225,18 +203,20 @@ class _ProjectsRailState extends State<ProjectsRail> {
     super.dispose();
   }
 
-  /// Clique no card do workspace [project] (V37): seleciona e/ou alterna a
-  /// lista de worktrees, conforme [workspaceCardTap]. [onSelect] varia entre
-  /// local e remoto — o resto da regra é o mesmo pros dois.
+  /// Clique no card do workspace [project]: **só seleciona**. Expandir/recolher
+  /// a lista de worktrees é exclusividade do chevron ([_toggleWorktrees]), pra
+  /// dar de olhar os forks de um workspace sem trazê-lo pra frente.
+  /// [onSelect] varia entre local e remoto — o resto da regra é o mesmo pros dois.
   void _onCardTap(Project project, VoidCallback onSelect) {
-    final action = workspaceCardTap(
-      selected: project.id == widget.selectedId,
-      expanded: widget.worktreesExpanded(project.id),
-      hasWorktrees: widget.worktreesOf(project.id).isNotEmpty,
+    if (project.id != widget.selectedId) onSelect();
+  }
+
+  /// Clique no chevron: alterna a lista de worktrees **sem** mexer na seleção.
+  void _toggleWorktrees(Project project) {
+    widget.onWorktreesExpanded(
+      project.id,
+      !widget.worktreesExpanded(project.id),
     );
-    if (action.select) onSelect();
-    final expand = action.expand;
-    if (expand != null) widget.onWorktreesExpanded(project.id, expand);
   }
 
   /// Os forks de um workspace, com `isLast` marcado pra linha de árvore fechar
@@ -339,9 +319,8 @@ class _ProjectsRailState extends State<ProjectsRail> {
                     controller: _scroll,
                     thumbVisibility: true,
                     child: ScrollConfiguration(
-                      behavior: ScrollConfiguration.of(
-                        context,
-                      ).copyWith(scrollbars: false),
+                      behavior: ScrollConfiguration.of(context)
+                          .copyWith(scrollbars: false),
                       child: ListView(
                         controller: _scroll,
                         padding: const EdgeInsets.symmetric(horizontal: 8),
@@ -378,13 +357,13 @@ class _ProjectsRailState extends State<ProjectsRail> {
                                     project,
                                     () => widget.onSelectRemote(project.id),
                                   ),
+                                  onToggleExpanded: () =>
+                                      _toggleWorktrees(project),
                                   onAction: (action) =>
                                       widget.onRemoteWorkspaceAction(
                                         project.id,
                                         action,
                                       ),
-                                  onRemove: () => widget
-                                      .onRemoveRemoteWorkspace(project.id),
                                 ),
                               ),
                               _ForkList(
@@ -426,6 +405,8 @@ class _ProjectsRailState extends State<ProjectsRail> {
                                     project,
                                     () => widget.onSelect(project.id),
                                   ),
+                                  onToggleExpanded: () =>
+                                      _toggleWorktrees(project),
                                   onConfigure: () =>
                                       widget.onConfigure(project),
                                   onDelete: () => widget.onDelete(project),
@@ -530,55 +511,39 @@ class _WorktreeSummary extends StatelessWidget {
 }
 
 /// Chevron do card: usa glifos explícitos para garantir direita/recolhido e
-/// baixo/expandido em todas as plataformas. Puramente indicativo — quem recebe
-/// o clique é o card inteiro, então ele não intercepta ponteiro nenhum.
+/// baixo/expandido em todas as plataformas. **Único botão do card** — recebe o
+/// clique com [HitTestBehavior.opaque] pra alternar a lista sem selecionar o
+/// workspace; o clique-direito, que ele não declara, sobe pro menu de contexto
+/// do card.
 class _WorktreeChevron extends StatelessWidget {
-  const _WorktreeChevron({required this.expanded});
+  const _WorktreeChevron({required this.expanded, required this.onTap});
 
   final bool expanded;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final tr = context.t.cockpit.projectsRail;
     return AppTooltip(
       message: expanded ? tr.collapseWorktrees : tr.expandWorktrees,
-      child: AnimatedSwitcher(
-        duration: _kToggleDuration,
-        switchInCurve: Curves.easeOutCubic,
-        switchOutCurve: Curves.easeInCubic,
-        transitionBuilder: (child, animation) =>
-            FadeTransition(opacity: animation, child: child),
-        child: Icon(
-          worktreeChevronIcon(expanded),
-          key: ValueKey(expanded),
-          size: 16,
-          color: context.colors.text3,
+      child: HoverTap(
+        onTap: onTap,
+        padding: const EdgeInsets.all(5),
+        borderRadius: BorderRadius.circular(6),
+        child: AnimatedSwitcher(
+          duration: _kToggleDuration,
+          switchInCurve: Curves.easeOutCubic,
+          switchOutCurve: Curves.easeInCubic,
+          transitionBuilder: (child, animation) =>
+              FadeTransition(opacity: animation, child: child),
+          child: Icon(
+            worktreeChevronIcon(expanded),
+            key: ValueKey(expanded),
+            size: 16,
+            color: context.colors.text3,
+          ),
         ),
       ),
-    );
-  }
-}
-
-class _CardTrailingSlot extends StatelessWidget {
-  const _CardTrailingSlot({
-    required this.menu,
-    required this.hasWorktrees,
-    required this.expanded,
-  });
-
-  final Widget menu;
-  final bool hasWorktrees;
-  final bool expanded;
-
-  @override
-  Widget build(BuildContext context) {
-    if (!hasWorktrees) return menu;
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        menu,
-        _WorktreeChevron(expanded: expanded),
-      ],
     );
   }
 }
@@ -662,8 +627,8 @@ class _RemoteSlot extends StatelessWidget {
     required this.hasWorktrees,
     required this.expanded,
     required this.onTap,
+    required this.onToggleExpanded,
     required this.onAction,
-    required this.onRemove,
   });
 
   /// `true` se o host tem forks pendurados — só então o chevron aparece.
@@ -697,15 +662,18 @@ class _RemoteSlot extends StatelessWidget {
 
   final VoidCallback onTap;
 
+  /// Alterna a lista de forks (clique no chevron) — sem tocar na seleção.
+  final VoidCallback onToggleExpanded;
+
   /// Ações roteadas pra página: 'pull' | 'push' | 'sync' | 'rename' | 'close'.
   final void Function(String action) onAction;
-  final VoidCallback onRemove;
 
-  Future<void> _showMenu(BuildContext context) async {
+  Future<void> _showMenu(BuildContext context, Offset at) async {
     final tr = context.t.cockpit.projectsRail;
     final hasGit = branch != null;
     final pick = await showAppMenu<String>(
       context,
+      globalPosition: at,
       items: [
         if (hasGit) ...[
           AppMenuItem(value: 'sync', label: tr.sync, icon: Icons.sync),
@@ -777,9 +745,10 @@ class _RemoteSlot extends StatelessWidget {
     final colors = context.colors;
     final accent = Color(colorValue);
     return GestureDetector(
-      // Botão-direito remove o pin (o registro do host sai; nada apagado no
-      // servidor). Tooltip via AppTooltip explica.
-      onSecondaryTap: onRemove,
+      // Botão-direito abre o menu no cursor — mesmo padrão do workspace local.
+      // Antes ele removia o pin direto, sem confirmação; hoje isso é o item
+      // "Close" do menu, que roteia pro mesmo removeRemoteWorkspace.
+      onSecondaryTapUp: (d) => _showMenu(context, d.globalPosition),
       child: HoverTap(
         color: selected ? colors.panel2 : Colors.transparent,
         borderRadius: BorderRadius.circular(7),
@@ -847,29 +816,12 @@ class _RemoteSlot extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 2),
-                _CardTrailingSlot(
-                  hasWorktrees: hasWorktrees,
-                  expanded: expanded,
-                  menu: Builder(
-                    // O menu ancora no RenderBox do ícone, não no slot inteiro.
-                    builder: (iconContext) => GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTapUp: (_) => _showMenu(iconContext),
-                      child: SizedBox(
-                        width: 22,
-                        height: 22,
-                        child: Icon(
-                          Icons.more_vert,
-                          size: 14,
-                          color: context.colors.text3,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+                if (hasWorktrees)
+                  _WorktreeChevron(expanded: expanded, onTap: onToggleExpanded),
               ],
             ),
-            if (hasWorktrees)
+            // Contagem só recolhido — expandido, os forks já estão à vista.
+            if (hasWorktrees && !expanded)
               Padding(
                 padding: const EdgeInsets.only(left: 38, top: 4),
                 child: Align(
@@ -897,6 +849,7 @@ class _ProjectItem extends StatelessWidget {
     required this.hasWorktrees,
     required this.expanded,
     required this.onTap,
+    required this.onToggleExpanded,
     required this.onConfigure,
     required this.onDelete,
     required this.onCreateWorktree,
@@ -929,6 +882,9 @@ class _ProjectItem extends StatelessWidget {
   /// Estado atual da lista de worktrees (V37).
   final bool expanded;
   final VoidCallback onTap;
+
+  /// Alterna a lista de worktrees (clique no chevron) — sem tocar na seleção.
+  final VoidCallback onToggleExpanded;
   final VoidCallback onConfigure;
   final VoidCallback onDelete;
   final void Function(String rootPath) onCreateWorktree;
@@ -944,112 +900,121 @@ class _ProjectItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final gitInfo = git;
+    final menu = _WorkspaceMenu(
+      workspaceId: project.id,
+      canCreateWorktree: canCreateWorktree,
+      roots: roots,
+      onConfigure: onConfigure,
+      onDelete: onDelete,
+      onCreateWorktree: onCreateWorktree,
+      onSync: onSync,
+      onPull: onPull,
+      onPush: onPush,
+      moveTargets: moveTargets,
+      onMoveToRealm: onMoveToRealm,
+    );
     return Padding(
       padding: const EdgeInsets.only(bottom: 2),
-      child: HoverTap(
-        color: selected ? colors.panel2 : Colors.transparent,
-        borderRadius: BorderRadius.circular(7),
-        onTap: onTap,
-        padding: const EdgeInsets.fromLTRB(9, 7, 5, 7),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                WorkspaceAvatar(
-                  imagePath: project.imagePath,
-                  colorValue: project.colorValue,
-                  initial: project.initial,
-                  size: 30,
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        project.name,
-                        overflow: TextOverflow.ellipsis,
-                        style: context.typo.body.copyWith(
-                          fontSize: 13.5,
-                          color: colors.text,
-                          fontWeight: selected
-                              ? FontWeight.w500
-                              : FontWeight.w400,
-                        ),
-                      ),
-                      // Linha do git — repo git (branch) ou multi-root (agregado);
-                      // pasta comum não mostra nada.
-                      if (gitInfo != null) ...[
-                        const SizedBox(height: 4),
-                        _AbsorbCardTap(child: _GitBadge(info: gitInfo)),
-                      ] else if (rootsSummary.$1 > 1) ...[
-                        const SizedBox(height: 4),
-                        _MultiRootBadge(
-                          roots: rootsSummary.$1,
-                          dirtyRoots: rootsSummary.$2,
-                          rootList: roots,
-                        ),
-                      ],
-                    ],
+      // Botão-direito em qualquer ponto do card abre o menu no cursor. Fica por
+      // FORA do HoverTap porque ele só expõe o tap primário; os badges internos
+      // (_AbsorbCardTap) também só declaram onTap, então o secundário sobe até aqui.
+      child: GestureDetector(
+        onSecondaryTapUp: (d) => menu.show(context, d.globalPosition),
+        child: HoverTap(
+          color: selected ? colors.panel2 : Colors.transparent,
+          borderRadius: BorderRadius.circular(7),
+          onTap: onTap,
+          padding: const EdgeInsets.fromLTRB(9, 7, 5, 7),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  WorkspaceAvatar(
+                    imagePath: project.imagePath,
+                    colorValue: project.colorValue,
+                    initial: project.initial,
+                    size: 30,
                   ),
-                ),
-                const SizedBox(width: 6),
-                if (notifications > 0) ...[
-                  _AbsorbCardTap(
-                    child: Container(
-                      constraints: const BoxConstraints(minWidth: 18),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 6,
-                        vertical: 1,
-                      ),
-                      decoration: BoxDecoration(
-                        color: colors.accent,
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: Text(
-                        '$notifications',
-                        textAlign: TextAlign.center,
-                        style: context.typo.mono.copyWith(
-                          fontSize: 11,
-                          color: onColor(colors.accent),
-                          fontWeight: FontWeight.w600,
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          project.name,
+                          overflow: TextOverflow.ellipsis,
+                          style: context.typo.body.copyWith(
+                            fontSize: 13.5,
+                            color: colors.text,
+                            fontWeight: selected
+                                ? FontWeight.w500
+                                : FontWeight.w400,
+                          ),
+                        ),
+                        // Linha do git — repo git (branch) ou multi-root (agregado);
+                        // pasta comum não mostra nada.
+                        if (gitInfo != null) ...[
+                          const SizedBox(height: 4),
+                          _AbsorbCardTap(child: _GitBadge(info: gitInfo)),
+                        ] else if (rootsSummary.$1 > 1) ...[
+                          const SizedBox(height: 4),
+                          _MultiRootBadge(
+                            roots: rootsSummary.$1,
+                            dirtyRoots: rootsSummary.$2,
+                            rootList: roots,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  if (notifications > 0) ...[
+                    _AbsorbCardTap(
+                      child: Container(
+                        constraints: const BoxConstraints(minWidth: 18),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 1,
+                        ),
+                        decoration: BoxDecoration(
+                          color: colors.accent,
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Text(
+                          '$notifications',
+                          textAlign: TextAlign.center,
+                          style: context.typo.mono.copyWith(
+                            fontSize: 11,
+                            color: onColor(colors.accent),
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 4),
+                    const SizedBox(width: 4),
+                  ],
+                  if (hasWorktrees)
+                    _WorktreeChevron(
+                      expanded: expanded,
+                      onTap: onToggleExpanded,
+                    ),
                 ],
-                _CardTrailingSlot(
-                  hasWorktrees: hasWorktrees,
-                  expanded: expanded,
-                  menu: _MenuButton(
-                    workspaceId: project.id,
-                    canCreateWorktree: canCreateWorktree,
-                    roots: roots,
-                    onConfigure: onConfigure,
-                    onDelete: onDelete,
-                    onCreateWorktree: onCreateWorktree,
-                    onSync: onSync,
-                    onPull: onPull,
-                    onPush: onPush,
-                    moveTargets: moveTargets,
-                    onMoveToRealm: onMoveToRealm,
+              ),
+              // Contagem só faz sentido recolhido: expandido, as linhas das
+              // worktrees já estão logo abaixo, à vista.
+              if (hasWorktrees && !expanded)
+                Padding(
+                  padding: const EdgeInsets.only(left: 40, top: 4),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: _WorktreeSummary(count: worktreeCount),
                   ),
                 ),
-              ],
-            ),
-            if (hasWorktrees)
-              Padding(
-                padding: const EdgeInsets.only(left: 40, top: 4),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: _WorktreeSummary(count: worktreeCount),
-                ),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -1059,9 +1024,9 @@ class _ProjectItem extends StatelessWidget {
 /// Item de uma worktree (fork): pendurado abaixo do workspace pai por uma
 /// **linha de árvore** (vertical contínua nos forks do meio, "└" no último),
 /// sem avatar (o branch é a identidade). À direita, o sinal combinado de
-/// dirtyCount + notificação (decisões 8, 16, 19) e o menu ⋮ "Remover". Hover
-/// no nome mostra tooltip com o rótulo completo (ellipsis corta nomes longos).
-/// A linha fica **fora** do realce do item.
+/// dirtyCount + notificação (decisões 8, 16, 19); as ações vêm no menu de
+/// **botão-direito**. Hover no nome mostra tooltip com o rótulo completo
+/// (ellipsis corta nomes longos). A linha fica **fora** do realce do item.
 class _WorktreeItem extends StatelessWidget {
   const _WorktreeItem({
     required this.worktree,
@@ -1103,6 +1068,13 @@ class _WorktreeItem extends StatelessWidget {
     final fullLabel = originName != null
         ? '${worktree.name}  ($originName)'
         : worktree.name;
+    final menu = _WorktreeMenu(
+      branch: worktree.name,
+      onRemove: onRemove,
+      onMerge: onMerge,
+      onUpdate: onUpdate,
+      onFork: onFork,
+    );
     return IntrinsicHeight(
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1118,59 +1090,57 @@ class _WorktreeItem extends StatelessWidget {
           Expanded(
             child: Padding(
               padding: const EdgeInsets.only(bottom: 2),
-              child: HoverTap(
-                color: selected ? colors.panel2 : Colors.transparent,
-                borderRadius: BorderRadius.circular(7),
-                onTap: onTap,
-                padding: const EdgeInsets.fromLTRB(0, 5, 7, 5),
-                child: Row(
-                  children: [
-                    Icon(Icons.call_split, size: 12, color: colors.text3),
-                    const SizedBox(width: 7),
-                    Expanded(
-                      child: AppTooltip(
-                        message: fullLabel,
-                        child: Text.rich(
-                          TextSpan(
-                            text: worktree.name,
-                            children: [
-                              // Sufixo `(root)` só em pai multi-root: diz de
-                              // qual repo o fork nasceu (branch pode repetir).
-                              if (originName != null)
-                                TextSpan(
-                                  text: '  ($originName)',
-                                  style: context.typo.mono.copyWith(
-                                    fontSize: 11,
-                                    color: colors.text3,
+              // Botão-direito na linha abre o menu do fork no cursor. Envolve só
+              // o HoverTap: a linha de árvore fica fora do realce e do gesto.
+              child: GestureDetector(
+                onSecondaryTapUp: (d) => menu.show(context, d.globalPosition),
+                child: HoverTap(
+                  color: selected ? colors.panel2 : Colors.transparent,
+                  borderRadius: BorderRadius.circular(7),
+                  onTap: onTap,
+                  // Sem o ⋮ de 22px, o padding direito segura o sinal longe da borda.
+                  padding: const EdgeInsets.fromLTRB(0, 5, 9, 5),
+                  child: Row(
+                    children: [
+                      Icon(Icons.call_split, size: 12, color: colors.text3),
+                      const SizedBox(width: 7),
+                      Expanded(
+                        child: AppTooltip(
+                          message: fullLabel,
+                          child: Text.rich(
+                            TextSpan(
+                              text: worktree.name,
+                              children: [
+                                // Sufixo `(root)` só em pai multi-root: diz de
+                                // qual repo o fork nasceu (branch pode repetir).
+                                if (originName != null)
+                                  TextSpan(
+                                    text: '  ($originName)',
+                                    style: context.typo.mono.copyWith(
+                                      fontSize: 11,
+                                      color: colors.text3,
+                                    ),
                                   ),
-                                ),
-                            ],
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                          style: context.typo.mono.copyWith(
-                            fontSize: 12,
-                            color: selected ? colors.text : colors.text2,
-                            fontWeight: selected
-                                ? FontWeight.w500
-                                : FontWeight.w400,
+                              ],
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                            style: context.typo.mono.copyWith(
+                              fontSize: 12,
+                              color: selected ? colors.text : colors.text2,
+                              fontWeight: selected
+                                  ? FontWeight.w500
+                                  : FontWeight.w400,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 6),
-                    _WorktreeSignal(
-                      dirtyCount: git?.dirtyCount ?? 0,
-                      hasNotification: notifications > 0,
-                    ),
-                    const SizedBox(width: 2),
-                    _ForkMenuButton(
-                      branch: worktree.name,
-                      onRemove: onRemove,
-                      onMerge: onMerge,
-                      onUpdate: onUpdate,
-                      onFork: onFork,
-                    ),
-                  ],
+                      const SizedBox(width: 6),
+                      _WorktreeSignal(
+                        dirtyCount: git?.dirtyCount ?? 0,
+                        hasNotification: notifications > 0,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -1181,9 +1151,10 @@ class _WorktreeItem extends StatelessWidget {
   }
 }
 
-/// Menu ⋮ compacto do fork — só "Remover" (plan/42, decisão 13).
-class _ForkMenuButton extends StatelessWidget {
-  const _ForkMenuButton({
+/// Menu de contexto do fork (botão-direito na linha da worktree). Não é widget
+/// — é só o descritor do menu, aberto por [show] no ponto do clique.
+class _WorktreeMenu {
+  const _WorktreeMenu({
     required this.branch,
     required this.onRemove,
     required this.onMerge,
@@ -1197,9 +1168,10 @@ class _ForkMenuButton extends StatelessWidget {
   final VoidCallback onUpdate;
   final VoidCallback onFork;
 
-  Future<void> _show(BuildContext context) async {
+  Future<void> show(BuildContext context, Offset at) async {
     final pick = await showAppMenu<String>(
       context,
+      globalPosition: at,
       items: [
         AppMenuItem(
           value: 'merge',
@@ -1240,22 +1212,6 @@ class _ForkMenuButton extends StatelessWidget {
       await Clipboard.setData(ClipboardData(text: branch));
     }
     if (pick == 'remove') onRemove();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTapUp: (_) => _show(context),
-        child: SizedBox(
-          width: 22,
-          height: 22,
-          child: Icon(Icons.more_vert, size: 14, color: context.colors.text3),
-        ),
-      ),
-    );
   }
 }
 
@@ -1624,10 +1580,11 @@ class _AheadBehind extends StatelessWidget {
   }
 }
 
-/// Botão ⋮ compacto (26px, encostado na borda) com menu Criar worktree (só em
-/// repo git) / Configurações / Deletar.
-class _MenuButton extends StatelessWidget {
-  const _MenuButton({
+/// Menu de contexto do workspace (botão-direito no card): Criar worktree (só em
+/// repo git) / Configurações / Deletar. Não é widget — é só o descritor do
+/// menu, aberto por [show] no ponto do clique.
+class _WorkspaceMenu {
+  const _WorkspaceMenu({
     required this.workspaceId,
     required this.canCreateWorktree,
     required this.roots,
@@ -1684,9 +1641,10 @@ class _MenuButton extends StatelessWidget {
     );
   }
 
-  Future<void> _show(BuildContext context) async {
+  Future<void> show(BuildContext context, Offset at) async {
     final pick = await showAppMenu<String>(
       context,
+      globalPosition: at,
       items: [
         // Ações de sincronização só quando há git (single ou multi-root).
         if (canCreateWorktree) ...[
@@ -1778,22 +1736,6 @@ class _MenuButton extends StatelessWidget {
     }
     if (pick == 'config') onConfigure();
     if (pick == 'delete') onDelete();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTapUp: (_) => _show(context),
-        child: SizedBox(
-          width: 26,
-          height: 26,
-          child: Icon(Icons.more_vert, size: 16, color: context.colors.text3),
-        ),
-      ),
-    );
   }
 }
 

--- a/cockpit/test/ui/projects_rail_context_menu_test.dart
+++ b/cockpit/test/ui/projects_rail_context_menu_test.dart
@@ -124,7 +124,7 @@ Widget _rail({
           worktreesExpanded: (_) => expanded,
           onWorktreesExpanded: onWorktreesExpanded ?? (_, _) {},
           selectedId: selectedId,
-          notificationCount: (_) => 0,
+          notificationCounts: const {},
           gitInfo: (_) => const GitInfo(branch: 'main'),
           rootsSummary: (_) => (1, 0),
           rootsOf: (_) => [

--- a/cockpit/test/ui/projects_rail_context_menu_test.dart
+++ b/cockpit/test/ui/projects_rail_context_menu_test.dart
@@ -1,0 +1,285 @@
+import 'package:cockpit/app/cockpit/domain/contracts/dismissed_update_store.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/self_updater.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/update_checker.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/url_opener.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_info.dart';
+import 'package:cockpit/app/cockpit/domain/entities/project.dart';
+import 'package:cockpit/app/cockpit/domain/entities/realm.dart';
+import 'package:cockpit/app/cockpit/domain/entities/update_info.dart';
+import 'package:cockpit/app/cockpit/domain/value_objects/update_target.dart';
+import 'package:cockpit/app/cockpit/ui/viewmodels/update_viewmodel.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/projects_rail.dart';
+import 'package:cockpit/app/core/ui/themes/themes.dart';
+import 'package:cockpit/i18n/strings.g.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+/// O rodapé da rail tem um [UpdateCard] que faz `context.watch<UpdateViewModel>()`.
+/// Estes fakes existem só pra o escopo resolver — sem update pendente, o card
+/// vira `SizedBox.shrink()` e não interfere em nada do que é testado aqui.
+class _NoUpdateChecker implements UpdateChecker {
+  @override
+  Future<UpdateInfo?> fetchLatest() async => null;
+}
+
+class _NoDismissStore implements DismissedUpdateStore {
+  @override
+  String? dismissedVersion() => null;
+  @override
+  Future<void> dismiss(String version) async {}
+}
+
+class _NoUrlOpener implements UrlOpener {
+  @override
+  Future<bool> open(String url) async => true;
+}
+
+class _NoSelfUpdater implements SelfUpdater {
+  @override
+  bool get isSupported => false;
+  @override
+  SelfUpdateState get state => const SelfUpdateState.idle();
+  @override
+  Stream<SelfUpdateState> get changes => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> checkForUpdates({bool inBackground = true}) async {}
+  @override
+  Future<void> applyUpdate() async {}
+  @override
+  void dispose() {}
+}
+
+UpdateViewModel _fakeUpdateVm() => UpdateViewModel(
+  _NoUpdateChecker(),
+  _NoDismissStore(),
+  _NoUrlOpener(),
+  const UpdateTarget(
+    version: '1.0.0',
+    platform: 'linux',
+    format: 'deb',
+    arch: 'x64',
+  ),
+  _NoSelfUpdater(),
+);
+
+/// Refino do card de workspace: o kebab ⋮ deu lugar ao **botão-direito**, e o
+/// chevron virou o único botão — alterna a lista sem selecionar o workspace.
+
+final _root = Project(
+  id: 'ws1',
+  name: 'Remote Pi',
+  path: '/repo',
+  colorValue: 0xFF3B82F6,
+  createdAt: DateTime.utc(2026),
+);
+
+final _fork = Project(
+  id: 'wt1',
+  name: 'feat/x',
+  path: '/repo/.worktrees/feat-x',
+  colorValue: 0xFF3B82F6,
+  createdAt: DateTime.utc(2026),
+  parentId: 'ws1',
+);
+
+final _realm = Realm(
+  id: Realm.defaultId,
+  name: 'Default',
+  createdAt: DateTime.utc(2026),
+);
+
+/// Raiz do app de teste: ShadcnApp (tema — `context.colors`/`typo`) sobre o
+/// router do Modular (que é quem carrega o escopo do UpdateViewModel).
+class _Root extends StatelessWidget {
+  const _Root();
+
+  @override
+  Widget build(BuildContext context) => ShadcnApp.router(
+    theme: buildTheme(brightness: Brightness.dark),
+    routerConfig: ModularApp.routerConfigOf(context),
+  );
+}
+
+/// Monta a rail com defaults no-op; cada teste sobrescreve só o que observa.
+Widget _rail({
+  String? selectedId,
+  List<Project> worktrees = const [],
+  bool expanded = true,
+  void Function(String rootId, bool expanded)? onWorktreesExpanded,
+  ValueChanged<String>? onSelect,
+  ValueChanged<Project>? onRemoveWorktree,
+}) {
+  final feature = createModule(
+    path: '/',
+    register: (c) => c.route(
+      '/',
+      child: (context, state) => Scaffold(
+        child: ProjectsRail(
+          projects: [_root],
+          worktreesOf: (id) => id == _root.id ? worktrees : const [],
+          worktreesExpanded: (_) => expanded,
+          onWorktreesExpanded: onWorktreesExpanded ?? (_, _) {},
+          selectedId: selectedId,
+          notificationCount: (_) => 0,
+          gitInfo: (_) => const GitInfo(branch: 'main'),
+          rootsSummary: (_) => (1, 0),
+          rootsOf: (_) => [
+            (path: '/repo', name: 'repo', git: const GitInfo(branch: 'main')),
+          ],
+          forkOriginName: (_) => null,
+          onSelect: onSelect ?? (_) {},
+          onAdd: () async => true,
+          onConfigure: (_) {},
+          onDelete: (_) {},
+          onCreateWorktree: (_, _) {},
+          onRemoveWorktree: onRemoveWorktree ?? (_) {},
+          onMergeWorktree: (_) {},
+          onUpdateWorktree: (_) {},
+          onForkWorktree: (_) {},
+          onSync: (_, _) {},
+          onPull: (_, _) {},
+          onPush: (_, _) {},
+          onOpenSettings: () {},
+          onReorder: (_, _, _) {},
+          realms: [_realm],
+          activeRealm: _realm,
+          onSwitchRealm: (_) {},
+          onCreateRealm: () {},
+          onManageRealms: () {},
+          moveTargetsOf: (_) => const [],
+          onMoveToRealm: (_, _) {},
+          onSelectCockpit: () {},
+          onNewWorkspace: (_) {},
+          onSelectRemote: (_) {},
+          remoteGitInfoOf: (_) => null,
+          onRemoteWorkspaceAction: (_, _) {},
+        ),
+      ),
+    ),
+  );
+  return TranslationProvider(
+    child: ModularApp(
+      module: createModule(register: (c) => c.module(feature)),
+      provide: (s) => s.addChangeNotifier<UpdateViewModel>(_fakeUpdateVm),
+      child: const _Root(),
+    ),
+  );
+}
+
+/// Rótulo traduzido de "N worktrees", lido da árvore já montada.
+String _countLabel(WidgetTester tester, int n) => TranslationProvider.of(
+  tester.element(find.text('Remote Pi')),
+).translations.cockpit.projectsRail.worktreeCount(n: n);
+
+/// Clique-direito no centro de [finder].
+Future<void> _secondaryTap(WidgetTester tester, Finder finder) async {
+  final gesture = await tester.startGesture(
+    tester.getCenter(finder),
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryButton,
+  );
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('card e worktree não têm mais o botão ⋮', (tester) async {
+    await tester.pumpWidget(_rail(worktrees: [_fork]));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.more_vert), findsNothing);
+  });
+
+  testWidgets('chevron alterna a lista sem selecionar o workspace', (
+    tester,
+  ) async {
+    final expandCalls = <(String, bool)>[];
+    var selectCalls = 0;
+
+    // Workspace NÃO selecionado e recolhido: antes o toggle exigia selecionar.
+    await tester.pumpWidget(
+      _rail(
+        selectedId: 'outro',
+        worktrees: [_fork],
+        expanded: false,
+        onWorktreesExpanded: (id, e) => expandCalls.add((id, e)),
+        onSelect: (_) => selectCalls++,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pumpAndSettle();
+
+    expect(expandCalls, [('ws1', true)]);
+    expect(selectCalls, 0);
+  });
+
+  testWidgets('clique no corpo do card só seleciona', (tester) async {
+    final expandCalls = <(String, bool)>[];
+    final selected = <String>[];
+
+    await tester.pumpWidget(
+      _rail(
+        selectedId: 'outro',
+        worktrees: [_fork],
+        onWorktreesExpanded: (id, e) => expandCalls.add((id, e)),
+        onSelect: selected.add,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Remote Pi'));
+    await tester.pumpAndSettle();
+
+    expect(selected, ['ws1']);
+    expect(expandCalls, isEmpty);
+  });
+
+  testWidgets('botão-direito no card abre o menu do workspace', (tester) async {
+    await tester.pumpWidget(_rail(worktrees: [_fork]));
+    await tester.pumpAndSettle();
+
+    final tr = TranslationProvider.of(
+      tester.element(find.text('Remote Pi')),
+    ).translations.cockpit.projectsRail;
+
+    expect(find.text(tr.settings), findsNothing);
+    await _secondaryTap(tester, find.text('Remote Pi'));
+    expect(find.text(tr.settings), findsOneWidget);
+    expect(find.text(tr.createWorktree), findsOneWidget);
+  });
+
+  testWidgets('botão-direito na worktree abre o menu do fork', (tester) async {
+    await tester.pumpWidget(_rail(worktrees: [_fork]));
+    await tester.pumpAndSettle();
+
+    final tr = TranslationProvider.of(
+      tester.element(find.text('Remote Pi')),
+    ).translations.cockpit.projectsRail;
+
+    await _secondaryTap(tester, find.text('feat/x'));
+    expect(find.text(tr.mergeToParent), findsOneWidget);
+    expect(find.text(tr.remove), findsOneWidget);
+  });
+
+  // Expandido, as linhas das worktrees já estão à vista — a contagem só
+  // duplicaria a informação. Recolhido, ela é a única pista do que há dentro.
+  testWidgets('expandido esconde a contagem de worktrees', (tester) async {
+    await tester.pumpWidget(_rail(worktrees: [_fork], expanded: true));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_countLabel(tester, 1)), findsNothing);
+  });
+
+  testWidgets('recolhido mostra a contagem de worktrees', (tester) async {
+    await tester.pumpWidget(_rail(worktrees: [_fork], expanded: false));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_countLabel(tester, 1)), findsOneWidget);
+  });
+}

--- a/cockpit/test/ui/projects_rail_perf_test.dart
+++ b/cockpit/test/ui/projects_rail_perf_test.dart
@@ -1,0 +1,264 @@
+import 'package:cockpit/app/cockpit/domain/contracts/dismissed_update_store.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/self_updater.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/update_checker.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/url_opener.dart';
+import 'package:cockpit/app/cockpit/domain/entities/git_info.dart';
+import 'package:cockpit/app/cockpit/domain/entities/project.dart';
+import 'package:cockpit/app/cockpit/domain/entities/realm.dart';
+import 'package:cockpit/app/cockpit/domain/entities/update_info.dart';
+import 'package:cockpit/app/cockpit/domain/value_objects/update_target.dart';
+import 'package:cockpit/app/cockpit/ui/viewmodels/update_viewmodel.dart';
+import 'package:cockpit/app/cockpit/ui/widgets/projects_rail.dart';
+import 'package:cockpit/app/core/ui/themes/themes.dart';
+import 'package:cockpit/i18n/strings.g.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+/// Custo de um build da rail. Cada teste conta quantas vezes o painel pergunta
+/// algo ao VM por frame — é isso que multiplica quando o VM notifica.
+
+class _NoUpdateChecker implements UpdateChecker {
+  @override
+  Future<UpdateInfo?> fetchLatest() async => null;
+}
+
+class _NoDismissStore implements DismissedUpdateStore {
+  @override
+  String? dismissedVersion() => null;
+  @override
+  Future<void> dismiss(String version) async {}
+}
+
+class _NoUrlOpener implements UrlOpener {
+  @override
+  Future<bool> open(String url) async => true;
+}
+
+class _NoSelfUpdater implements SelfUpdater {
+  @override
+  bool get isSupported => false;
+  @override
+  SelfUpdateState get state => const SelfUpdateState.idle();
+  @override
+  Stream<SelfUpdateState> get changes => const Stream.empty();
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> checkForUpdates({bool inBackground = true}) async {}
+  @override
+  Future<void> applyUpdate() async {}
+  @override
+  void dispose() {}
+}
+
+UpdateViewModel _fakeUpdateVm() => UpdateViewModel(
+  _NoUpdateChecker(),
+  _NoDismissStore(),
+  _NoUrlOpener(),
+  const UpdateTarget(
+    version: '1.0.0',
+    platform: 'linux',
+    format: 'deb',
+    arch: 'x64',
+  ),
+  _NoSelfUpdater(),
+);
+
+final _realm = Realm(
+  id: Realm.defaultId,
+  name: 'Default',
+  createdAt: DateTime.utc(2026),
+);
+
+Project _ws(int i) => Project(
+  id: 'ws$i',
+  name: 'Workspace $i',
+  path: '/repo$i',
+  colorValue: 0xFF3B82F6,
+  createdAt: DateTime.utc(2026),
+  order: i,
+);
+
+Project _fork(int w, int f) => Project(
+  id: 'ws$w-fork$f',
+  name: 'feat/$w-$f',
+  path: '/repo$w/.worktrees/$f',
+  colorValue: 0xFF3B82F6,
+  createdAt: DateTime.utc(2026),
+  parentId: 'ws$w',
+);
+
+class _Root extends StatelessWidget {
+  const _Root();
+
+  @override
+  Widget build(BuildContext context) => ShadcnApp.router(
+    theme: buildTheme(brightness: Brightness.dark),
+    routerConfig: ModularApp.routerConfigOf(context),
+  );
+}
+
+/// Contador de perguntas que o painel faz ao VM durante um build.
+class _Calls {
+  int gitInfo = 0;
+  int rootsOf = 0;
+  int moveTargetsOf = 0;
+  int forkOriginName = 0;
+
+  void reset() => gitInfo = rootsOf = moveTargetsOf = forkOriginName = 0;
+}
+
+Widget _rail({
+  required int workspaces,
+  required int forksEach,
+  required bool expanded,
+  required _Calls calls,
+}) {
+  final projects = [for (var i = 0; i < workspaces; i++) _ws(i)];
+  final forksOf = <String, List<Project>>{
+    for (var i = 0; i < workspaces; i++)
+      'ws$i': [for (var f = 0; f < forksEach; f++) _fork(i, f)],
+  };
+
+  final feature = createModule(
+    path: '/',
+    register: (c) => c.route(
+      '/',
+      child: (context, state) => Scaffold(
+        child: ProjectsRail(
+          projects: projects,
+          worktreesOf: (id) => forksOf[id] ?? const [],
+          worktreesExpanded: (_) => expanded,
+          onWorktreesExpanded: (_, _) {},
+          selectedId: null,
+          notificationCounts: const {},
+          gitInfo: (_) {
+            calls.gitInfo++;
+            return const GitInfo(branch: 'main');
+          },
+          rootsSummary: (_) => (1, 0),
+          rootsOf: (id) {
+            calls.rootsOf++;
+            return [
+              (path: '/repo', name: 'repo', git: const GitInfo(branch: 'main')),
+            ];
+          },
+          forkOriginName: (_) {
+            calls.forkOriginName++;
+            return null;
+          },
+          onSelect: (_) {},
+          onAdd: () async => true,
+          onConfigure: (_) {},
+          onDelete: (_) {},
+          onCreateWorktree: (_, _) {},
+          onRemoveWorktree: (_) {},
+          onMergeWorktree: (_) {},
+          onUpdateWorktree: (_) {},
+          onForkWorktree: (_) {},
+          onSync: (_, _) {},
+          onPull: (_, _) {},
+          onPush: (_, _) {},
+          onOpenSettings: () {},
+          onReorder: (_, _, _) {},
+          realms: [_realm],
+          activeRealm: _realm,
+          onSwitchRealm: (_) {},
+          onCreateRealm: () {},
+          onManageRealms: () {},
+          moveTargetsOf: (_) {
+            calls.moveTargetsOf++;
+            return const [];
+          },
+          onMoveToRealm: (_, _) {},
+          onSelectCockpit: () {},
+          onNewWorkspace: (_) {},
+          onSelectRemote: (_) {},
+          remoteGitInfoOf: (_) => null,
+          onRemoteWorkspaceAction: (_, _) {},
+        ),
+      ),
+    ),
+  );
+  return TranslationProvider(
+    child: ModularApp(
+      module: createModule(register: (c) => c.module(feature)),
+      provide: (s) => s.addChangeNotifier<UpdateViewModel>(_fakeUpdateVm),
+      child: const _Root(),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('worktrees recolhidas não constroem nenhuma linha de fork', (
+    tester,
+  ) async {
+    final calls = _Calls();
+    await tester.pumpWidget(
+      _rail(workspaces: 3, forksEach: 4, expanded: false, calls: calls),
+    );
+    await tester.pumpAndSettle();
+
+    // forkOriginName é perguntado uma vez por _WorktreeItem construído.
+    expect(calls.forkOriginName, 0);
+  });
+
+  testWidgets('worktrees expandidas constroem uma linha por fork', (
+    tester,
+  ) async {
+    final calls = _Calls();
+    await tester.pumpWidget(
+      _rail(workspaces: 3, forksEach: 4, expanded: true, calls: calls),
+    );
+    await tester.pumpAndSettle();
+
+    expect(calls.forkOriginName, 3 * 4);
+  });
+
+  testWidgets('o build não resolve os dados que só o menu usa', (tester) async {
+    final calls = _Calls();
+    await tester.pumpWidget(
+      _rail(workspaces: 3, forksEach: 2, expanded: false, calls: calls),
+    );
+    await tester.pumpAndSettle();
+
+    expect(calls.rootsOf, 0);
+    expect(calls.moveTargetsOf, 0);
+
+    // ...mas o menu, quando abre, tem tudo o que precisa.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('Workspace 0')),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(calls.rootsOf, greaterThan(0));
+    expect(calls.moveTargetsOf, greaterThan(0));
+  });
+
+  testWidgets('cada workspace visível é perguntado uma vez só', (tester) async {
+    final calls = _Calls();
+    await tester.pumpWidget(
+      _rail(workspaces: 3, forksEach: 0, expanded: false, calls: calls),
+    );
+    await tester.pumpAndSettle();
+
+    // Um gitInfo por card — antes eram dois (o valor e o `canCreateWorktree`).
+    expect(calls.gitInfo, 3);
+  });
+
+  testWidgets('lista longa só constrói o que cabe na viewport', (tester) async {
+    final calls = _Calls();
+    await tester.pumpWidget(
+      _rail(workspaces: 200, forksEach: 0, expanded: false, calls: calls),
+    );
+    await tester.pumpAndSettle();
+
+    // Viewport de 600px com cards de ~50px: uma fração dos 200 workspaces.
+    expect(calls.gitInfo, lessThan(60));
+  });
+}

--- a/cockpit/test/ui/worktrees_toggle_test.dart
+++ b/cockpit/test/ui/worktrees_toggle_test.dart
@@ -7,8 +7,9 @@ import 'package:cockpit/app/core/data/setup/json_state_store.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
-/// Toggle de worktrees no card do workspace (V37): a regra do clique e a
-/// persistência do estado dentro do **documento de layout** já existente.
+/// Toggle de worktrees no card do workspace (V37): a persistência do estado
+/// dentro do **documento de layout** já existente. A regra do clique (card
+/// seleciona, chevron alterna) é coberta em `projects_rail_context_menu_test`.
 void main() {
   group('worktreesExpandedOf', () {
     test('workspace sem layout salvo nasce expandido', () {
@@ -80,53 +81,6 @@ void main() {
         expect(worktreesExpandedOf(await layouts.load('nunca-salvo')), isTrue);
       },
     );
-  });
-
-  group('workspaceCardTap', () {
-    test('não selecionado: seleciona e abre a lista', () {
-      final action = workspaceCardTap(
-        selected: false,
-        expanded: false,
-        hasWorktrees: true,
-      );
-      expect(action.select, isTrue);
-      expect(action.expand, isTrue);
-    });
-
-    test('não selecionado e já expandido: seleciona e mantém aberto', () {
-      // Selecionar nunca RECOLHE — seria perder a lista sem pedir.
-      final action = workspaceCardTap(
-        selected: false,
-        expanded: true,
-        hasWorktrees: true,
-      );
-      expect(action.select, isTrue);
-      expect(action.expand, isTrue);
-    });
-
-    test('já selecionado: o clique só alterna', () {
-      expect(
-        workspaceCardTap(selected: true, expanded: true, hasWorktrees: true),
-        (select: false, expand: false),
-      );
-      expect(
-        workspaceCardTap(selected: true, expanded: false, hasWorktrees: true),
-        (select: false, expand: true),
-      );
-    });
-
-    test('sem worktrees: nunca mexe no estado da lista', () {
-      // Sem fork não há chevron nem lista; gravar um estado aqui só sujaria o
-      // layout de workspaces que nunca vão mostrar nada.
-      expect(
-        workspaceCardTap(selected: false, expanded: true, hasWorktrees: false),
-        (select: true, expand: null),
-      );
-      expect(
-        workspaceCardTap(selected: true, expanded: true, hasWorktrees: false),
-        (select: false, expand: null),
-      );
-    });
   });
 
   group('worktreeChevronIcon', () {


### PR DESCRIPTION
## Motivação

O card de workspace na rail vinha acumulando controles: um kebab `⋮` sempre
visível, um chevron logo abaixo dele e a contagem "N worktrees" repetida mesmo
com a lista de forks aberta à vista. Três affordances competindo pelo mesmo
canto do card, num painel que deveria ser uma lista de leitura rápida.

A ideia aqui é **simplificar visualmente o painel** — deixar no card só o que
precisa estar lá — e, de quebra, **alinhá-lo ao resto do app**: a árvore de
arquivos e as abas de pane já abrem seus menus com **botão-direito**, e a rail
era a única que ainda exigia mirar um botão. Agora o padrão é o mesmo em todo
lugar.

## O que muda

| # | Antes | Depois |
|---|---|---|
| 1 | Menu pelo botão `⋮` fixo no card | Menu de contexto no **botão-direito**, aberto no cursor |
| 2 | Chevron abaixo do `⋮`, meramente decorativo | Chevron é o **único botão** do card, e é clicável |
| 3 | Expandir exigia selecionar o workspace | Chevron alterna a lista **sem** mudar a seleção; o card só seleciona |
| 4 | "N worktrees" visível sempre | Contagem só quando **recolhido** (expandido, as linhas já estão à vista) |
| 5 | Menu da worktree pelo `⋮` | Botão-direito na linha da worktree |
| 6 | Botão-direito no slot SSH **removia o pin direto, sem confirmação** | Abre o menu, como os demais; remover é o item "Close" |

O item 6 vale destaque: era um clique-direito destrutivo e silencioso num
painel onde clique-direito não fazia mais nada — fácil de disparar sem querer.

## Screenshots

| Cenário | Preview |
|---|---|
| Card do workspace (recolhido) | <img width="248" height="559" alt="image" src="https://github.com/user-attachments/assets/ac55e4d9-7474-4765-a6e4-712e887778b5" /> |
| Card do workspace (expandido) | <img width="253" height="626" alt="image" src="https://github.com/user-attachments/assets/6bdda924-41ac-49c1-9713-df3255a051fe" /> |
| Menu de contexto do workspace | <img width="363" height="605" alt="image" src="https://github.com/user-attachments/assets/87b40a81-eef6-414f-9328-f5e4667b8eaf" /> |
| Menu de contexto da worktree | <img width="389" height="500" alt="image" src="https://github.com/user-attachments/assets/b4ad66d6-cb3b-4fd8-94f3-175cd620e78d" /> |

## Performance

Aproveitando que o menu passou a ser sob demanda, a rail deixou de pagar por
ele a cada frame. O painel é reconstruído inteiro a cada `notifyListeners()` do
`CockpitViewModel`, então todo trabalho por item era multiplicado por essa
frequência:

- **`notificationCount` era O(sessões) por item** — varria todas as sessões uma
  vez por workspace *e* por worktree. Virou o getter `notificationCounts`: uma
  varredura só, devolvendo o mapa.
- **O build resolvia dados que só o menu usa** — `rootsOf` (um `split` e um
  lookup de git por root) e `moveTargetsOf` (que varre os workspaces por realm,
  O(workspaces²) somando a rail toda) eram chamados por workspace, por build.
  Viraram thunks, resolvidos no clique.
- **Worktrees recolhidas eram construídas para serem descartadas** — o
  `AnimatedSize` jogava fora o conteúdo, mas cada `_WorktreeItem` já tinha
  custado um `forkOriginName` e um `gitInfo`. Agora só constrói se expandido.
- **A lista não era preguiçosa** — `ListView` → `ListView.builder`. Com 200
  workspaces, passam a ser construídos **13** (os que cabem na viewport).
- **Perguntas repetidas ao VM** — `worktreesOf` 3x, `gitInfo` 2x,
  `rootsSummary` 2x e `worktreesExpanded` 2x para o mesmo workspace, sendo que
  as duas do meio realocam a lista de roots no `GitController`. Hoistadas em
  `_workspaceBlock`, uma vez por item.

Junto veio uma correção: os itens da lista não tinham `Key`. Como
`_WorkspaceReorderable` é `StatefulWidget`, o caret de drop escorregava para o
vizinho quando um workspace saía do meio da lista.

## Testes

- `test/ui/projects_rail_context_menu_test.dart` (novo, 7 casos) — ausência do
  `⋮`, chevron alterna sem selecionar, card seleciona sem expandir,
  botão-direito abre os dois menus, contagem só recolhida.
- `test/ui/projects_rail_perf_test.dart` (novo, 5 casos) — conta as chamadas ao
  VM por build e trava cada ganho como regressão (forks recolhidos não
  constroem nada, `rootsOf`/`moveTargetsOf` em zero até o menu abrir, um
  `gitInfo` por card visível, lista longa constrói só a viewport).
- `test/ui/worktrees_toggle_test.dart` — grupo `workspaceCardTap` removido
  junto com a função; persistência do estado recolhido segue coberta.

`flutter analyze` limpo nos arquivos tocados. Suíte: 1063 passam. As 7 falhas
restantes (`cockpit_terminal_input_test.dart`, `xterm/terminal_view_test.dart`)
são pré-existentes na base e não têm relação com o painel.

## Nota

Sem o `⋮` visível, o menu perde afordância para quem não conhece o app. É o
custo assumido da limpeza; se incomodar, o caminho barato é trazer o `⋮` de
volta **só no hover** do card — padrão que já existe no `file_tree_panel` —
sem desfazer nada daqui.
