### PR TITLE
feat(app): show pi-ask recommended options as accent tint

### DIFF
--- a/app/lib/protocol/protocol.dart
+++ b/app/lib/protocol/protocol.dart
@@ -1438,12 +1438,17 @@ class AskOptionWire {
   final String? preview;
   final bool freeform;
 
+  /// pi-ask 1.2.0 addition: presentation-only marker — never sent back on
+  /// submit. Drives the accent tint in the option list.
+  final bool recommended;
+
   const AskOptionWire({
     required this.value,
     required this.label,
     this.description,
     this.preview,
     this.freeform = false,
+    this.recommended = false,
   });
 
   factory AskOptionWire.fromJson(Map<String, dynamic> j) {
@@ -1455,6 +1460,7 @@ class AskOptionWire {
       description: j['description'] as String?,
       preview: j['preview'] as String?,
       freeform: (j['freeform'] as bool?) ?? false,
+      recommended: (j['recommended'] as bool?) ?? false,
     );
   }
 }

--- a/app/lib/ui/chat/widgets/extension_ui_sheet.dart
+++ b/app/lib/ui/chat/widgets/extension_ui_sheet.dart
@@ -373,6 +373,12 @@ class _ExtensionUiSheetState extends State<ExtensionUiSheet> {
                     o.label,
                     style: text.bodyLarge?.copyWith(
                       fontWeight: FontWeight.w600,
+                      // pi-ask `recommended` marker: tint only (no badge).
+                      // A selected tile is already accent-colored, so the
+                      // tint matters only when unselected.
+                      color: o.recommended && !selected
+                          ? colors.accent
+                          : null,
                     ),
                   ),
                 ),

--- a/pi-extension/src/extension_ui_bridge.ts
+++ b/pi-extension/src/extension_ui_bridge.ts
@@ -405,6 +405,9 @@ function parseOption(value: unknown): AskOptionWire | null {
     description: asString(value.description),
     preview: asString(value.preview),
     freeform: value.freeform === true ? true : undefined,
+    // pi-ask 1.2.0 marks recommended options. Presentation-only metadata —
+    // pass through so clients can highlight it; never sent back on submit.
+    recommended: value.recommended === true ? true : undefined,
   };
 }
 

--- a/pi-extension/src/protocol/types.ts
+++ b/pi-extension/src/protocol/types.ts
@@ -40,6 +40,8 @@ export interface AskOptionWire {
   preview?: string;
   /** pi-ask addition: option allows freeform custom entry. */
   freeform?: boolean;
+  /** pi-ask 1.2.0 addition: presentation-only marker (never affects submit). */
+  recommended?: boolean;
 }
 
 export interface AskQuestionWire {


### PR DESCRIPTION
## What

pi-ask 1.2.0 marks recommended options on its `started` event (`options[].recommended: true` — presentation-only metadata per its remote-events contract). The `extension_ui_bridge` silently dropped the flag in `parseOption`, so mobile apps paired via `extension_ui_request` never saw it while the desktop TUI does.

## Change

- `pi-extension/src/extension_ui_bridge.ts`: pass `recommended` through in `parseOption`
- `pi-extension/src/protocol/types.ts`: optional `recommended?: boolean` on `AskOptionWire`
- `app/lib/protocol/protocol.dart`: parse `recommended` (defaults false)
- `app/lib/ui/chat/widgets/extension_ui_sheet.dart`: render a recommended-but-unselected option label in accent color (tint only, no badge — selected tiles are already accent-colored)

Additive only: no wire-format change beyond one optional field, older clients ignore it, and the flag is never sent back on submit.

## Testing

- `pi-extension`: `npx vitest run src/extension_ui_bridge.test.ts` → 23/23
- `app`: `flutter test test/ui/chat/extension_ui_sheet_test.dart` → all pass; `flutter analyze` clean on touched files
