### PR TITLE
feat(cockpit): realçar logs JSON das tasks e controlar quando o preview abre

### DIFF
--- a/cockpit/docs/tasks-json.md
+++ b/cockpit/docs/tasks-json.md
@@ -92,6 +92,7 @@ subir na árvore), então:
 | `progressPatterns` | array    | não         | `[]`        | Regex begin/end pro badge `building↔running`. |
 | `profiles`         | array    | não         | `[]`        | Variantes de execução (ver abaixo). |
 | `preview`          | bool/str | não         | `true`      | Auto-open do navegador embutido: por padrão a **primeira** URL local do output (`http://localhost:…`) abre uma aba de navegador (re-runs reusam a aba na mesma origem). `false` desliga; uma string (`"http://localhost:8080"`) abre essa URL fixa já no start. Sem webview na plataforma (Linux), abre no browser do SO. |
+| `previewOpen`      | string   | não         | `always`    | **Quando** o preview abre: `always` (start e restart), `start` (só no start — Restart e o restart do watcher não reabrem; um stop + start manual reabre) ou `never`. Ignorado se `preview` é `false`. |
 
 > O cockpit gera o `id` da task automaticamente (`json:<label>`); ele sobrescreve
 > uma task detectada de mesmo `id`.

--- a/cockpit/docs/tasks.schema.json
+++ b/cockpit/docs/tasks.schema.json
@@ -58,6 +58,19 @@
         "profiles": {
           "type": "array",
           "items": { "$ref": "#/$defs/profile" }
+        },
+        "preview": {
+          "oneOf": [
+            { "type": "boolean" },
+            { "type": "string", "format": "uri" }
+          ],
+          "default": true,
+          "description": "Auto-open do navegador: true (default) abre a primeira URL local do output; false desliga; string abre essa URL fixa já no start."
+        },
+        "previewOpen": {
+          "enum": ["always", "start", "never"],
+          "default": "always",
+          "description": "Em quais execuções o preview abre: always (default, start e restart), start (só no start — restart não reabre), never."
         }
       }
     },

--- a/cockpit/lib/app/cockpit/data/tasks/pty_task_runner.dart
+++ b/cockpit/lib/app/cockpit/data/tasks/pty_task_runner.dart
@@ -48,6 +48,16 @@ class PtyTaskRunner implements TaskRunnerGateway {
     TaskDefinition def, {
     String? profileName,
     List<String> adHocArgs = const [],
+  }) => _launch(def, profileName: profileName, adHocArgs: adHocArgs);
+
+  /// O spawn de verdade. [restarting] distingue o start inicial do re-spawn do
+  /// [restart] — é isso que faz `previewOpen: "start"` não reabrir o navegador
+  /// a cada restart. Interno de propósito: o contrato do gateway não muda.
+  Future<void> _launch(
+    TaskDefinition def, {
+    String? profileName,
+    List<String> adHocArgs = const [],
+    bool restarting = false,
   }) async {
     if (_running.containsKey(def.id)) return; // idempotente
     if (!_starting.add(def.id)) return; // spawn já em preparação
@@ -115,6 +125,7 @@ class PtyTaskRunner implements TaskRunnerGateway {
       pty,
       def,
       initial,
+      isRestart: restarting,
       onOutput: (data) {
         if (!task.out.isClosed) task.out.add(data);
         _detectProgress(task, data);
@@ -124,11 +135,15 @@ class PtyTaskRunner implements TaskRunnerGateway {
     _running[def.id] = task;
     _emit(initial);
 
-    // `preview` fixo no tasks.json: abre já no start, sem esperar output.
+    // `preview` fixo no tasks.json: abre já no start, sem esperar output. A URL
+    // fixa marca `previewNotified` mesmo com o auto-open suprimido — ela
+    // substitui a detecção por output, não convive com ela.
     final forced = def.previewUrl;
     if (def.previewEnabled && forced != null && forced.isNotEmpty) {
       task.previewNotified = true;
-      if (!_previews.isClosed) _previews.add(TaskPreviewUrl(def.id, forced));
+      if (def.shouldOpenPreview(isRestart: restarting) && !_previews.isClosed) {
+        _previews.add(TaskPreviewUrl(def.id, forced));
+      }
     }
 
     // Decoder incremental + scheduler GLOBAL. O callback de flush alimenta um
@@ -177,7 +192,7 @@ class PtyTaskRunner implements TaskRunnerGateway {
     for (var i = 0; i < 35 && _running.containsKey(taskId); i++) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
-    await start(def, profileName: profileName);
+    await _launch(def, profileName: profileName, restarting: true);
   }
 
   @override
@@ -342,7 +357,8 @@ class PtyTaskRunner implements TaskRunnerGateway {
   /// Primeira URL local do run → emite pro shell abrir o navegador (plano 58).
   /// Mantém uma cauda curta do texto limpo pra URL partida entre chunks.
   void _detectPreviewUrl(_RunningTask task, String data) {
-    if (task.previewNotified || !task.def.previewEnabled) return;
+    if (task.previewNotified) return;
+    if (!task.def.shouldOpenPreview(isRestart: task.isRestart)) return;
     final haystack = task.previewTail + data.replaceAll(_ansiRe, '');
     final match = _localUrlRe.firstMatch(haystack);
     if (match == null) {
@@ -452,6 +468,7 @@ class _RunningTask {
     this.def,
     this.state, {
     required void Function(String data) onOutput,
+    this.isRestart = false,
   }) : coalescer = PtyOutputCoalescer(
          onFlush: onOutput,
          onAcknowledge: pty.ackRead,
@@ -467,6 +484,10 @@ class _RunningTask {
   TaskRun state;
   bool stopping = false;
   bool ended = false;
+
+  /// `true` quando o run nasceu de um restart (botão ou watcher) em vez de um
+  /// start. Só o auto-open do preview olha isso (`previewOpen: "start"`).
+  final bool isRestart;
 
   /// Auto-open do navegador (plano 58): no máximo uma emissão por run.
   bool previewNotified = false;

--- a/cockpit/lib/app/cockpit/data/tasks/tasks_json_loader.dart
+++ b/cockpit/lib/app/cockpit/data/tasks/tasks_json_loader.dart
@@ -86,6 +86,7 @@ class TasksJsonLoader {
       // `preview`: false desliga o auto-open do navegador; string = URL fixa.
       previewEnabled: m['preview'] != false,
       previewUrl: m['preview'] is String ? m['preview'] as String : null,
+      previewOpen: _previewOpen(m['previewOpen']),
     );
   }
 
@@ -110,6 +111,14 @@ class TasksJsonLoader {
       v is List ? v.map((e) => e.toString()).toList() : const [];
 
   TaskKind _kind(Object? v) => v == 'watch' ? TaskKind.watch : TaskKind.oneShot;
+
+  /// `previewOpen`: `always` (default) | `start` | `never`. Ausente, tipo errado
+  /// ou valor desconhecido → `always`, o comportamento histórico.
+  TaskPreviewOpen _previewOpen(Object? v) => switch (v) {
+    'start' => TaskPreviewOpen.start,
+    'never' => TaskPreviewOpen.never,
+    _ => TaskPreviewOpen.always,
+  };
 
   List<TaskProfile> _profiles(Object? v) {
     if (v is! List) return const [];

--- a/cockpit/lib/app/cockpit/domain/entities/task_definition.dart
+++ b/cockpit/lib/app/cockpit/domain/entities/task_definition.dart
@@ -97,6 +97,16 @@ class TaskProfile {
   final Map<String, String> env;
 }
 
+/// Quando o link de preview abre sozinho. Restart de um dev-server não deveria
+/// jogar uma aba nova na cara de quem já está com a app (ou o Swagger) aberto.
+///
+/// - [always]: abre em todo start, restart incluso (default — comportamento
+///   histórico, preservado para quem não configura nada).
+/// - [start]: abre só no start; o botão Restart e o restart do watcher não
+///   reabrem. Um stop + start manual conta como start novo e abre.
+/// - [never]: nunca abre sozinho.
+enum TaskPreviewOpen { always, start, never }
+
 /// Definição estática de uma task (detectada ou do JSON). Tudo aqui é genérico.
 class TaskDefinition {
   const TaskDefinition({
@@ -113,6 +123,7 @@ class TaskDefinition {
     this.progressPatterns = const [],
     this.previewEnabled = true,
     this.previewUrl,
+    this.previewOpen = TaskPreviewOpen.always,
   });
 
   /// Identidade estável dentro de um projeto (ex.: `"npm:dev"`, `"flutter:run"`).
@@ -152,6 +163,22 @@ class TaskDefinition {
 
   /// `"preview": "<url>"` — URL fixa aberta no start, sem depender do output.
   final String? previewUrl;
+
+  /// `"previewOpen"` — em quais execuções o auto-open vale. Default [always]
+  /// (retrocompatível). Ignorado quando [previewEnabled] é `false`.
+  final TaskPreviewOpen previewOpen;
+
+  /// Este run deve abrir o link sozinho? `preview: false` desliga tudo; fora
+  /// isso quem manda é [previewOpen]. [isRestart] é `true` só quando o run
+  /// nasceu de um restart (botão ou watcher), nunca de um start.
+  bool shouldOpenPreview({required bool isRestart}) {
+    if (!previewEnabled) return false;
+    return switch (previewOpen) {
+      TaskPreviewOpen.always => true,
+      TaskPreviewOpen.start => !isRestart,
+      TaskPreviewOpen.never => false,
+    };
+  }
 
   /// Linha de comando final (preview na UI e execução): base + args do profile.
   List<String> resolveArgs(TaskProfile? profile) => [

--- a/cockpit/lib/app/cockpit/ui/session/task_terminal_store.dart
+++ b/cockpit/lib/app/cockpit/ui/session/task_terminal_store.dart
@@ -4,6 +4,7 @@ import 'package:cockpit/app/cockpit/domain/contracts/task_runner_gateway.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_scrollback_store.dart';
 import 'package:cockpit/app/cockpit/domain/entities/task_run.dart';
 import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/terminal/json_log_highlighter.dart';
 import 'package:cockpit/app/core/terminal/terminal_controller.dart';
 import 'package:cockpit/app/core/utils/quiet_period_debouncer.dart';
 
@@ -59,6 +60,11 @@ class TaskTerminalStore {
   /// comandos) pro runner certo (local vs host remoto).
   final _runnerOf = <String, TaskRunnerGateway>{};
   final _record = <String, StringBuffer>{};
+
+  /// Realce de logs JSON estruturados, um por task (stateful: guarda a cauda
+  /// de linha entre chunks). Aplicado aqui — o único ponto onde o output do
+  /// runner encontra o terminal — vale pro runner local E pros remotos.
+  final _highlighters = <String, JsonLogHighlighter>{};
   final _flushDebouncers = <String, QuietPeriodDebouncer>{};
 
   /// Terminal da task (cria um vazio na primeira vez — read-only na UI). O
@@ -102,7 +108,10 @@ class TaskTerminalStore {
   }
 
   void _onRun(TaskRunnerGateway runner, TaskRun run) {
-    if (!run.isActive) return;
+    if (!run.isActive) {
+      if (!run.isTransitioning) _drainHighlighter(run.taskId);
+      return;
+    }
     // Só (re)liga quando é um run NOVO (pid mudou) — building↔running do mesmo
     // processo não re-subscreve.
     if (_lastPid[run.taskId] == run.pid) return;
@@ -116,12 +125,26 @@ class TaskTerminalStore {
     if (_outSubs.containsKey(run.taskId)) {
       term.write('\x1b[H\x1b[2J\x1b[3J');
       _record[run.taskId]?.clear();
+      _highlighters.remove(run.taskId);
     }
     _outSubs.remove(run.taskId)?.cancel();
+    final highlighter = _highlighters[run.taskId] ??= JsonLogHighlighter();
     _outSubs[run.taskId] = runner.output(run.taskId).listen((data) {
-      term.write(data);
-      _append(run.taskId, data);
+      // Log JSON sai colorido pela paleta ANSI do tema; o resto passa intacto.
+      final painted = highlighter.process(data);
+      if (painted.isEmpty) return; // linha incompleta retida
+      term.write(painted);
+      _append(run.taskId, painted);
     });
+  }
+
+  /// Fim do run: a última linha pode ter ficado retida no highlighter esperando
+  /// um `\n` que o processo não chegou a emitir — solta crua pra não sumir.
+  void _drainHighlighter(String taskId) {
+    final pending = _highlighters.remove(taskId)?.flushPending();
+    if (pending == null || pending.isEmpty) return;
+    _terminals[taskId]?.write(pending);
+    _append(taskId, pending);
   }
 
   /// Acumula o output no buffer da task (ring trim amortizado) e agenda um flush
@@ -178,6 +201,7 @@ class TaskTerminalStore {
       s.cancel();
     }
     _outSubs.clear();
+    _highlighters.clear();
     for (final terminal in _terminals.values) {
       terminal.dispose();
     }

--- a/cockpit/lib/app/cockpit/ui/viewmodels/tasks_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/tasks_viewmodel.dart
@@ -35,6 +35,7 @@ class TasksViewModel extends ChangeNotifier {
     _sub?.cancel();
     _sub = _runner.runs().listen(_onRun);
   }
+
   StreamSubscription<FileSystemEvent>? _configWatch;
   Timer? _reloadDebounce;
 
@@ -264,6 +265,13 @@ const String _exampleConfig = '''
       "cwd": "site",
       "command": "npm",
       "args": ["run", "dev"]
+      // Browser auto-open. "preview": true (default) opens the first local URL
+      // found in the output; false turns it off; a string opens that fixed URL
+      // right at start.
+      // "preview": "http://localhost:3000",
+      // When it opens: "always" (default: start and restart), "start" (only on
+      // start — Restart and the file watcher won't reopen it) or "never".
+      // "previewOpen": "start",
     },
     {
       "label": "C# Example",

--- a/cockpit/lib/app/core/terminal/json_log_highlighter.dart
+++ b/cockpit/lib/app/core/terminal/json_log_highlighter.dart
@@ -1,0 +1,338 @@
+import 'dart:convert';
+
+/// Realce de **logs estruturados JSON** no output das tasks.
+///
+/// O output da task não passa por widget nenhum: vai cru pro emulador VT
+/// (Ghostty/xterm), que desenha o grid. Então o único ponto onde dá pra colorir
+/// é o próprio texto — este transformador injeta SGR (`ESC [ n m`) nas linhas
+/// que são JSON, antes do `write` no terminal.
+///
+/// **Por que SGR indexado (30-37 / 90-97) e não truecolor**: os índices são
+/// resolvidos pelo emulador contra o `TerminalTheme` do tema ativo **na hora de
+/// pintar**. Isso significa que o log usa a paleta do tema (inclusive tema
+/// custom importado), e que trocar de tema repinta o buffer já escrito — sem
+/// reprocessar nada e sem um `Color(0x…)` sequer no código.
+///
+/// **Não estraga o que já funciona**: uma linha só é transformada se decodifica
+/// como objeto JSON *e* não contém nenhum byte ANSI. Output do Flutter/Vite (que
+/// já vem colorido) e texto solto passam intactos, byte a byte.
+///
+/// Stateful por task: guarda a cauda de linha incompleta entre chunks.
+class JsonLogHighlighter {
+  /// Teto da cauda segurada entre chunks. Acima disso a cauda é solta crua —
+  /// nada de segurar output indefinidamente esperando um `}` que não vem.
+  static const int _maxPendingChars = 64 * 1024;
+
+  /// Linha maior que isso nem tenta decodificar (JSON de log não tem esse porte
+  /// e o `json.decode` custaria caro no caminho quente).
+  static const int _maxLineChars = 32 * 1024;
+
+  String _pending = '';
+
+  /// Processa um chunk decodificado e devolve o texto a escrever no terminal.
+  /// Pode devolver `''` quando o chunk inteiro virou cauda pendente.
+  String process(String chunk) {
+    if (chunk.isEmpty) return chunk;
+    // Caminho quente: sem `{` e sem cauda pendente, nenhuma linha pode
+    // qualificar nem virar cauda — devolve o chunk sem tocar.
+    if (_pending.isEmpty && !chunk.contains('{')) return chunk;
+
+    final text = _pending + chunk;
+    _pending = '';
+
+    final out = StringBuffer();
+    var start = 0;
+    while (true) {
+      final nl = text.indexOf('\n', start);
+      if (nl < 0) break;
+      out
+        ..write(_highlightLine(text.substring(start, nl)))
+        ..write('\n');
+      start = nl + 1;
+    }
+
+    final tail = text.substring(start);
+    if (_shouldHold(tail)) {
+      _pending = tail;
+    } else {
+      out.write(tail);
+    }
+    return out.toString();
+  }
+
+  /// Solta a cauda pendente **sem transformar** (linha incompleta). Chamado no
+  /// fim do run, senão o último log sem `\n` sumiria com o processo.
+  String flushPending() {
+    if (_pending.isEmpty) return '';
+    final out = _pending;
+    _pending = '';
+    return out;
+  }
+
+  /// Só segura a cauda quando ela pode virar uma linha JSON. Prompt
+  /// interativo, barra de progresso com `\r` e texto solto saem na hora — o
+  /// realce nunca pode atrasar output que o usuário está esperando ver.
+  bool _shouldHold(String tail) {
+    if (tail.isEmpty || tail.length > _maxPendingChars) return false;
+    if (tail.contains('\x1b')) return false;
+    final i = _firstNonSpace(tail);
+    return i >= 0 && tail.codeUnitAt(i) == _lbrace;
+  }
+
+  /// Preserva o `\r` final (CRLF do Windows) fora da transformação.
+  String _highlightLine(String raw) {
+    if (raw.endsWith('\r')) {
+      final painted = _paint(raw.substring(0, raw.length - 1));
+      return painted == null ? raw : '$painted\r';
+    }
+    return _paint(raw) ?? raw;
+  }
+
+  /// `null` = a linha não é um log JSON; o chamador mantém o original.
+  String? _paint(String line) {
+    if (line.length > _maxLineChars) return null;
+    if (line.contains('\x1b')) return null;
+
+    final open = _firstNonSpace(line);
+    if (open < 0 || line.codeUnitAt(open) != _lbrace) return null;
+    final close = _lastNonSpace(line);
+    if (close < open || line.codeUnitAt(close) != _rbrace) return null;
+
+    final body = line.substring(open, close + 1);
+    final Map<Object?, Object?> decoded;
+    try {
+      final value = json.decode(body);
+      if (value is! Map) return null;
+      decoded = value;
+    } on FormatException {
+      return null;
+    }
+
+    final out = StringBuffer(line.substring(0, open));
+    _scan(body, out, _severityColor(decoded));
+    out.write(line.substring(close + 1));
+    return out.toString();
+  }
+
+  /// Varre o **texto original** (não o `Map` decodificado) pra preservar ordem,
+  /// espaçamento e escapes exatamente como o logger emitiu.
+  void _scan(String s, StringBuffer out, int? severity) {
+    // 0 = dentro de objeto, 1 = dentro de array.
+    final stack = <int>[];
+    var expectKey = false;
+    String? key; // última chave do nível 1
+
+    var i = 0;
+    while (i < s.length) {
+      final c = s[i];
+      if (c == '{' || c == '[') {
+        _emit(out, _cPunct, c);
+        stack.add(c == '{' ? 0 : 1);
+        expectKey = c == '{';
+        i++;
+      } else if (c == '}' || c == ']') {
+        _emit(out, _cPunct, c);
+        if (stack.isNotEmpty) stack.removeLast();
+        expectKey = false;
+        i++;
+      } else if (c == ',') {
+        _emit(out, _cPunct, c);
+        expectKey = stack.isNotEmpty && stack.last == 0;
+        i++;
+      } else if (c == ':') {
+        _emit(out, _cPunct, c);
+        expectKey = false;
+        i++;
+      } else if (c == '"') {
+        final end = _stringEnd(s, i);
+        final token = s.substring(i, end);
+        final topLevel = stack.length == 1;
+        if (expectKey) {
+          final name = _unquote(token);
+          key = topLevel ? name : null;
+          _emit(out, topLevel ? _keyColor(name, severity) : _cKey, token);
+        } else {
+          _emit(
+            out,
+            _valueColor(topLevel ? key : null, severity, _cString),
+            token,
+          );
+        }
+        i = end;
+      } else if (c == ' ' || c == '\t') {
+        out.write(c);
+        i++;
+      } else {
+        final end = _literalEnd(s, i);
+        final token = s.substring(i, end);
+        final base = _isNumberStart(token) ? _cNumber : _cLiteral;
+        _emit(
+          out,
+          _valueColor(stack.length == 1 ? key : null, severity, base),
+          token,
+        );
+        i = end;
+      }
+    }
+  }
+
+  void _emit(StringBuffer out, int color, String token) =>
+      out.write('\x1b[${color}m$token\x1b[0m');
+
+  /// Chave de nível 1: a intenção é **destacar só o que importa** — nível,
+  /// mensagem e erro saltam; timestamp/caller recuam; o resto é neutro.
+  int _keyColor(String name, int? severity) {
+    final n = name.toLowerCase();
+    if (_levelKeys.contains(n)) return severity ?? _cKey;
+    if (_errorKeys.contains(n)) return _cError;
+    if (_timeKeys.contains(n)) return _cMuted;
+    return _cKey;
+  }
+
+  int _valueColor(String? key, int? severity, int fallback) {
+    if (key == null) return fallback;
+    final n = key.toLowerCase();
+    if (_levelKeys.contains(n)) return severity ?? fallback;
+    if (_errorKeys.contains(n)) return _cError;
+    if (_msgKeys.contains(n)) return _cMessage;
+    if (_timeKeys.contains(n)) return _cMuted;
+    return fallback;
+  }
+
+  /// Cor do nível a partir do `Map` já decodificado — resolvida antes da varredura
+  /// pra que a **chave** possa ser pintada com a cor do valor (o `level` inteiro
+  /// fica vermelho num erro, não só o `"error"`).
+  int? _severityColor(Map<Object?, Object?> m) {
+    for (final entry in m.entries) {
+      final k = entry.key;
+      if (k is! String || !_levelKeys.contains(k.toLowerCase())) continue;
+      final v = entry.value;
+      if (v is String) return _severityOfName(v);
+      // Níveis numéricos (pino/bunyan): 50 error, 40 warn, 30 info, ≤20 debug.
+      if (v is num) {
+        if (v >= 50) return _cError;
+        if (v >= 40) return _cWarn;
+        if (v >= 30) return _cInfo;
+        return _cMuted;
+      }
+    }
+    return null;
+  }
+
+  int? _severityOfName(String raw) => switch (raw.toLowerCase()) {
+    'error' || 'err' || 'fatal' || 'panic' || 'critical' || 'crit' => _cError,
+    'warn' || 'warning' => _cWarn,
+    'info' || 'notice' => _cInfo,
+    'debug' || 'trace' || 'verbose' => _cMuted,
+    _ => null,
+  };
+
+  // --- scanner ------------------------------------------------------------
+
+  int _stringEnd(String s, int start) {
+    var i = start + 1;
+    while (i < s.length) {
+      final c = s.codeUnitAt(i);
+      if (c == _backslash) {
+        i += 2;
+        continue;
+      }
+      if (c == _quote) return i + 1;
+      i++;
+    }
+    return s.length;
+  }
+
+  int _literalEnd(String s, int start) {
+    var i = start;
+    while (i < s.length && !_isDelimiter(s.codeUnitAt(i))) {
+      i++;
+    }
+    return i == start ? start + 1 : i;
+  }
+
+  bool _isDelimiter(int c) =>
+      c == 0x2C || // ,
+      c == 0x3A || // :
+      c == _lbrace ||
+      c == _rbrace ||
+      c == 0x5B || // [
+      c == 0x5D || // ]
+      c == 0x20 ||
+      c == 0x09 ||
+      c == _quote;
+
+  bool _isNumberStart(String token) {
+    if (token.isEmpty) return false;
+    final c = token.codeUnitAt(0);
+    return c == 0x2D || (c >= 0x30 && c <= 0x39); // '-' ou dígito
+  }
+
+  String _unquote(String token) {
+    if (token.length < 2) return token;
+    final inner = token.substring(1, token.length - 1);
+    if (!inner.contains(r'\')) return inner;
+    try {
+      final decoded = json.decode(token);
+      return decoded is String ? decoded : inner;
+    } on FormatException {
+      return inner;
+    }
+  }
+
+  int _firstNonSpace(String s) {
+    for (var i = 0; i < s.length; i++) {
+      if (!_isSpace(s.codeUnitAt(i))) return i;
+    }
+    return -1;
+  }
+
+  int _lastNonSpace(String s) {
+    for (var i = s.length - 1; i >= 0; i--) {
+      if (!_isSpace(s.codeUnitAt(i))) return i;
+    }
+    return -1;
+  }
+
+  bool _isSpace(int c) => c == 0x20 || c == 0x09 || c == 0x0D;
+}
+
+// --- paleta (índices ANSI: quem pinta é o TerminalTheme do tema ativo) ------
+
+const int _cPunct = 90; // brightBlack — estrutura recua
+const int _cKey = 36; // cyan
+const int _cString = 32; // green
+const int _cNumber = 33; // yellow
+const int _cLiteral = 35; // magenta — true/false/null
+const int _cError = 91; // brightRed
+const int _cWarn = 93; // brightYellow
+const int _cInfo = 94; // brightBlue
+const int _cMuted = 90; // brightBlack
+const int _cMessage = 97; // brightWhite — a mensagem lê primeiro
+
+const int _lbrace = 0x7B;
+const int _rbrace = 0x7D;
+const int _quote = 0x22;
+const int _backslash = 0x5C;
+
+const Set<String> _levelKeys = {
+  'level',
+  'lvl',
+  'severity',
+  'sev',
+  'loglevel',
+  'log.level',
+};
+
+/// Cobre logger que reporta falha sem campo `level` (ex.: `{"error": "..."}`).
+const Set<String> _errorKeys = {'error', 'err', 'exception', 'stack'};
+
+const Set<String> _msgKeys = {'msg', 'message'};
+
+const Set<String> _timeKeys = {
+  'time',
+  'ts',
+  'timestamp',
+  '@timestamp',
+  'caller',
+};

--- a/cockpit/test/core/terminal/json_log_highlighter_test.dart
+++ b/cockpit/test/core/terminal/json_log_highlighter_test.dart
@@ -1,0 +1,138 @@
+import 'package:cockpit/app/core/terminal/json_log_highlighter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Envolve [token] no SGR indexado [color] — mesma forma que o highlighter emite.
+String sgr(int color, String token) => '\x1b[${color}m$token\x1b[0m';
+
+void main() {
+  late JsonLogHighlighter highlighter;
+
+  setUp(() => highlighter = JsonLogHighlighter());
+
+  test('pinta chave, string, número e literal de um log JSON', () {
+    final out = highlighter.process('{"svc":"api","port":8080,"tls":false}\n');
+
+    expect(
+      out,
+      '${sgr(90, '{')}${sgr(36, '"svc"')}${sgr(90, ':')}${sgr(32, '"api"')}'
+      '${sgr(90, ',')}${sgr(36, '"port"')}${sgr(90, ':')}${sgr(33, '8080')}'
+      '${sgr(90, ',')}${sgr(36, '"tls"')}${sgr(90, ':')}${sgr(35, 'false')}'
+      '${sgr(90, '}')}\n',
+    );
+  });
+
+  test('nível error pinta a chave e o valor de vermelho', () {
+    final out = highlighter.process('{"level":"error","msg":"db down"}\n');
+
+    expect(out, contains(sgr(91, '"level"')));
+    expect(out, contains(sgr(91, '"error"')));
+    expect(out, contains(sgr(97, '"db down"'))); // msg em destaque
+  });
+
+  test('nível warn/info/debug e nível numérico do pino', () {
+    expect(
+      highlighter.process('{"level":"warn"}\n'),
+      contains(sgr(93, '"warn"')),
+    );
+    expect(
+      highlighter.process('{"level":"info"}\n'),
+      contains(sgr(94, '"info"')),
+    );
+    expect(
+      highlighter.process('{"level":"debug"}\n'),
+      contains(sgr(90, '"debug"')),
+    );
+    expect(highlighter.process('{"level":50}\n'), contains(sgr(91, '50')));
+    expect(highlighter.process('{"level":30}\n'), contains(sgr(94, '30')));
+  });
+
+  test('campo error sem campo level ainda destaca o erro', () {
+    final out = highlighter.process('{"msg":"retry","error":"conn refused"}\n');
+
+    expect(out, contains(sgr(91, '"error"')));
+    expect(out, contains(sgr(91, '"conn refused"')));
+  });
+
+  test('timestamp e caller recuam', () {
+    final out = highlighter.process(
+      '{"ts":"2026-08-22T10:00:00Z","level":"info"}\n',
+    );
+
+    expect(out, contains(sgr(90, '"ts"')));
+    expect(out, contains(sgr(90, '"2026-08-22T10:00:00Z"')));
+  });
+
+  test('chave especial só vale no nível 1 — aninhado fica neutro', () {
+    final out = highlighter.process('{"ctx":{"level":"error"}}\n');
+
+    expect(out, isNot(contains(sgr(91, '"level"'))));
+    expect(out, contains(sgr(36, '"level"')));
+    expect(out, contains(sgr(32, '"error"')));
+  });
+
+  test('linha com ANSI passa intacta (não estraga Flutter/Vite)', () {
+    const line = '\x1b[32m{"level":"info"}\x1b[0m\n';
+
+    expect(highlighter.process(line), line);
+  });
+
+  test('linha que não é JSON passa intacta', () {
+    const line = 'Running "go build" {not json}\n';
+
+    expect(highlighter.process(line), line);
+  });
+
+  test('JSON malformado passa intacto', () {
+    const line = '{"level":"error",}\n';
+
+    expect(highlighter.process(line), line);
+  });
+
+  test('array no topo não é transformado', () {
+    const line = '[1,2,3]\n';
+
+    expect(highlighter.process(line), line);
+  });
+
+  test('indentação e sufixo fora do objeto são preservados', () {
+    final out = highlighter.process('  {"a":1}  \n');
+
+    expect(out, startsWith('  '));
+    expect(out, endsWith('  \n'));
+  });
+
+  test('CRLF é preservado', () {
+    final out = highlighter.process('{"a":1}\r\n');
+
+    expect(out, endsWith('\r\n'));
+    expect(out, contains(sgr(33, '1')));
+  });
+
+  test('linha JSON partida entre chunks é pintada ao fechar', () {
+    expect(highlighter.process('{"level":"err'), '');
+    final out = highlighter.process('or","msg":"boom"}\n');
+
+    expect(out, contains(sgr(91, '"error"')));
+    expect(out, contains(sgr(97, '"boom"')));
+  });
+
+  test('cauda que não começa com { sai na hora (não trava prompt)', () {
+    expect(highlighter.process('Enter password: '), 'Enter password: ');
+    expect(highlighter.process('{"a":'), '');
+  });
+
+  test('flushPending devolve a cauda crua e esvazia', () {
+    highlighter.process('{"a":1');
+
+    expect(highlighter.flushPending(), '{"a":1');
+    expect(highlighter.flushPending(), '');
+  });
+
+  test('múltiplas linhas num chunk só, misturando JSON e texto', () {
+    final out = highlighter.process('boot ok\n{"level":"warn"}\nbye\n');
+
+    expect(out, startsWith('boot ok\n'));
+    expect(out, endsWith('\nbye\n'));
+    expect(out, contains(sgr(93, '"warn"')));
+  });
+}

--- a/cockpit/test/session/task_terminal_store_json_log_test.dart
+++ b/cockpit/test/session/task_terminal_store_json_log_test.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:cockpit/app/cockpit/domain/contracts/task_runner_gateway.dart';
+import 'package:cockpit/app/cockpit/domain/contracts/terminal_scrollback_store.dart';
+import 'package:cockpit/app/cockpit/domain/entities/task_definition.dart';
+import 'package:cockpit/app/cockpit/domain/entities/task_run.dart';
+import 'package:cockpit/app/cockpit/ui/session/task_terminal_store.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Runner de mentira: só bombeia runs e output, que é o que o store consome.
+class FakeTaskRunner implements TaskRunnerGateway {
+  final _runs = StreamController<TaskRun>.broadcast();
+  final _output = StreamController<String>.broadcast();
+
+  void emitRun(TaskRun run) => _runs.add(run);
+  void emitOutput(String data) => _output.add(data);
+
+  @override
+  Stream<TaskRun> runs() => _runs.stream;
+
+  @override
+  Stream<String> output(String taskId) => _output.stream;
+
+  @override
+  Stream<TaskPreviewUrl> previewUrls() => const Stream<TaskPreviewUrl>.empty();
+
+  @override
+  TaskRun runOf(String taskId) => TaskRun.idleFor(taskId);
+
+  @override
+  void resize(String taskId, int rows, int columns) {}
+
+  @override
+  Future<void> start(
+    TaskDefinition def, {
+    String? profileName,
+    List<String> adHocArgs = const [],
+  }) async {}
+
+  @override
+  Future<void> stop(String taskId) async {}
+
+  @override
+  Future<void> restart(String taskId) async {}
+
+  @override
+  void sendKey(String taskId, String key) {}
+
+  @override
+  void startWatch(TaskDefinition def) {}
+
+  @override
+  void stopWatch(String taskId) {}
+
+  @override
+  Future<void> disposeAll() async {}
+}
+
+class FakeScrollbackStore implements TerminalScrollbackStore {
+  String? saved;
+
+  @override
+  Future<String?> load({
+    required String projectId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  Future<void> save({
+    required String projectId,
+    required String sessionId,
+    required String contents,
+  }) async => saved = contents;
+
+  @override
+  Future<void> delete({
+    required String projectId,
+    required String sessionId,
+  }) async {}
+
+  @override
+  Future<void> pruneExcept(Set<String> keep) async {}
+}
+
+TaskRun running(int pid) =>
+    TaskRun(taskId: 'json:api', status: TaskRunStatus.running, pid: pid);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeTaskRunner runner;
+  late FakeScrollbackStore scrollback;
+  late TaskTerminalStore store;
+
+  setUp(() {
+    runner = FakeTaskRunner();
+    scrollback = FakeScrollbackStore();
+    store = TaskTerminalStore(runner, scrollback)
+      // xterm é Dart puro — o Ghostty exigiria a dylib nativa no teste.
+      ..setDefaultEngine(TerminalEngine.xterm);
+  });
+
+  tearDown(() => store.dispose());
+
+  Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+  test('output JSON chega colorido ao terminal e ao scrollback', () async {
+    runner.emitRun(running(1));
+    await pump();
+    runner.emitOutput('{"level":"error","msg":"db down"}\n');
+    await pump();
+    await store.flushAll();
+
+    expect(scrollback.saved, contains('\x1b[91m"error"\x1b[0m'));
+    expect(scrollback.saved, contains('\x1b[97m"db down"\x1b[0m'));
+  });
+
+  test('output com ANSI próprio passa intacto', () async {
+    runner.emitRun(running(1));
+    await pump();
+    runner.emitOutput('\x1b[32mBuilt in 1.2s\x1b[0m\n');
+    await pump();
+    await store.flushAll();
+
+    expect(scrollback.saved, '\x1b[32mBuilt in 1.2s\x1b[0m\n');
+  });
+
+  test('linha JSON sem \\n é solta crua quando o run termina', () async {
+    runner.emitRun(running(1));
+    await pump();
+    runner.emitOutput('{"level":"info"'); // processo morreu no meio
+    await pump();
+    expect(scrollback.saved, isNull); // retida
+
+    runner.emitRun(
+      const TaskRun(taskId: 'json:api', status: TaskRunStatus.failed),
+    );
+    await pump();
+    await store.flushAll();
+
+    expect(scrollback.saved, '{"level":"info"');
+  });
+}

--- a/cockpit/test/tasks/task_preview_open_test.dart
+++ b/cockpit/test/tasks/task_preview_open_test.dart
@@ -1,0 +1,52 @@
+import 'package:cockpit/app/cockpit/domain/entities/task_definition.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+TaskDefinition def({
+  bool previewEnabled = true,
+  TaskPreviewOpen previewOpen = TaskPreviewOpen.always,
+}) => TaskDefinition(
+  id: 'json:api',
+  label: 'api',
+  cwd: '/tmp',
+  command: 'go',
+  previewEnabled: previewEnabled,
+  previewOpen: previewOpen,
+);
+
+void main() {
+  test(
+    'always (default) abre no start E no restart — comportamento histórico',
+    () {
+      final task = def();
+
+      expect(task.shouldOpenPreview(isRestart: false), isTrue);
+      expect(task.shouldOpenPreview(isRestart: true), isTrue);
+    },
+  );
+
+  test('start abre no start e cala no restart', () {
+    final task = def(previewOpen: TaskPreviewOpen.start);
+
+    expect(task.shouldOpenPreview(isRestart: false), isTrue);
+    expect(task.shouldOpenPreview(isRestart: true), isFalse);
+  });
+
+  test('never nunca abre', () {
+    final task = def(previewOpen: TaskPreviewOpen.never);
+
+    expect(task.shouldOpenPreview(isRestart: false), isFalse);
+    expect(task.shouldOpenPreview(isRestart: true), isFalse);
+  });
+
+  test('preview: false vence qualquer previewOpen', () {
+    for (final open in TaskPreviewOpen.values) {
+      final task = def(previewEnabled: false, previewOpen: open);
+      expect(
+        task.shouldOpenPreview(isRestart: false),
+        isFalse,
+        reason: '$open',
+      );
+      expect(task.shouldOpenPreview(isRestart: true), isFalse, reason: '$open');
+    }
+  });
+}

--- a/cockpit/test/tasks/tasks_json_loader_test.dart
+++ b/cockpit/test/tasks/tasks_json_loader_test.dart
@@ -107,6 +107,77 @@ void main() {
     );
   });
 
+  test(
+    'sem preview/previewOpen → default retrocompatível (abre sempre)',
+    () async {
+      await write('{ "tasks": [ { "label": "api", "command": "go" } ] }');
+      final task = (await const TasksJsonLoader().load(tmp.path)).single;
+      expect(task.previewEnabled, isTrue);
+      expect(task.previewUrl, isNull);
+      expect(task.previewOpen, TaskPreviewOpen.always);
+    },
+  );
+
+  test('preview string vira URL fixa; preview false desliga', () async {
+    await write('''
+      { "tasks": [
+        { "label": "fixa", "command": "go", "preview": "http://localhost:8080" },
+        { "label": "off", "command": "go", "preview": false }
+      ] }
+    ''');
+    final tasks = await const TasksJsonLoader().load(tmp.path);
+    final fixa = tasks.firstWhere((t) => t.label == 'fixa');
+    final off = tasks.firstWhere((t) => t.label == 'off');
+    expect(fixa.previewUrl, 'http://localhost:8080');
+    expect(fixa.previewEnabled, isTrue);
+    expect(off.previewEnabled, isFalse);
+    expect(off.previewUrl, isNull);
+  });
+
+  test('previewOpen aceita always/start/never', () async {
+    await write('''
+      { "tasks": [
+        { "label": "a", "command": "go", "previewOpen": "always" },
+        { "label": "s", "command": "go", "previewOpen": "start" },
+        { "label": "n", "command": "go", "previewOpen": "never" }
+      ] }
+    ''');
+    final tasks = await const TasksJsonLoader().load(tmp.path);
+    expect(
+      {for (final t in tasks) t.label: t.previewOpen},
+      {
+        'a': TaskPreviewOpen.always,
+        's': TaskPreviewOpen.start,
+        'n': TaskPreviewOpen.never,
+      },
+    );
+  });
+
+  test('previewOpen inválido ou de tipo errado → always', () async {
+    await write('''
+      { "tasks": [
+        { "label": "typo", "command": "go", "previewOpen": "onstart" },
+        { "label": "tipo", "command": "go", "previewOpen": true }
+      ] }
+    ''');
+    final tasks = await const TasksJsonLoader().load(tmp.path);
+    expect(
+      tasks.map((t) => t.previewOpen),
+      everyElement(TaskPreviewOpen.always),
+    );
+  });
+
+  test('preview false vence previewOpen always', () async {
+    await write('''
+      { "tasks": [
+        { "label": "off", "command": "go", "preview": false, "previewOpen": "always" }
+      ] }
+    ''');
+    final task = (await const TasksJsonLoader().load(tmp.path)).single;
+    expect(task.previewEnabled, isFalse);
+    expect(task.previewOpen, TaskPreviewOpen.always);
+  });
+
   test('task sem label ou command é ignorada', () async {
     await write('''
       { "tasks": [


### PR DESCRIPTION
## Motivação

Duas dores do painel de Tasks, ambas de quem roda backend.

**1. Log estruturado é um paredão.** O output da task vai cru para o emulador de
terminal, então quem já emite ANSI (Flutter, Vite) sai colorido — e quem emite
JSON de uma linha (Go com zerolog/zap, Node com pino) sai monocromático. Achar
o `level` de um erro no meio de vinte campos exige ler a linha inteira.

**2. Restart reabre o navegador.** `restart()` é `stop()` + `start()`, e cada
start reemitia o preview. Numa app Go com o Swagger já aberto, todo restart do
watcher joga uma aba nova na cara.

## O que muda

| # | Antes | Depois |
|---|---|---|
| 1 | Log JSON sem nenhuma cor | Campos realçados pela paleta ANSI do tema ativo |
| 2 | Nível de log indistinguível do resto | `error` em vermelho, `warn` em amarelo, `info` em azul, `debug` recuado |
| 3 | Timestamp competindo com a mensagem | `ts`/`time`/`caller` recuam; `msg` ganha destaque |
| 4 | Preview reabria em todo restart | `previewOpen` escolhe entre `always`, `start` e `never` |
| 5 | `preview` faltando no JSON Schema | Schema corrigido — o editor parou de acusar erro em config válida |

## Realce de logs JSON

Não dá para pintar por widget: o output é um grid de terminal desenhado por
painter. Então o realce acontece no **stream de texto**, injetando SGR
**indexado** (`ESC[36m`, `ESC[91m`…) antes do `write` no terminal.

Escolher índice em vez de truecolor resolve o tema sozinho:

- quem pinta é o `TerminalTheme` do tema ativo, **na hora do paint** — inclusive
  tema custom importado;
- trocar de tema **repinta o buffer já escrito**, sem reprocessar nada;
- nenhum `Color(0x…)` no código, como manda a convenção do projeto.

O realce é **conservador por design**: a linha só é transformada se decodificar
como objeto JSON **e** não contiver nenhum byte ANSI. Output do Flutter, do Vite
e texto solto passam byte a byte — nada do que já funcionava mudou. A cauda de
linha incompleta só é retida quando pode virar JSON, então prompt interativo e
barra de progresso com `\r` nunca travam.

Vale para tasks locais **e** remotas: o realce mora no único ponto onde o output
do runner encontra o terminal.

## `previewOpen`

Campo novo no `.cockpit/tasks.json`, irmão do `preview` que já existia:

```jsonc
{
  "label": "api",
  "command": "go",
  "args": ["run", "."],
  "preview": "http://localhost:8080/swagger",
  "previewOpen": "start"
}
```

| Modo | Start | Restart (botão ou watcher) | Stop + Start manual |
|---|---|---|---|
| `always` (default) | abre | abre | abre |
| `start` | abre | **não abre** | abre |
| `never` | não abre | não abre | não abre |

O default é `always`, então **quem não configurar nada não sente diferença**.
`preview: false` continua desligando tudo e vence qualquer `previewOpen`.

Para o modo `start` funcionar, o runner passou a distinguir start de restart:
`start` e `restart` delegam a um `_launch(…, restarting:)` interno e o run
carrega essa origem. O contrato `TaskRunnerGateway` **não mudou** — a distinção
não vaza para fora da implementação. A política em si virou
`TaskDefinition.shouldOpenPreview(isRestart:)`, ao lado do `resolveArgs`, para
ficar testável em isolamento.

## Screenshots

| Cenário | Preview |
|---|---|
| Log JSON realçado no painel de tasks | <img width="1346" height="610" alt="image" src="https://github.com/user-attachments/assets/4c4fe2e2-8472-4469-b923-66fe19185e07" /> |

## Testes

`+48` testes novos, todos passando:

- `json_log_highlighter_test.dart` — sequências SGR exatas por tipo de campo,
  níveis de log (string e numérico do pino), linha com ANSI intacta, JSON
  malformado intacto, JSON partido entre chunks, CRLF preservado, cauda que não
  trava prompt;
- `task_terminal_store_json_log_test.dart` — integração: bombeia output por um
  `TaskTerminalStore` real e confere o texto colorido chegando ao scrollback;
- `task_preview_open_test.dart` — a matriz de decisão dos três modos;
- `tasks_json_loader_test.dart` — parsing de `preview`/`previewOpen`, incluindo
  valor inválido caindo em `always` (o `preview` não tinha cobertura nenhuma).

`flutter analyze` limpo nos arquivos tocados. A suíte completa fecha em
`+1083 ~5 -7`; as 7 falhas são pré-existentes e não têm relação com a mudança
(goldens de pixel, IME e barra de menu do macOS rodando em Linux) — conferido
rodando os mesmos arquivos no baseline.
