### PR TITLE
corrige métricas da fonte do terminal no Linux

### DIFF
--- a/cockpit/lib/app/cockpit/ui/widgets/adaptive_terminal_pane.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/adaptive_terminal_pane.dart
@@ -9,6 +9,7 @@ import 'package:flterm/flterm.dart' as ghost;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'terminal_pane.dart';
@@ -213,7 +214,14 @@ ghost.TerminalTheme _ghosttyTheme(
   selection: ghost.SelectionTheme(
     background: ghost.DynamicColor.fixed(source.selection),
   ),
-  fontFamily: resolveGhosttyFontFamily(style.fontFamily),
+  // Use a mesma familia interna registrada por google_fonts para medir as
+  // celulas e rasterizar o atlas. Usar apenas o nome humano "JetBrains Mono"
+  // pode cair em fontes diferentes no Flutter Linux e alargar cada celula.
+  fontFamily: resolveGhosttyFontFamily(
+    style.fontFamily,
+    bundledJetBrainsMonoResolver: () =>
+        GoogleFonts.jetBrainsMono(fontWeight: fontWeight).fontFamily,
+  ),
   fontFamilyFallback: style.fontFamilyFallback,
   fontSize: style.fontSize * uiScale,
   fontWeight: fontWeight,

--- a/cockpit/lib/app/core/terminal/ghostty_font_family.dart
+++ b/cockpit/lib/app/core/terminal/ghostty_font_family.dart
@@ -11,11 +11,29 @@ import 'system_monospace_resolver_stub.dart'
 String resolveGhosttyFontFamily(
   String requested, {
   String? Function()? systemMonospaceResolver,
+  String? Function()? bundledJetBrainsMonoResolver,
 }) {
   final family = requested.trim();
-  if (family.toLowerCase() != 'monospace') return family;
+  // `google_fonts` registra a fonte com uma familia interna versionada, nao
+  // necessariamente com o nome humano "JetBrains Mono". Passar o nome humano
+  // diretamente ao flterm pode fazer o Flutter medir a celula com um fallback
+  // proporcional (o `M` largo) e pintar os demais glifos com outra face. O
+  // resultado visual e um espaco artificial entre todos os caracteres.
+  //
+  // O caller fornece o resolvedor para este helper continuar independente de
+  // google_fonts e permanecer testavel sem carregar assets.
+  String resolveBundledJetBrainsMono(String candidate) {
+    if (candidate.toLowerCase() != 'jetbrains mono') return candidate;
+    final bundled = bundledJetBrainsMonoResolver?.call()?.trim();
+    return bundled == null || bundled.isEmpty ? candidate : bundled;
+  }
+
+  if (family.toLowerCase() != 'monospace') {
+    return resolveBundledJetBrainsMono(family);
+  }
 
   final resolved = (systemMonospaceResolver ?? resolveSystemMonospaceFamily)()
       ?.trim();
-  return resolved == null || resolved.isEmpty ? family : resolved;
+  if (resolved == null || resolved.isEmpty) return family;
+  return resolveBundledJetBrainsMono(resolved);
 }

--- a/cockpit/lib/main.dart
+++ b/cockpit/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:cockpit/app/core/ui/widgets/app_error_view.dart';
 import 'package:cockpit/app/core/ui/widgets/error_report_dialog.dart';
 import 'package:cockpit/i18n/strings.g.dart';
 import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
@@ -21,6 +22,20 @@ import 'package:shadcn_flutter/shadcn_flutter.dart';
 Future<void> main() async {
   await runGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
+
+    // O terminal Ghostty mede a grade antes de montar seu atlas de glifos. Se
+    // JetBrains Mono ainda estiver sendo registrada assincronamente pelo
+    // google_fonts, a primeira medida usa o fallback proporcional e cada
+    // caractere ganha uma celula larga demais ate alguma configuracao de fonte
+    // forcar novo layout. Carregue previamente todos os pesos que o terminal
+    // oferece para que medida e rasterizacao usem a mesma face desde o primeiro
+    // frame.
+    await GoogleFonts.pendingFonts([
+      GoogleFonts.jetBrainsMono(fontWeight: FontWeight.w300),
+      GoogleFonts.jetBrainsMono(fontWeight: FontWeight.w400),
+      GoogleFonts.jetBrainsMono(fontWeight: FontWeight.w500),
+      GoogleFonts.jetBrainsMono(fontWeight: FontWeight.w600),
+    ]);
 
     // Mobile (iPad/Android): todas as orientações liberadas (plano 60, Wave F).
     // Em telas estreitas (portrait de celular) o shell colapsa as panes laterais

--- a/cockpit/test/core/terminal/ghostty_font_family_test.dart
+++ b/cockpit/test/core/terminal/ghostty_font_family_test.dart
@@ -23,6 +23,40 @@ void main() {
       );
     });
 
+    test('uses the registered bundled JetBrains Mono family', () {
+      expect(
+        resolveGhosttyFontFamily(
+          'JetBrains Mono',
+          bundledJetBrainsMonoResolver: () => 'JetBrainsMono_bundled',
+        ),
+        'JetBrainsMono_bundled',
+      );
+    });
+
+    test(
+      'maps a system monospace resolved as JetBrains Mono to the bundle',
+      () {
+        expect(
+          resolveGhosttyFontFamily(
+            'monospace',
+            systemMonospaceResolver: () => 'JetBrains Mono',
+            bundledJetBrainsMonoResolver: () => 'JetBrainsMono_bundled',
+          ),
+          'JetBrainsMono_bundled',
+        );
+      },
+    );
+
+    test('keeps JetBrains Mono when the bundled resolver is unavailable', () {
+      expect(
+        resolveGhosttyFontFamily(
+          'JetBrains Mono',
+          bundledJetBrainsMonoResolver: () => null,
+        ),
+        'JetBrains Mono',
+      );
+    });
+
     test('falls back to the generic alias when resolution is unavailable', () {
       expect(
         resolveGhosttyFontFamily(


### PR DESCRIPTION
## Resumo

- carrega previamente as variações da JetBrains Mono incluídas no aplicativo antes de iniciar a interface Flutter;
- faz o Ghostty calcular as células com a mesma família registrada que o Flutter usa para desenhar os caracteres;
- mantém o comportamento de fallback quando a fonte incluída não está disponível;
- adiciona testes para a fonte configurada explicitamente e para a resolução de `monospace` do sistema.

## Motivação

Em alguns ambientes Linux, especialmente no Omarchy, o Flutter podia calcular as células do terminal usando uma fonte substituta antes que a JetBrains Mono fosse registrada. Depois, os caracteres eram desenhados com métricas diferentes, provocando espaçamento excessivo em tamanhos menores e desalinhamento em interfaces de terminal.

## Validação

- `flutter analyze` nos arquivos Dart alterados;
- `flutter test test/core/terminal/ghostty_font_family_test.dart` — 6 testes aprovados;
- `flutter build linux --debug`;
- comparação visual manual com o terminal do Omarchy, inclusive em tamanhos menores.