### PR TITLE
fix(pi-extension): clear 5 audit advisories via dependency overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,23 @@ and 27 (see [`plan/`](plan/) directory for design history).
   relay sees plaintext envelopes at rest and in forwarding. Self-hosting is
   the recommended path for sensitive deployments. E2E payload encryption is
   on the public roadmap (see `PROTOCOL.md` "Roadmap").
+- **Audit advisories cleared via targeted dependency overrides.**
+  `pi install npm:remote-pi` reported 5 advisories (2 high, 3 moderate),
+  inherited from the bundled `@earendil-works/pi-coding-agent` SDK pinned at
+  `^0.79.10`: undici < 8.9.0 (response desynchronization via retry
+  interceptor, cache-directive info disclosure, CRLF injection via blob-like
+  body `type`, cookie attribute injection), brace-expansion < 5.0.9 (DoS via
+  unbounded `{}` expansion), protobufjs < 7.6.5 (DoS in `.proto` option
+  parsing). With the SDK floor intentionally kept at `^0.79.10`, the
+  `pnpm-workspace.yaml` security overrides were extended instead: undici
+  8.5.0 → 8.10.0, brace-expansion 5.0.6 → 5.0.9, protobufjs 7.6.4 → 7.6.6,
+  hono 4.12.27 → 4.13.5, @hono/node-server 1.19.14 → 1.19.17, fast-uri
+  3.1.2 → 3.1.6, ip-address 10.2.0 → 10.5.0, nanoid 3.3.15 → 3.3.18, postcss
+  8.5.15 → 8.5.26 (all others pinned floors raised: esbuild, vite, ws
+  unchanged). `pnpm audit` (prod + dev): no known vulnerabilities. Note:
+  overrides do not propagate to consumer installs — the undici advisory
+  there persists until the SDK floor is raised (0.79.x pins undici 8.5.0
+  exact; the fixed 8.9.0+ ships in pi-coding-agent 0.84.3+).
 
 ### Removed
 

--- a/pi-extension/pnpm-lock.yaml
+++ b/pi-extension/pnpm-lock.yaml
@@ -5,9 +5,16 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@hono/node-server': ^1.19.15
   esbuild: ^0.28.1
-  hono: ^4.12.25
-  protobufjs: ^7.6.3
+  brace-expansion: ^5.0.9
+  fast-uri: ^3.1.5
+  hono: ^4.12.34
+  ip-address: ^10.3.1
+  nanoid: ^3.3.18
+  postcss: ^8.5.23
+  protobufjs: ^7.6.5
+  undici: ^8.9.0
   vite: ^8.0.16
   ws: ^8.21.0
 
@@ -373,11 +380,11 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.12.25
+      hono: ^4.12.34
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -830,9 +837,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -989,8 +996,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1079,8 +1086,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@9.0.3:
@@ -1110,8 +1117,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1270,8 +1277,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1355,15 +1362,15 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.6:
+    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -1521,8 +1528,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
@@ -1944,7 +1951,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.1.38
-      undici: 8.5.0
+      undici: 8.10.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -2059,7 +2066,7 @@ snapshots:
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.6
       ws: 8.21.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
@@ -2068,9 +2075,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@1.19.17(hono@4.13.5)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.13.5
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2132,7 +2139,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@hono/node-server': 1.19.17(hono@4.13.5)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2142,7 +2149,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.27
+      hono: 4.13.5
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2426,7 +2433,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2454,7 +2461,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2585,7 +2592,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.5.0
 
   express@5.2.1:
     dependencies:
@@ -2624,7 +2631,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.6: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2726,7 +2733,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.27: {}
+  hono@4.13.5: {}
 
   hosted-git-info@9.0.3:
     dependencies:
@@ -2762,7 +2769,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -2871,13 +2878,13 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -2934,9 +2941,9 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2946,7 +2953,7 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -3133,7 +3140,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.5.0: {}
+  undici@8.10.0: {}
 
   unpipe@1.0.0: {}
 
@@ -3143,7 +3150,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pi-extension/pnpm-workspace.yaml
+++ b/pi-extension/pnpm-workspace.yaml
@@ -8,8 +8,15 @@ allowBuilds:
 # Keep transitive packages above known vulnerable ranges until upstreams
 # release dependency updates that naturally resolve these versions.
 overrides:
+  '@hono/node-server': ^1.19.15
   esbuild: ^0.28.1
-  hono: ^4.12.25
-  protobufjs: ^7.6.3
+  brace-expansion: ^5.0.9
+  fast-uri: ^3.1.5
+  hono: ^4.12.34
+  ip-address: ^10.3.1
+  nanoid: ^3.3.18
+  postcss: ^8.5.23
+  protobufjs: ^7.6.5
+  undici: ^8.9.0
   vite: ^8.0.16
   ws: ^8.21.0


### PR DESCRIPTION
`pi install npm:remote-pi` reports 5 advisories (2 high, 3 moderate). None of
them are in remote-pi's own code — they all come from the
`@earendil-works/pi-coding-agent` SDK, pinned at `^0.79.10`:

| Advisory | Package | Severity | Fixed in |
|---|---|---|---|
| GHSA-8xcm-r25x-g524 (+4) | undici | high | 8.9.0 |
| GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 | brace-expansion | high | 5.0.9 |
| GHSA-j3f2-48v5-ccww | protobufjs | moderate | 7.6.5 |

**This PR doesn't bump the SDK.** Following #28's approach (overrides "until
upstream packages naturally resolve patched versions"), it pins the affected
transitive packages to their fixed versions in `pnpm-workspace.yaml`:

| Package | main | This PR |
|---|---|---|
| undici | 8.5.0 | 8.10.0 |
| brace-expansion | 5.0.6 | 5.0.9 |
| protobufjs | 7.6.4 | 7.6.6 |
| hono | 4.12.27 | 4.13.5 |
| @hono/node-server | 1.19.14 | 1.19.17 |
| fast-uri | 3.1.2 | 3.1.6 |
| ip-address | 10.2.0 | 10.5.0 |
| nanoid | 3.3.15 | 3.3.18 |
| postcss | 8.5.15 | 8.5.26 |

The last two are dev-only (vite → postcss → nanoid). The esbuild/vite/ws
floors from #28 stay as they are. Nothing else moves — the lockfile diff is
84 lines, and `engines`, README, and CLAUDE.md are untouched.

### One thing to know

pnpm overrides don't reach consumers. A fresh `pi install npm:remote-pi`
resolves its own tree and will keep flagging undici until we raise the SDK
floor — 0.79.x pins `undici: 8.5.0` exactly, and patched undici only ships in
pi-coding-agent 0.84.3+. The brace-expansion and protobufjs items do
self-heal for consumers, since fresh installs already pick up the patched
releases. When we're ready to take the SDK bump, that closes the last gap.

### Smaller notes

- undici 8.5.0 → 8.10.0 is the same bump the pi monorepo shipped in-tree for
  0.84.3, so the SDK is known to run against it.
- On Node: the SDK 0.79.x and undici 8.9.0+ both declare `node >=22.19.0`, so
  Node 20 installs already print `EBADENGINE` warnings today — this PR
  doesn't change that. There is a patched undici that still supports Node 20
  (7.29.0), but downgrading 8.5.0 → 7.29.0 crosses a major against the SDK's
  pin, so I left it.
- No runtime, protocol, pairing, or command changes.

### Verification

- `pnpm audit` (prod + dev): no known vulnerabilities
- `pnpm typecheck`: clean
- `pnpm test`: 798 passed, 3 skipped

Refs #158
