### PR TITLE
feat(cockpit): adiciona integração opcional com Neovim

### DIFF
--- a/cockpit/lib/app/cockpit/domain/services/file_editor_facade.dart
+++ b/cockpit/lib/app/cockpit/domain/services/file_editor_facade.dart
@@ -1,0 +1,102 @@
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+
+/// Contexto completo de uma abertura, independente da superfície que vai
+/// hospedar o editor (pane hoje, janela no futuro).
+class FileOpenRequest {
+  const FileOpenRequest({
+    required this.path,
+    required this.projectId,
+    required this.paneId,
+    required this.isRemote,
+    this.isPreview = true,
+    this.revealLine,
+    this.asSource = false,
+    this.isNotebook = false,
+    this.focusPane = false,
+  });
+
+  final String path;
+  final String projectId;
+  final String paneId;
+  final bool isRemote;
+  final bool isPreview;
+  final int? revealLine;
+  final bool asSource;
+  final bool isNotebook;
+  final bool focusPane;
+}
+
+enum FileOpenOutcome { opened, notHandled }
+
+class FileOpenResult {
+  const FileOpenResult(this.engine, this.outcome);
+
+  final FileEditorEngine engine;
+  final FileOpenOutcome outcome;
+}
+
+typedef FileEngineOpener =
+    Future<FileOpenOutcome> Function(FileOpenRequest request);
+
+/// Registro extensível dos motores disponíveis nesta superfície.
+class FileEditorRegistry {
+  FileEditorRegistry(Map<FileEditorEngine, FileEngineOpener> engines)
+    : _engines = Map.unmodifiable(engines);
+
+  final Map<FileEditorEngine, FileEngineOpener> _engines;
+
+  Future<FileOpenOutcome> open(
+    FileEditorEngine engine,
+    FileOpenRequest request,
+  ) =>
+      _engines[engine]?.call(request) ??
+      Future<FileOpenOutcome>.value(FileOpenOutcome.notHandled);
+}
+
+/// Orquestra classificação, escolha do motor e fallback. Não conhece árvore,
+/// tabs ou sessões: essas mutações pertencem ao host registrado.
+class FileEditorFacade {
+  FileEditorFacade(this._registry);
+
+  final FileEditorRegistry _registry;
+  FileEditorEngine engine = FileEditorEngine.cockpit;
+
+  static const Set<String> _cockpitExtensions = {
+    // Experiências especializadas.
+    'http', 'dbq', 'kanban',
+    // Mídia e SVG.
+    'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svg',
+    'mp4', 'mov', 'avi', 'mkv', 'webm', 'm4v', 'wmv', 'flv',
+    'mp3', 'wav', 'aac', 'm4a', 'flac', 'ogg', 'opus',
+  };
+
+  FileEditorEngine engineFor(FileOpenRequest request) {
+    if (request.isRemote || request.isNotebook) {
+      return FileEditorEngine.cockpit;
+    }
+    if (!request.asSource &&
+        _cockpitExtensions.contains(_extension(request.path))) {
+      return FileEditorEngine.cockpit;
+    }
+    return engine;
+  }
+
+  Future<FileOpenResult> open(FileOpenRequest request) async {
+    final selected = engineFor(request);
+    final outcome = await _registry.open(selected, request);
+    if (outcome == FileOpenOutcome.opened ||
+        selected == FileEditorEngine.cockpit) {
+      return FileOpenResult(selected, outcome);
+    }
+    return FileOpenResult(
+      FileEditorEngine.cockpit,
+      await _registry.open(FileEditorEngine.cockpit, request),
+    );
+  }
+
+  static String _extension(String path) {
+    final name = path.split('/').last;
+    final dot = name.lastIndexOf('.');
+    return dot <= 0 ? '' : name.substring(dot + 1).toLowerCase();
+  }
+}

--- a/cockpit/lib/app/cockpit/ui/actions/tab_actions.dart
+++ b/cockpit/lib/app/cockpit/ui/actions/tab_actions.dart
@@ -1,9 +1,12 @@
 import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
+import 'package:cockpit/app/cockpit/ui/session/neovim_session.dart';
+import 'package:cockpit/app/core/domain/result.dart';
 import 'package:cockpit/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart';
 import 'package:cockpit/app/cockpit/ui/widgets/confirm_dialog.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:cockpit/i18n/strings.g.dart';
 
 /// Fecha [item] pedindo confirmação quando há edição não salva.
 ///
@@ -17,6 +20,23 @@ Future<bool> requestCloseTab(
   PaneItem? item,
   VoidCallback onClose,
 ) async {
+  if (item is NeovimSession) {
+    final modified = await item.hasModifiedBuffers();
+    if (!context.mounted) return false;
+    if (modified case Success(value: true)) {
+      final tr = context.t.cockpit.neovim;
+      final confirmed = await showConfirmDialog(
+        context,
+        title: tr.unsavedTitle,
+        message: tr.unsavedMessage,
+        confirmLabel: tr.closeAnyway,
+        danger: true,
+      );
+      if (!context.mounted || !confirmed) return false;
+    }
+    onClose();
+    return true;
+  }
   if (item is! FileViewerSession || !item.dirty) {
     onClose();
     return true;

--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -1,4 +1,5 @@
 import 'package:cockpit_core/cockpit_core.dart';
+
 import 'dart:async' show StreamSubscription, unawaited;
 import 'dart:io';
 
@@ -11,6 +12,7 @@ import 'package:cockpit/app/core/app_intents.dart';
 import 'package:cockpit/app/cockpit/domain/entities/project.dart';
 import 'package:cockpit/app/core/domain/entities/app_settings.dart';
 import 'package:cockpit/app/core/domain/entities/automation.dart';
+import 'package:cockpit/app/core/domain/exceptions/neovim_error.dart';
 import 'package:cockpit/app/core/routes.dart';
 import 'package:cockpit/app/core/ui/menu/workspace_menu_bridge.dart';
 import 'package:cockpit/app/cockpit/ui/session/agent_session.dart';
@@ -144,7 +146,8 @@ class _CockpitPageState extends State<CockpitPage> {
     _sourceControlViewMode = initialSettings.sourceControlViewMode;
     context.read<CockpitViewModel>()
       ..setDefaultTerminalProfileId(initialSettings.defaultTerminalProfileId)
-      ..setDefaultTerminalEngine(initialSettings.terminalEngine);
+      ..setDefaultTerminalEngine(initialSettings.terminalEngine)
+      ..setNeovimEnabled(initialSettings.neovimEnabled);
     // Dispara o carregamento inicial dos ViewModels page-scoped ao montar a rota.
     // Os módulos provêm via `.new`, então não encadeiam mais `..init()`/`..check()`.
     context.read<CockpitViewModel>().init();
@@ -185,11 +188,14 @@ class _CockpitPageState extends State<CockpitPage> {
       ..addListener(_syncNotifications)
       ..addListener(_syncCockpit)
       ..addListener(_syncSourceControlViewMode)
-      ..addListener(_syncAutomationSelection);
+      ..addListener(_syncAutomationSelection)
+      ..addListener(_syncNeovim);
+    context.read<CockpitViewModel>().onNeovimError = _showNeovimError;
     _syncLspCommands();
     _syncNotifications();
     _syncCockpit();
     _syncAutomationSelection();
+    _syncNeovim();
     // Restaura a visibilidade dos painéis (rail/árvore) salva na sessão anterior
     // e persiste de volta a cada toggle. A VM é a fonte de verdade em runtime.
     final vm = context.read<CockpitViewModel>();
@@ -426,6 +432,30 @@ class _CockpitPageState extends State<CockpitPage> {
     _vm.setAutomationSelection(_settings!.settings.automationSelection);
   }
 
+  void _syncNeovim() {
+    _vm.setNeovimEnabled(_settings!.settings.neovimEnabled);
+  }
+
+  void _showNeovimError(NeovimError error) {
+    if (!mounted) return;
+    final tr = context.t.cockpit.neovim;
+    final message = switch (error.kind) {
+      NeovimErrorKind.unavailable => tr.unavailable,
+      NeovimErrorKind.connectionFailed ||
+      NeovimErrorKind.timeout => tr.openFailed,
+    };
+    showToast(
+      context: context,
+      location: ToastLocation.bottomRight,
+      builder: (context, overlay) => SurfaceCard(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Text(message, style: context.typo.label),
+        ),
+      ),
+    );
+  }
+
   void _syncLspCommands() {
     final next = _settings!.settings.lspCommands;
     _vm.applyLspCommands(next);
@@ -483,6 +513,8 @@ class _CockpitPageState extends State<CockpitPage> {
     _settings?.removeListener(_syncCockpit);
     _settings?.removeListener(_syncSourceControlViewMode);
     _settings?.removeListener(_syncAutomationSelection);
+    _settings?.removeListener(_syncNeovim);
+    _vm.onNeovimError = null;
     _menuVm?.removeListener(_syncWorkspaceMenu);
     _workspaceMenu?.setWorkspace(hasWorkspace: false);
     // Túneis SSH abertos morrem com o shell — e os prompts vão junto, senão

--- a/cockpit/lib/app/cockpit/ui/cockpit_page.dart
+++ b/cockpit/lib/app/cockpit/ui/cockpit_page.dart
@@ -147,7 +147,7 @@ class _CockpitPageState extends State<CockpitPage> {
     context.read<CockpitViewModel>()
       ..setDefaultTerminalProfileId(initialSettings.defaultTerminalProfileId)
       ..setDefaultTerminalEngine(initialSettings.terminalEngine)
-      ..setNeovimEnabled(initialSettings.neovimEnabled);
+      ..setFileEditorEngine(initialSettings.fileEditorEngine);
     // Dispara o carregamento inicial dos ViewModels page-scoped ao montar a rota.
     // Os módulos provêm via `.new`, então não encadeiam mais `..init()`/`..check()`.
     context.read<CockpitViewModel>().init();
@@ -189,13 +189,13 @@ class _CockpitPageState extends State<CockpitPage> {
       ..addListener(_syncCockpit)
       ..addListener(_syncSourceControlViewMode)
       ..addListener(_syncAutomationSelection)
-      ..addListener(_syncNeovim);
+      ..addListener(_syncFileEditorEngine);
     context.read<CockpitViewModel>().onNeovimError = _showNeovimError;
     _syncLspCommands();
     _syncNotifications();
     _syncCockpit();
     _syncAutomationSelection();
-    _syncNeovim();
+    _syncFileEditorEngine();
     // Restaura a visibilidade dos painéis (rail/árvore) salva na sessão anterior
     // e persiste de volta a cada toggle. A VM é a fonte de verdade em runtime.
     final vm = context.read<CockpitViewModel>();
@@ -432,8 +432,8 @@ class _CockpitPageState extends State<CockpitPage> {
     _vm.setAutomationSelection(_settings!.settings.automationSelection);
   }
 
-  void _syncNeovim() {
-    _vm.setNeovimEnabled(_settings!.settings.neovimEnabled);
+  void _syncFileEditorEngine() {
+    _vm.setFileEditorEngine(_settings!.settings.fileEditorEngine);
   }
 
   void _showNeovimError(NeovimError error) {
@@ -513,7 +513,7 @@ class _CockpitPageState extends State<CockpitPage> {
     _settings?.removeListener(_syncCockpit);
     _settings?.removeListener(_syncSourceControlViewMode);
     _settings?.removeListener(_syncAutomationSelection);
-    _settings?.removeListener(_syncNeovim);
+    _settings?.removeListener(_syncFileEditorEngine);
     _vm.onNeovimError = null;
     _menuVm?.removeListener(_syncWorkspaceMenu);
     _workspaceMenu?.setWorkspace(hasWorkspace: false);

--- a/cockpit/lib/app/cockpit/ui/session/neovim_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/neovim_session.dart
@@ -1,0 +1,64 @@
+import 'package:cockpit/app/cockpit/domain/contracts/terminal_gateway.dart';
+import 'package:cockpit/app/cockpit/ui/session/terminal_session.dart';
+import 'package:cockpit/app/core/domain/contracts/neovim_gateway.dart';
+import 'package:cockpit/app/core/domain/entities/terminal_profile.dart';
+import 'package:cockpit/app/core/domain/result.dart';
+import 'package:cockpit/app/core/domain/exceptions/neovim_error.dart';
+
+/// TUI do Neovim hospedada no terminal do Cockpit, com servidor RPC próprio.
+class NeovimSession extends TerminalSession {
+  NeovimSession({
+    required super.id,
+    required super.projectId,
+    required super.workingDirectory,
+    required TerminalGateway terminalGateway,
+    required this.neovimGateway,
+    required this.executable,
+    required this.serverAddress,
+    required this.lastPath,
+    this.lastLine,
+    required super.engine,
+  }) : super(
+         gateway: terminalGateway,
+         profile: TerminalProfile(
+           id: 'cockpit-neovim',
+           label: 'Neovim',
+           executable: executable,
+           args: [
+             '--listen',
+             serverAddress,
+             if (lastLine != null) '+$lastLine',
+             lastPath,
+           ],
+         ),
+         title: 'Neovim',
+       ) {
+    restoreManualLabel('Neovim');
+  }
+
+  final NeovimGateway neovimGateway;
+  final String executable;
+  final String serverAddress;
+  String lastPath;
+  int? lastLine;
+
+  Future<bool> isAlive() => neovimGateway.isAlive(executable, serverAddress);
+
+  Future<Result<bool, NeovimError>> hasModifiedBuffers() =>
+      neovimGateway.hasModifiedBuffers(executable, serverAddress);
+
+  Future<Result<void, NeovimError>> open(String path, {int? line}) async {
+    final result = await neovimGateway.openRemote(
+      executable,
+      serverAddress,
+      path,
+      line: line,
+    );
+    if (result.isSuccess) {
+      lastPath = path;
+      lastLine = line;
+      notifyListeners();
+    }
+    return result;
+  }
+}

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
@@ -23,6 +23,7 @@ import 'package:cockpit/app/cockpit/ui/session/browser_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/notebook_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/mongo_browser_session.dart';
+import 'package:cockpit/app/cockpit/ui/session/neovim_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
 import 'package:cockpit/app/cockpit/ui/session/redis_browser_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/task_output_session.dart';
@@ -254,6 +255,14 @@ class CockpitCliHandler {
           return CockpitCommandResult.fail(
             'tab "${s.id}" is not in any pane (already closed?)',
           );
+        }
+        if (s is NeovimSession) {
+          final modified = await s.hasModifiedBuffers();
+          if (modified case Success(value: true)) {
+            return const CockpitCommandResult.fail(
+              'Neovim has modified buffers; close it from the UI to confirm',
+            );
+          }
         }
         // O fechamento roda DEPOIS da resposta (`afterResponse`): fechar a
         // própria aba emissora mata o PTY — e com ele o shell e o processo

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -30,12 +30,14 @@ import 'package:cockpit/app/cockpit/domain/contracts/rpc_gateway_factory.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/session_history.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_gateway_factory.dart';
 import 'package:cockpit/app/core/domain/contracts/terminal_profile_resolver.dart';
+import 'package:cockpit/app/core/domain/contracts/neovim_gateway.dart';
 import 'package:cockpit/app/core/domain/entities/terminal_profile.dart';
 import 'package:cockpit/app/core/domain/entities/app_settings.dart';
 import 'package:cockpit/app/core/domain/entities/sound_event.dart';
 import 'package:cockpit/app/core/domain/entities/automation.dart';
 import 'package:cockpit/app/core/domain/exceptions/automation_error.dart';
 import 'package:cockpit/app/core/domain/exceptions/file_operation_error.dart';
+import 'package:cockpit/app/core/domain/exceptions/neovim_error.dart';
 import 'package:cockpit/app/core/domain/services/commit_message_prompt.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/terminal_status_server.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/workspace_layout_store.dart';
@@ -78,6 +80,7 @@ import 'package:cockpit/app/cockpit/ui/session/diff_viewer_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/mongo_browser_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/notebook_session.dart';
+import 'package:cockpit/app/cockpit/ui/session/neovim_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
 import 'package:cockpit/app/cockpit/domain/entities/browser_capability.dart';
 import 'package:cockpit/app/cockpit/ui/session/browser_session.dart';
@@ -156,6 +159,7 @@ class CockpitViewModel extends ChangeNotifier {
     this.remote,
     this.files,
     this.notifications,
+    this._neovim,
   ) {
     _worktreeReconciler = WorktreeReconciler(_worktreeMgr);
     // Contexto do shell que o GitController precisa (page-scoped, mesma vida).
@@ -256,6 +260,7 @@ class CockpitViewModel extends ChangeNotifier {
   final LayoutLoader _layoutLoader;
   final RemoteHostsController _remoteHosts;
   final TerminalHarnessMonitor _harnessMonitor;
+  final NeovimGateway _neovim;
   final RpcGatewayFactory _factory;
   final FolderLister _folders;
   final SessionHistory _history;
@@ -352,6 +357,13 @@ class CockpitViewModel extends ChangeNotifier {
   final List<Project> _projectList = <Project>[];
   String? _selectedProjectId;
   final Map<String, PaneItem> _sessions = <String, PaneItem>{};
+
+  /// Fila por workspace: dois cliques simultâneos nunca podem observar "sem
+  /// Neovim" e criar duas instâncias.
+  final Map<String, Future<void>> _neovimTails = <String, Future<void>>{};
+
+  /// Erros são tipados; a página traduz e apresenta o toast na borda da UI.
+  void Function(NeovimError error)? onNeovimError;
 
   /// Realms (conjuntos de workspaces) e o recorte ativo. [_projectList] guarda
   /// os workspaces de TODOS os realms (sessões de realms ocultos seguem vivas);
@@ -522,6 +534,10 @@ class CockpitViewModel extends ChangeNotifier {
     _defaultTerminalEngine = engine;
     _taskTerminals.setDefaultEngine(engine);
   }
+
+  bool _neovimEnabled = false;
+
+  void setNeovimEnabled(bool value) => _neovimEnabled = value;
 
   /// Perfis descobertos, para o seletor ao lado do `+`. Já aquecidos no boot.
   List<TerminalProfile> get terminalProfiles =>
@@ -1114,6 +1130,17 @@ class CockpitViewModel extends ChangeNotifier {
     final tree = _activeTree;
     final paneId = inPane ?? (projectId == null ? null : _focused[projectId]);
     if (projectId == null || tree == null || paneId == null) return;
+    if (_shouldOpenInNeovim(projectId, path)) {
+      final opened = await _enqueueNeovimOpen(
+        projectId,
+        paneId,
+        path,
+        line: revealLine,
+      );
+      if (opened) return;
+      // Executável ausente/falha de spawn: mantém o usuário produtivo usando o
+      // fluxo integrado já existente. A UI recebe o erro tipado via callback.
+    }
     final leaf = findLeaf(tree, paneId);
     if (leaf == null) return;
     _recordHistoryBeforeSwitch(paneId);
@@ -1204,6 +1231,156 @@ class CockpitViewModel extends ChangeNotifier {
     _sessions[viewer.id] = viewer;
     _watchFileViewer(viewer);
     _placeNewViewer(viewer, projectId, paneId, tree, isPreview: isPreview);
+  }
+
+  static const Set<String> _neovimInternalExtensions = {
+    // Editores com runner próprio.
+    'http', 'dbq',
+    // Visualizações de mídia do Cockpit.
+    'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svg',
+    'mp4', 'mov', 'avi', 'mkv', 'webm', 'm4v', 'wmv', 'flv',
+    'mp3', 'wav', 'aac', 'm4a', 'flac', 'ogg', 'opus',
+  };
+
+  bool _shouldOpenInNeovim(String projectId, String path) {
+    if (!_neovimEnabled || _isRemoteWorkspace(projectId)) return false;
+    final name = path.split('/').last;
+    final dot = name.lastIndexOf('.');
+    final ext = dot <= 0 ? '' : name.substring(dot + 1).toLowerCase();
+    return !_neovimInternalExtensions.contains(ext);
+  }
+
+  Future<bool> _enqueueNeovimOpen(
+    String projectId,
+    String paneId,
+    String path, {
+    int? line,
+  }) async {
+    final previous = _neovimTails[projectId] ?? Future<void>.value();
+    final turn = Completer<void>();
+    final tail = turn.future;
+    _neovimTails[projectId] = tail;
+    await previous;
+    try {
+      return await _openInNeovim(projectId, paneId, path, line: line);
+    } finally {
+      turn.complete();
+      if (identical(_neovimTails[projectId], tail)) {
+        _neovimTails.remove(projectId);
+      }
+    }
+  }
+
+  Future<bool> _openInNeovim(
+    String projectId,
+    String paneId,
+    String path, {
+    int? line,
+  }) async {
+    final executable = await _neovim.executable();
+    if (executable == null) {
+      onNeovimError?.call(const NeovimError(NeovimErrorKind.unavailable));
+      return false;
+    }
+
+    NeovimSession? existing;
+    for (final session in _sessions.values) {
+      if (session is NeovimSession && session.projectId == projectId) {
+        existing = session;
+        break;
+      }
+    }
+
+    if (existing != null && await _waitForNeovim(existing)) {
+      final result = await existing.open(path, line: line);
+      if (result.isSuccess) {
+        _focusNeovim(existing);
+        return true;
+      }
+    }
+
+    final currentTree = _trees[projectId];
+    if (currentTree == null) return false;
+    final oldLeafId = existing == null
+        ? null
+        : leafOfTab(projectId, existing.id);
+    final targetPane = oldLeafId ?? paneId;
+    final leaf = findLeaf(currentTree, targetPane);
+    if (leaf == null) return false;
+
+    if (existing != null) {
+      _sessions.remove(existing.id);
+      await existing.dispose();
+    }
+
+    final address = _neovim.serverAddress(projectId);
+    await _neovim.prepareServer(address);
+    final session = NeovimSession(
+      id: _nid('n'),
+      projectId: projectId,
+      workingDirectory: _projectById(projectId)?.path ?? '',
+      terminalGateway: _gatewayForProject(projectId),
+      neovimGateway: _neovim,
+      executable: executable,
+      serverAddress: address,
+      lastPath: path,
+      lastLine: line,
+      engine: _defaultTerminalEngine,
+    );
+    _sessions[session.id] = session;
+
+    final oldId = existing?.id;
+    final active = _sessions[leaf.active];
+    final replaceEmpty =
+        active is AgentSession && active.status == AgentStatus.empty;
+    _trees[projectId] = updateLeaf(currentTree, leaf.id, (p) {
+      if (oldId != null && p.tabs.contains(oldId)) {
+        return p.copyWith(
+          tabs: p.tabs.map((id) => id == oldId ? session.id : id).toList(),
+          active: session.id,
+        );
+      }
+      if (replaceEmpty) {
+        return p.copyWith(
+          tabs: p.tabs.map((id) => id == p.active ? session.id : id).toList(),
+          active: session.id,
+        );
+      }
+      return p.copyWith(tabs: [...p.tabs, session.id], active: session.id);
+    });
+    if (replaceEmpty) _disposeSession(leaf.active);
+    _focused[projectId] = leaf.id;
+    notifyListeners();
+    if (!await _waitForNeovim(session)) {
+      onNeovimError?.call(const NeovimError(NeovimErrorKind.connectionFailed));
+      if (_sessions[session.id] == session) {
+        closeTab(leaf.id, session.id);
+      }
+      return false;
+    }
+    return true;
+  }
+
+  Future<bool> _waitForNeovim(NeovimSession session) async {
+    for (var attempt = 0; attempt < 20; attempt++) {
+      if (await session.isAlive()) return true;
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    return false;
+  }
+
+  void _focusNeovim(NeovimSession session) {
+    final tree = _trees[session.projectId];
+    final leafId = leafOfTab(session.projectId, session.id);
+    if (tree == null || leafId == null) return;
+    _recordHistoryBeforeSwitch(leafId);
+    _trees[session.projectId] = updateLeaf(
+      tree,
+      leafId,
+      (leaf) => leaf.copyWith(active: session.id),
+    );
+    _focused[session.projectId] = leafId;
+    notifyListeners();
   }
 
   /// Insere uma aba de viewer recém-criada na pane [paneId]: substitui o
@@ -2065,12 +2242,7 @@ class CockpitViewModel extends ChangeNotifier {
   Future<void> openTerminalPath(String token, {String? cwd, int? line}) async {
     final abs = _resolveTerminalPath(token, cwd);
     if (abs == null) return;
-    await openFile(abs, isPreview: false);
-    if (line != null) {
-      for (final s in _sessions.values) {
-        if (s is FileViewerSession && s.path == abs) s.reveal(line);
-      }
-    }
+    await openFile(abs, isPreview: false, revealLine: line);
   }
 
   /// Resolve um token de caminho do terminal para absoluto: expande `~`, junta
@@ -2125,10 +2297,7 @@ class CockpitViewModel extends ChangeNotifier {
   Future<void> openSearchResult(String relative, int line) async {
     final abs = _absoluteOf(relative);
     if (abs == null) return;
-    await openFile(abs);
-    for (final s in _sessions.values) {
-      if (s is FileViewerSession && s.path == abs) s.reveal(line);
-    }
+    await openFile(abs, revealLine: line);
   }
 
   /// `true` se [path] está **dentro** do workspace [projectId] (ele mesmo ou
@@ -5477,6 +5646,36 @@ class CockpitViewModel extends ChangeNotifier {
     }
 
     switch (desc['type']) {
+      case 'neovim':
+        if (!_neovimEnabled || project.isRemoteTerminal) return false;
+        if (_sessions.values.whereType<NeovimSession>().any(
+          (session) => session.projectId == project.id,
+        )) {
+          return false;
+        }
+        final path = desc['path'] as String?;
+        if (path == null || path.isEmpty) return false;
+        final executable = await _neovim.executable();
+        if (executable == null) return false;
+        final address = _neovim.serverAddress(project.id);
+        await _neovim.prepareServer(address);
+        _sessions[id] = NeovimSession(
+          id: id,
+          projectId: project.id,
+          workingDirectory: project.path,
+          terminalGateway: _gatewayForProject(project.id),
+          neovimGateway: _neovim,
+          executable: executable,
+          serverAddress: address,
+          lastPath: path,
+          lastLine: desc['line'] as int?,
+          engine: _enumByName(
+            TerminalEngine.values,
+            desc['engine'],
+            _defaultTerminalEngine,
+          ),
+        );
+        return true;
       case 'terminal':
         // Carrega o scrollback salvo e o reproduz no terminal restaurado. O
         // `\x1bc` (RIS) prepended limpa qualquer modo residual (alt-screen) em
@@ -5777,8 +5976,12 @@ class CockpitViewModel extends ChangeNotifier {
     final newSessions = <String, dynamic>{};
     for (final entry in sessionsJson.entries) {
       final desc = Map<String, dynamic>.from(entry.value as Map);
-      // worktree não replica viewers nem diffs (efêmeros)
-      if (desc['type'] == 'viewer' || desc['type'] == 'diff') continue;
+      // worktree não replica viewers/diffs nem a instância de editor do pai.
+      if (desc['type'] == 'viewer' ||
+          desc['type'] == 'diff' ||
+          desc['type'] == 'neovim') {
+        continue;
+      }
       // Zera qualquer estado de continuação — o worktree é um workspace novo,
       // sessões começam do zero. `sessionPath` (agente) e `claude_sid`
       // (terminal: dispararia `claude --resume <sid>` do pai) reanexariam a
@@ -5841,6 +6044,14 @@ class CockpitViewModel extends ChangeNotifier {
   }
 
   Map<String, dynamic> _sessionToJson(PaneItem s, Project project) {
+    if (s is NeovimSession) {
+      return <String, dynamic>{
+        'type': 'neovim',
+        'path': s.lastPath,
+        if (s.lastLine != null) 'line': s.lastLine,
+        'engine': s.terminal.engine.name,
+      };
+    }
     if (s is TerminalSession) {
       return <String, dynamic>{
         'type': 'terminal',

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -65,6 +65,7 @@ import 'package:cockpit/app/cockpit/domain/entities/session_info.dart';
 import 'package:cockpit/app/cockpit/domain/entities/thinking_level.dart';
 import 'package:cockpit/app/cockpit/domain/entities/worktree.dart';
 import 'package:cockpit/app/cockpit/domain/services/worktree_reconciler.dart';
+import 'package:cockpit/app/cockpit/domain/services/file_editor_facade.dart';
 import 'package:cockpit/app/cockpit/ui/session/scm_line_decoration_coordinator.dart';
 import 'package:cockpit/app/core/data/lsp/lsp_server_pool.dart';
 import 'package:cockpit/app/core/data/lsp/lsp_text_edit.dart';
@@ -161,6 +162,12 @@ class CockpitViewModel extends ChangeNotifier {
     this.notifications,
     this._neovim,
   ) {
+    _fileEditorFacade = FileEditorFacade(
+      FileEditorRegistry({
+        FileEditorEngine.cockpit: _openWithCockpitEditor,
+        FileEditorEngine.neovim: _openWithNeovimEditor,
+      }),
+    );
     _worktreeReconciler = WorktreeReconciler(_worktreeMgr);
     // Contexto do shell que o GitController precisa (page-scoped, mesma vida).
     git
@@ -535,9 +542,10 @@ class CockpitViewModel extends ChangeNotifier {
     _taskTerminals.setDefaultEngine(engine);
   }
 
-  bool _neovimEnabled = false;
+  late final FileEditorFacade _fileEditorFacade;
 
-  void setNeovimEnabled(bool value) => _neovimEnabled = value;
+  void setFileEditorEngine(FileEditorEngine engine) =>
+      _fileEditorFacade.engine = engine;
 
   /// Perfis descobertos, para o seletor ao lado do `+`. Já aquecidos no boot.
   List<TerminalProfile> get terminalProfiles =>
@@ -1107,7 +1115,15 @@ class CockpitViewModel extends ChangeNotifier {
   /// resultante — enfiar o modo nos quatro caminhos de abertura (já aberta,
   /// remota, preview reusado, aba nova) espalharia a decisão por todos eles.
   Future<void> openFileAsSource(String path) async {
-    await openFile(path, isPreview: false);
+    final result = await _dispatchFileOpen(
+      path,
+      isPreview: false,
+      asSource: true,
+    );
+    if (result?.engine != FileEditorEngine.cockpit ||
+        result?.outcome != FileOpenOutcome.opened) {
+      return;
+    }
     for (final s in _sessions.values) {
       if (s is FileViewerSession && s.path == path && !s.rawSource) {
         s.toggleRawSource();
@@ -1121,31 +1137,74 @@ class CockpitViewModel extends ChangeNotifier {
     bool isPreview = true,
     int? revealLine,
   }) async {
-    // Pasta `.notebook` é um documento (caderno), não uma pasta a expandir.
-    if (isNotebookFolder(path.split('/').last)) {
-      openNotebook(path);
-      return;
-    }
+    await _dispatchFileOpen(
+      path,
+      inPane: inPane,
+      isPreview: isPreview,
+      revealLine: revealLine,
+    );
+  }
+
+  Future<FileOpenResult?> _dispatchFileOpen(
+    String path, {
+    String? inPane,
+    bool isPreview = true,
+    int? revealLine,
+    bool asSource = false,
+  }) async {
     final projectId = _selectedProjectId;
     final tree = _activeTree;
     final paneId = inPane ?? (projectId == null ? null : _focused[projectId]);
-    if (projectId == null || tree == null || paneId == null) return;
-    if (_shouldOpenInNeovim(projectId, path)) {
-      final opened = await _enqueueNeovimOpen(
-        projectId,
-        paneId,
-        path,
-        line: revealLine,
-      );
-      if (opened) return;
-      // Executável ausente/falha de spawn: mantém o usuário produtivo usando o
-      // fluxo integrado já existente. A UI recebe o erro tipado via callback.
+    if (projectId == null || tree == null || paneId == null) return null;
+    return _fileEditorFacade.open(
+      FileOpenRequest(
+        path: path,
+        projectId: projectId,
+        paneId: paneId,
+        isRemote: _isRemoteWorkspace(projectId),
+        isPreview: isPreview,
+        revealLine: revealLine,
+        asSource: asSource,
+        isNotebook: isNotebookFolder(path.split('/').last),
+        focusPane: inPane != null,
+      ),
+    );
+  }
+
+  Future<FileOpenOutcome> _openWithCockpitEditor(
+    FileOpenRequest request,
+  ) async {
+    if (request.isNotebook) {
+      openNotebook(request.path);
+      return FileOpenOutcome.opened;
     }
+    await _openFileInCockpit(request);
+    return FileOpenOutcome.opened;
+  }
+
+  Future<FileOpenOutcome> _openWithNeovimEditor(FileOpenRequest request) async {
+    final opened = await _enqueueNeovimOpen(
+      request.projectId,
+      request.paneId,
+      request.path,
+      line: request.revealLine,
+    );
+    return opened ? FileOpenOutcome.opened : FileOpenOutcome.notHandled;
+  }
+
+  Future<void> _openFileInCockpit(FileOpenRequest request) async {
+    final path = request.path;
+    final projectId = request.projectId;
+    final tree = _trees[projectId];
+    final paneId = request.paneId;
+    final isPreview = request.isPreview;
+    final revealLine = request.revealLine;
+    if (tree == null) return;
     final leaf = findLeaf(tree, paneId);
     if (leaf == null) return;
     _recordHistoryBeforeSwitch(paneId);
     // Soltar um arquivo numa pane específica também a foca.
-    if (inPane != null) _focused[projectId] = inPane;
+    if (request.focusPane) _focused[projectId] = paneId;
 
     // Se isPreview, tenta reutilizar a aba de preview existente ou substituir a ativa.
     // Se não é preview, cria uma aba normal (comportamento original).
@@ -1231,23 +1290,6 @@ class CockpitViewModel extends ChangeNotifier {
     _sessions[viewer.id] = viewer;
     _watchFileViewer(viewer);
     _placeNewViewer(viewer, projectId, paneId, tree, isPreview: isPreview);
-  }
-
-  static const Set<String> _neovimInternalExtensions = {
-    // Editores com runner próprio.
-    'http', 'dbq',
-    // Visualizações de mídia do Cockpit.
-    'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svg',
-    'mp4', 'mov', 'avi', 'mkv', 'webm', 'm4v', 'wmv', 'flv',
-    'mp3', 'wav', 'aac', 'm4a', 'flac', 'ogg', 'opus',
-  };
-
-  bool _shouldOpenInNeovim(String projectId, String path) {
-    if (!_neovimEnabled || _isRemoteWorkspace(projectId)) return false;
-    final name = path.split('/').last;
-    final dot = name.lastIndexOf('.');
-    final ext = dot <= 0 ? '' : name.substring(dot + 1).toLowerCase();
-    return !_neovimInternalExtensions.contains(ext);
   }
 
   Future<bool> _enqueueNeovimOpen(
@@ -5645,18 +5687,47 @@ class CockpitViewModel extends ChangeNotifier {
       return sub.isEmpty ? project.path : '${project.path}/$sub';
     }
 
+    Future<bool> restoreCockpitViewer(String path) async {
+      final view = await _readFile(path);
+      if (view is FileViewUnsupported) return false;
+      final viewer = FileViewerSession(
+        id: id,
+        projectId: project.id,
+        path: path,
+        view: view,
+      );
+      viewer.boardAsList = desc['boardAsList'] as bool? ?? false;
+      viewer.rawSource = desc['rawSource'] as bool? ?? false;
+      viewer.restoreManualLabel(desc['label'] as String?);
+      _applyKanbanBoardTitle(viewer);
+      _ensureScmCoordinator(viewer);
+      _sessions[id] = viewer;
+      _watchFileViewer(viewer);
+      return true;
+    }
+
     switch (desc['type']) {
+      case 'file_engine':
       case 'neovim':
-        if (!_neovimEnabled || project.isRemoteTerminal) return false;
+        final path = desc['path'] as String?;
+        if (path == null || path.isEmpty) return false;
+        final fileEngine = desc['type'] == 'neovim'
+            ? FileEditorEngine.neovim
+            : _enumByName(
+                FileEditorEngine.values,
+                desc['fileEngine'],
+                FileEditorEngine.cockpit,
+              );
+        if (fileEngine != FileEditorEngine.neovim || project.isRemoteTerminal) {
+          return restoreCockpitViewer(path);
+        }
         if (_sessions.values.whereType<NeovimSession>().any(
           (session) => session.projectId == project.id,
         )) {
-          return false;
+          return restoreCockpitViewer(path);
         }
-        final path = desc['path'] as String?;
-        if (path == null || path.isEmpty) return false;
         final executable = await _neovim.executable();
-        if (executable == null) return false;
+        if (executable == null) return restoreCockpitViewer(path);
         final address = _neovim.serverAddress(project.id);
         await _neovim.prepareServer(address);
         _sessions[id] = NeovimSession(
@@ -5671,7 +5742,7 @@ class CockpitViewModel extends ChangeNotifier {
           lastLine: desc['line'] as int?,
           engine: _enumByName(
             TerminalEngine.values,
-            desc['engine'],
+            desc['type'] == 'neovim' ? desc['engine'] : desc['terminalEngine'],
             _defaultTerminalEngine,
           ),
         );
@@ -5725,30 +5796,7 @@ class CockpitViewModel extends ChangeNotifier {
       case 'viewer':
         final path = desc['path'] as String?;
         if (path == null) return false;
-        // `_readFile` roteia pro host quando o workspace ativo é remoto (o
-        // restore no boot roda só pro projeto selecionado); local usa o
-        // `_fileReader`. Sem isto, aba de arquivo de workspace remoto tentava
-        // ler no disco do cliente e caía fora (não restaurava).
-        final view = await _readFile(path);
-        if (view is FileViewUnsupported) return false;
-        final viewer = FileViewerSession(
-          id: id,
-          projectId: project.id,
-          path: path,
-          view: view,
-        );
-        viewer.boardAsList = desc['boardAsList'] as bool? ?? false;
-        viewer.rawSource = desc['rawSource'] as bool? ?? false;
-        // Rótulo salvo primeiro, frontmatter depois: num `.kanban` o `title:`
-        // do arquivo é a fonte de verdade e sobrescreve o que veio do layout.
-        viewer.restoreManualLabel(desc['label'] as String?);
-        _applyKanbanBoardTitle(viewer);
-        // Same pipeline as openFile: SCM coordinator + live-reload.
-        // Without this, restored tabs have no diff gutter until reopen.
-        _ensureScmCoordinator(viewer);
-        _sessions[id] = viewer;
-        _watchFileViewer(viewer);
-        return true;
+        return restoreCockpitViewer(path);
       case 'diff':
         final path = desc['path'] as String?;
         if (path == null) return false;
@@ -5979,7 +6027,8 @@ class CockpitViewModel extends ChangeNotifier {
       // worktree não replica viewers/diffs nem a instância de editor do pai.
       if (desc['type'] == 'viewer' ||
           desc['type'] == 'diff' ||
-          desc['type'] == 'neovim') {
+          desc['type'] == 'neovim' ||
+          desc['type'] == 'file_engine') {
         continue;
       }
       // Zera qualquer estado de continuação — o worktree é um workspace novo,
@@ -6046,10 +6095,11 @@ class CockpitViewModel extends ChangeNotifier {
   Map<String, dynamic> _sessionToJson(PaneItem s, Project project) {
     if (s is NeovimSession) {
       return <String, dynamic>{
-        'type': 'neovim',
+        'type': 'file_engine',
+        'fileEngine': FileEditorEngine.neovim.name,
         'path': s.lastPath,
         if (s.lastLine != null) 'line': s.lastLine,
-        'engine': s.terminal.engine.name,
+        'terminalEngine': s.terminal.engine.name,
       };
     }
     if (s is TerminalSession) {

--- a/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
@@ -7,6 +7,7 @@ import 'package:cockpit/app/cockpit/ui/session/agent_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/browser_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/diff_viewer_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/file_viewer_session.dart';
+import 'package:cockpit/app/cockpit/ui/session/neovim_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
 import 'package:cockpit/app/cockpit/ui/session/mongo_browser_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/notebook_session.dart';
@@ -175,6 +176,7 @@ const double _kTabWidth = 188;
 
 /// Ícone por tipo de aba (usado na aba e no dropdown "todas as abas").
 IconData _tabIcon(PaneItem? item) {
+  if (item is NeovimSession) return Icons.edit_note_outlined;
   if (item is TerminalSession) return Icons.terminal_outlined;
   if (item is TaskOutputSession) return Icons.play_circle_outline;
   if (item is FileViewerSession) return Icons.description_outlined;

--- a/cockpit/lib/app/core/core_module.dart
+++ b/cockpit/lib/app/core/core_module.dart
@@ -1,12 +1,14 @@
 import 'package:cockpit/app/core/data/automation/cli_automation_gateway.dart';
 import 'package:cockpit/app/core/data/lsp/lsp_client_impl.dart';
 import 'package:cockpit/app/core/data/lsp/lsp_server_pool.dart';
+import 'package:cockpit/app/core/data/neovim/neovim_gateway_impl.dart';
 import 'package:cockpit/app/core/data/relay/pairing_gateway_impl.dart';
 import 'package:cockpit/app/core/data/relay/revoke_gateway_impl.dart';
 import 'package:cockpit/app/core/data/setup/environment_probe_impl.dart';
 import 'package:cockpit/app/core/data/setup/system_permissions_impl.dart';
 import 'package:cockpit/app/core/domain/contracts/environment_probe.dart';
 import 'package:cockpit/app/core/domain/contracts/lsp_client.dart';
+import 'package:cockpit/app/core/domain/contracts/neovim_gateway.dart';
 import 'package:cockpit/app/core/domain/contracts/pairing_gateway.dart';
 import 'package:cockpit/app/core/domain/contracts/revoke_gateway.dart';
 import 'package:cockpit/app/core/domain/contracts/system_permissions.dart';
@@ -61,6 +63,7 @@ Module buildCoreModule({
       ..addInstance<TerminalProfileResolver>(terminalProfiles)
       ..addInstance<LspClientFactory>(lspFactory)
       ..addInstance<AutomationController>(automation)
+      ..addLazySingleton<NeovimGateway>(NeovimGatewayImpl.new)
       ..addLazySingleton<LspServerPool>(LspServerPool.new)
       ..add<PairingGatewayFactory>(PairingGatewayFactoryImpl.new)
       ..add<RevokeGatewayFactory>(RevokeGatewayFactoryImpl.new)

--- a/cockpit/lib/app/core/data/neovim/neovim_gateway_impl.dart
+++ b/cockpit/lib/app/core/data/neovim/neovim_gateway_impl.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:cockpit/app/core/domain/contracts/neovim_gateway.dart';
+import 'package:cockpit/app/core/domain/exceptions/neovim_error.dart';
+import 'package:cockpit/app/core/domain/result.dart';
+import 'package:cockpit/app/core/utils/executable_resolver.dart';
+
+class NeovimGatewayImpl implements NeovimGateway {
+  String? _cachedExecutable;
+  bool _didProbe = false;
+
+  static const Duration _timeout = Duration(seconds: 3);
+
+  @override
+  Future<String?> executable({bool refresh = false}) async {
+    if (_didProbe && !refresh) return _cachedExecutable;
+    _didProbe = true;
+    final resolved = await resolveExecutable(
+      'nvim',
+      unixCandidates: const [
+        '/opt/homebrew/bin/nvim',
+        '/usr/local/bin/nvim',
+        '/usr/bin/nvim',
+      ],
+    );
+    _cachedExecutable = await isExecutableAvailable(resolved) ? resolved : null;
+    return _cachedExecutable;
+  }
+
+  @override
+  String serverAddress(String workspaceId) {
+    final token = _fnv1a(workspaceId).toRadixString(16);
+    final name = 'cockpit-nvim-${pid.toRadixString(16)}-$token';
+    return Platform.isWindows ? r'\\.\pipe\' + name : '/tmp/$name.sock';
+  }
+
+  @override
+  Future<void> prepareServer(String address) async {
+    if (Platform.isWindows) return;
+    final socket = File(address);
+    try {
+      if (await socket.exists()) await socket.delete();
+    } on FileSystemException {
+      // O spawn do Neovim produzirá um erro visível se o endereço estiver de
+      // fato ocupado. Limpeza aqui é apenas best-effort para sockets mortos.
+    }
+  }
+
+  @override
+  Future<Result<void, NeovimError>> openRemote(
+    String executable,
+    String address,
+    String path, {
+    int? line,
+  }) async {
+    final opened = await _run(executable, [
+      '--server',
+      address,
+      '--remote',
+      path,
+    ]);
+    if (opened case Failure(:final error)) return Failure(error);
+    if (line == null) return const Success(null);
+
+    // O `+{cmd}` documentado para Vim ainda não é suportado pelo `--remote`
+    // do Neovim: depois de `--remote`, tudo vira nome de arquivo. Posicionamos
+    // o cursor numa segunda chamada RPC, já com o buffer trazido por `:drop`.
+    final revealed = await _run(executable, [
+      '--server',
+      address,
+      '--remote-expr',
+      'cursor($line, 1)',
+    ]);
+    return switch (revealed) {
+      Success() => const Success(null),
+      Failure(:final error) => Failure(error),
+    };
+  }
+
+  @override
+  Future<bool> isAlive(String executable, String address) async {
+    final result = await _run(executable, [
+      '--server',
+      address,
+      '--remote-expr',
+      '1',
+    ]);
+    return result is Success<ProcessResult, NeovimError>;
+  }
+
+  @override
+  Future<Result<bool, NeovimError>> hasModifiedBuffers(
+    String executable,
+    String address,
+  ) async {
+    final result = await _run(executable, [
+      '--server',
+      address,
+      '--remote-expr',
+      "len(filter(getbufinfo(), 'v:val.changed'))",
+    ]);
+    return switch (result) {
+      Success(:final value) => Success(
+        (int.tryParse('${value.stdout}'.trim()) ?? 0) > 0,
+      ),
+      Failure(:final error) => Failure(error),
+    };
+  }
+
+  Future<Result<ProcessResult, NeovimError>> _run(
+    String executable,
+    List<String> args,
+  ) async {
+    try {
+      final result = await Process.run(executable, args).timeout(_timeout);
+      if (result.exitCode == 0) return Success(result);
+      final detail = '${result.stderr}'.trim();
+      return Failure(
+        NeovimError(
+          NeovimErrorKind.connectionFailed,
+          detail: detail.isEmpty ? null : detail,
+        ),
+      );
+    } on TimeoutException {
+      return const Failure(NeovimError(NeovimErrorKind.timeout));
+    } on ProcessException catch (error) {
+      return Failure(
+        NeovimError(NeovimErrorKind.unavailable, detail: error.message),
+      );
+    }
+  }
+
+  /// FNV-1a 64-bit determinístico: evita caminhos longos/ilegais de worktrees.
+  int _fnv1a(String value) {
+    var hash = 0xcbf29ce484222325;
+    for (final byte in value.codeUnits) {
+      hash ^= byte;
+      hash = (hash * 0x100000001b3) & 0x7fffffffffffffff;
+    }
+    return hash;
+  }
+}

--- a/cockpit/lib/app/core/domain/contracts/neovim_gateway.dart
+++ b/cockpit/lib/app/core/domain/contracts/neovim_gateway.dart
@@ -1,0 +1,33 @@
+import '../exceptions/neovim_error.dart';
+import '../result.dart';
+
+/// Descoberta e controle das instâncias Neovim usadas pelo Cockpit.
+abstract class NeovimGateway {
+  /// Caminho absoluto do `nvim`, ou `null` quando não está instalado na PATH do
+  /// shell do usuário. [refresh] invalida o cache (botão das Configurações).
+  Future<String?> executable({bool refresh = false});
+
+  /// Endereço curto e exclusivo desta execução do Cockpit + workspace.
+  String serverAddress(String workspaceId);
+
+  /// Remove um socket POSIX obsoleto antes de iniciar uma nova instância.
+  Future<void> prepareServer(String address);
+
+  /// Abre [path] na instância existente usando `:drop` (`--remote`).
+  Future<Result<void, NeovimError>> openRemote(
+    String executable,
+    String address,
+    String path, {
+    int? line,
+  });
+
+  /// `true` quando o servidor no endereço ainda responde.
+  Future<bool> isAlive(String executable, String address);
+
+  /// Consulta se há algum buffer modificado. Falha significa que o processo já
+  /// não é consultável e, portanto, não há trabalho vivo a proteger na aba.
+  Future<Result<bool, NeovimError>> hasModifiedBuffers(
+    String executable,
+    String address,
+  );
+}

--- a/cockpit/lib/app/core/domain/entities/app_settings.dart
+++ b/cockpit/lib/app/core/domain/entities/app_settings.dart
@@ -41,6 +41,7 @@ class AppSettings {
     this.lspCommands = const <String, String>{},
     this.lspFormatters = const <String, String>{},
     this.formatOnSave = false,
+    this.neovimEnabled = false,
     this.notificationsEnabled = true,
     this.soundEvents = const <SoundEvent, bool>{},
     this.soundOverrides = const <SoundEvent, String>{},
@@ -116,6 +117,10 @@ class AppSettings {
 
   /// Formatar automaticamente ao salvar (Cmd+S).
   final bool formatOnSave;
+
+  /// Abre arquivos comuns numa instância Neovim por workspace/worktree.
+  /// Desligado por padrão; visualizações especializadas continuam internas.
+  final bool neovimEnabled;
 
   /// Disparar notificações do SO quando um agente termina um turno com a janela
   /// fora de foco. Editado na aba "Notifications" das Configurações.
@@ -251,6 +256,7 @@ class AppSettings {
     Map<String, String>? lspCommands,
     Map<String, String>? lspFormatters,
     bool? formatOnSave,
+    bool? neovimEnabled,
     bool? notificationsEnabled,
     Map<SoundEvent, bool>? soundEvents,
     Map<SoundEvent, String>? soundOverrides,
@@ -299,6 +305,7 @@ class AppSettings {
       lspCommands: lspCommands ?? this.lspCommands,
       lspFormatters: lspFormatters ?? this.lspFormatters,
       formatOnSave: formatOnSave ?? this.formatOnSave,
+      neovimEnabled: neovimEnabled ?? this.neovimEnabled,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
       soundEvents: soundEvents ?? this.soundEvents,
       soundOverrides: soundOverrides ?? this.soundOverrides,
@@ -347,6 +354,7 @@ class AppSettings {
     if (lspCommands.isNotEmpty) 'lspCommands': lspCommands,
     if (lspFormatters.isNotEmpty) 'lspFormatters': lspFormatters,
     if (formatOnSave) 'formatOnSave': true,
+    if (neovimEnabled) 'editor.neovim.enabled': true,
     if (!notificationsEnabled) 'notificationsEnabled': false,
     if (soundEvents.isNotEmpty)
       'sound.events': <String, bool>{
@@ -429,6 +437,7 @@ class AppSettings {
       lspCommands: _strMap(json['lspCommands']),
       lspFormatters: _strMap(json['lspFormatters']),
       formatOnSave: json['formatOnSave'] as bool? ?? false,
+      neovimEnabled: json['editor.neovim.enabled'] as bool? ?? false,
       notificationsEnabled: json['notificationsEnabled'] as bool? ?? true,
       soundEvents: _migrateSoundEvents(json),
       soundOverrides: _soundEventMap<String>(json['sound.overrides']),

--- a/cockpit/lib/app/core/domain/entities/app_settings.dart
+++ b/cockpit/lib/app/core/domain/entities/app_settings.dart
@@ -8,6 +8,9 @@ enum AppThemeMode { system, light, dark }
 /// Motor VT usado por terminais criados daqui pra frente.
 enum TerminalEngine { ghostty, xterm }
 
+/// Motor usado para abrir arquivos de texto editáveis.
+enum FileEditorEngine { cockpit, neovim }
+
 /// Peso do traço da fonte do terminal.
 ///
 /// Existe porque a **mesma** fonte, no mesmo tamanho, tem peso aparente
@@ -41,7 +44,7 @@ class AppSettings {
     this.lspCommands = const <String, String>{},
     this.lspFormatters = const <String, String>{},
     this.formatOnSave = false,
-    this.neovimEnabled = false,
+    this.fileEditorEngine = FileEditorEngine.cockpit,
     this.notificationsEnabled = true,
     this.soundEvents = const <SoundEvent, bool>{},
     this.soundOverrides = const <SoundEvent, String>{},
@@ -118,9 +121,9 @@ class AppSettings {
   /// Formatar automaticamente ao salvar (Cmd+S).
   final bool formatOnSave;
 
-  /// Abre arquivos comuns numa instância Neovim por workspace/worktree.
-  /// Desligado por padrão; visualizações especializadas continuam internas.
-  final bool neovimEnabled;
+  /// Motor global de arquivos comuns. Visualizações especializadas e arquivos
+  /// remotos continuam no Cockpit, independentemente desta preferência.
+  final FileEditorEngine fileEditorEngine;
 
   /// Disparar notificações do SO quando um agente termina um turno com a janela
   /// fora de foco. Editado na aba "Notifications" das Configurações.
@@ -256,7 +259,7 @@ class AppSettings {
     Map<String, String>? lspCommands,
     Map<String, String>? lspFormatters,
     bool? formatOnSave,
-    bool? neovimEnabled,
+    FileEditorEngine? fileEditorEngine,
     bool? notificationsEnabled,
     Map<SoundEvent, bool>? soundEvents,
     Map<SoundEvent, String>? soundOverrides,
@@ -305,7 +308,7 @@ class AppSettings {
       lspCommands: lspCommands ?? this.lspCommands,
       lspFormatters: lspFormatters ?? this.lspFormatters,
       formatOnSave: formatOnSave ?? this.formatOnSave,
-      neovimEnabled: neovimEnabled ?? this.neovimEnabled,
+      fileEditorEngine: fileEditorEngine ?? this.fileEditorEngine,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
       soundEvents: soundEvents ?? this.soundEvents,
       soundOverrides: soundOverrides ?? this.soundOverrides,
@@ -354,7 +357,7 @@ class AppSettings {
     if (lspCommands.isNotEmpty) 'lspCommands': lspCommands,
     if (lspFormatters.isNotEmpty) 'lspFormatters': lspFormatters,
     if (formatOnSave) 'formatOnSave': true,
-    if (neovimEnabled) 'editor.neovim.enabled': true,
+    'editor.engine': fileEditorEngine.name,
     if (!notificationsEnabled) 'notificationsEnabled': false,
     if (soundEvents.isNotEmpty)
       'sound.events': <String, bool>{
@@ -437,7 +440,13 @@ class AppSettings {
       lspCommands: _strMap(json['lspCommands']),
       lspFormatters: _strMap(json['lspFormatters']),
       formatOnSave: json['formatOnSave'] as bool? ?? false,
-      neovimEnabled: json['editor.neovim.enabled'] as bool? ?? false,
+      fileEditorEngine: _enumByName(
+        FileEditorEngine.values,
+        json['editor.engine'],
+        json['editor.neovim.enabled'] == true
+            ? FileEditorEngine.neovim
+            : FileEditorEngine.cockpit,
+      ),
       notificationsEnabled: json['notificationsEnabled'] as bool? ?? true,
       soundEvents: _migrateSoundEvents(json),
       soundOverrides: _soundEventMap<String>(json['sound.overrides']),

--- a/cockpit/lib/app/core/domain/exceptions/neovim_error.dart
+++ b/cockpit/lib/app/core/domain/exceptions/neovim_error.dart
@@ -1,0 +1,11 @@
+enum NeovimErrorKind { unavailable, connectionFailed, timeout }
+
+/// Falha estruturada ao detectar ou controlar uma instância do Neovim.
+///
+/// [detail] é saída crua do processo e só deve ser interpolada pela UI.
+class NeovimError implements Exception {
+  const NeovimError(this.kind, {this.detail});
+
+  final NeovimErrorKind kind;
+  final String? detail;
+}

--- a/cockpit/lib/app/core/ui/settings_controller.dart
+++ b/cockpit/lib/app/core/ui/settings_controller.dart
@@ -213,6 +213,9 @@ class SettingsController extends ChangeNotifier {
   void setFormatOnSave(bool value) =>
       _apply(_settings.copyWith(formatOnSave: value));
 
+  void setNeovimEnabled(bool value) =>
+      _apply(_settings.copyWith(neovimEnabled: value));
+
   void setNotificationsEnabled(bool value) =>
       _apply(_settings.copyWith(notificationsEnabled: value));
 

--- a/cockpit/lib/app/core/ui/settings_controller.dart
+++ b/cockpit/lib/app/core/ui/settings_controller.dart
@@ -213,8 +213,8 @@ class SettingsController extends ChangeNotifier {
   void setFormatOnSave(bool value) =>
       _apply(_settings.copyWith(formatOnSave: value));
 
-  void setNeovimEnabled(bool value) =>
-      _apply(_settings.copyWith(neovimEnabled: value));
+  void setFileEditorEngine(FileEditorEngine engine) =>
+      _apply(_settings.copyWith(fileEditorEngine: engine));
 
   void setNotificationsEnabled(bool value) =>
       _apply(_settings.copyWith(notificationsEnabled: value));

--- a/cockpit/lib/app/settings/domain/editor_appearance_policy.dart
+++ b/cockpit/lib/app/settings/domain/editor_appearance_policy.dart
@@ -1,0 +1,12 @@
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+
+/// Visibilidade das opções que controlam o editor integrado. O tamanho de
+/// código continua exposto quando ainda é a fonte do tamanho do terminal.
+abstract final class EditorAppearancePolicy {
+  static bool showCodeFont(AppSettings settings) =>
+      settings.fileEditorEngine == FileEditorEngine.cockpit;
+
+  static bool showCodeSize(AppSettings settings) =>
+      settings.fileEditorEngine == FileEditorEngine.cockpit ||
+      settings.terminalSize == null;
+}

--- a/cockpit/lib/app/settings/settings_module.dart
+++ b/cockpit/lib/app/settings/settings_module.dart
@@ -8,6 +8,7 @@ import 'package:cockpit/app/settings/ui/connectivity_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/cron_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/daemons_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/notifications_viewmodel.dart';
+import 'package:cockpit/app/settings/ui/neovim_settings_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/settings_env_gate.dart';
 import 'package:cockpit/app/settings/ui/settings_page.dart';
 import 'package:cockpit/app/core/routes.dart';
@@ -56,6 +57,9 @@ Module buildSettingsModule() => createModule(
           ..addChangeNotifier<SettingsEnvGate>(SettingsEnvGate.new)
           ..addChangeNotifier<NotificationsViewModel>(
             NotificationsViewModel.new,
+          )
+          ..addChangeNotifier<NeovimSettingsViewModel>(
+            NeovimSettingsViewModel.new,
           ),
         child: (context, state) => SettingsPage(
           initialTab: state.arguments is SettingsTab

--- a/cockpit/lib/app/settings/ui/neovim_settings_viewmodel.dart
+++ b/cockpit/lib/app/settings/ui/neovim_settings_viewmodel.dart
@@ -1,0 +1,24 @@
+import 'package:cockpit/app/core/domain/contracts/neovim_gateway.dart';
+import 'package:flutter/foundation.dart';
+
+class NeovimSettingsViewModel extends ChangeNotifier {
+  NeovimSettingsViewModel(this._gateway);
+
+  final NeovimGateway _gateway;
+
+  bool _checking = false;
+  bool get checking => _checking;
+
+  String? _executable;
+  String? get executable => _executable;
+  bool get available => _executable != null;
+
+  Future<void> check({bool refresh = false}) async {
+    if (_checking) return;
+    _checking = true;
+    notifyListeners();
+    _executable = await _gateway.executable(refresh: refresh);
+    _checking = false;
+    notifyListeners();
+  }
+}

--- a/cockpit/lib/app/settings/ui/settings_page.dart
+++ b/cockpit/lib/app/settings/ui/settings_page.dart
@@ -39,6 +39,7 @@ import 'package:cockpit/app/settings/ui/connectivity_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/cron_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/daemons_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/notifications_viewmodel.dart';
+import 'package:cockpit/app/settings/ui/neovim_settings_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/pairing_dialog.dart';
 import 'package:cockpit/app/settings/ui/revoke_dialog.dart';
 import 'package:cockpit/app/settings/ui/settings_env_gate.dart';
@@ -123,7 +124,9 @@ class _SettingsPageState extends State<SettingsPage> {
     }
     // Sonda o ambiente para decidir se as abas remotas aparecem.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) context.read<SettingsEnvGate>().check();
+      if (!mounted) return;
+      context.read<SettingsEnvGate>().check();
+      context.read<NeovimSettingsViewModel>().check();
     });
   }
 
@@ -466,6 +469,7 @@ class _GeneralPanel extends StatelessWidget {
     final s = controller.settings;
     // `agentTabsInUse` é publicado pelo shell (cross-route) via bridge app-scoped.
     final agentsInUse = context.watch<WorkspaceMenuBridge>().agentTabsInUse;
+    final neovim = context.watch<NeovimSettingsViewModel>();
     final tr = context.t.settings.page.general;
 
     return SingleChildScrollView(
@@ -521,6 +525,42 @@ class _GeneralPanel extends StatelessWidget {
                         trailing: Switch(
                           value: s.launchAtStartup,
                           onChanged: controller.setLaunchAtStartup,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                _Section(
+                  label: tr.sectionEditor,
+                  child: _Card(
+                    children: [
+                      _Row(
+                        title: tr.neovimTitle,
+                        description: neovim.checking
+                            ? tr.neovimChecking
+                            : neovim.executable ?? tr.neovimNotFound,
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            AppTooltip(
+                              message: tr.neovimRefresh,
+                              child: IconButton.outline(
+                                onPressed: neovim.checking
+                                    ? null
+                                    : () => neovim.check(refresh: true),
+                                icon: neovim.checking
+                                    ? const CircularProgressIndicator(size: 14)
+                                    : const Icon(Icons.refresh, size: 16),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Switch(
+                              value: s.neovimEnabled,
+                              onChanged: neovim.available || s.neovimEnabled
+                                  ? controller.setNeovimEnabled
+                                  : null,
+                            ),
+                          ],
                         ),
                       ),
                     ],

--- a/cockpit/lib/app/settings/ui/settings_page.dart
+++ b/cockpit/lib/app/settings/ui/settings_page.dart
@@ -40,6 +40,7 @@ import 'package:cockpit/app/settings/ui/cron_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/daemons_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/notifications_viewmodel.dart';
 import 'package:cockpit/app/settings/ui/neovim_settings_viewmodel.dart';
+import 'package:cockpit/app/settings/domain/editor_appearance_policy.dart';
 import 'package:cockpit/app/settings/ui/pairing_dialog.dart';
 import 'package:cockpit/app/settings/ui/revoke_dialog.dart';
 import 'package:cockpit/app/settings/ui/settings_env_gate.dart';
@@ -535,7 +536,7 @@ class _GeneralPanel extends StatelessWidget {
                   child: _Card(
                     children: [
                       _Row(
-                        title: tr.neovimTitle,
+                        title: tr.editorEngineTitle,
                         description: neovim.checking
                             ? tr.neovimChecking
                             : neovim.executable ?? tr.neovimNotFound,
@@ -554,11 +555,10 @@ class _GeneralPanel extends StatelessWidget {
                               ),
                             ),
                             const SizedBox(width: 8),
-                            Switch(
-                              value: s.neovimEnabled,
-                              onChanged: neovim.available || s.neovimEnabled
-                                  ? controller.setNeovimEnabled
-                                  : null,
+                            _FileEditorEngineDropdown(
+                              value: s.fileEditorEngine,
+                              neovimAvailable: neovim.available,
+                              onChanged: controller.setFileEditorEngine,
                             ),
                           ],
                         ),
@@ -1296,6 +1296,48 @@ class _TerminalEngineDropdown extends StatelessWidget {
   }
 }
 
+class _FileEditorEngineDropdown extends StatelessWidget {
+  const _FileEditorEngineDropdown({
+    required this.value,
+    required this.neovimAvailable,
+    required this.onChanged,
+  });
+
+  final FileEditorEngine value;
+  final bool neovimAvailable;
+  final ValueChanged<FileEditorEngine> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final tr = context.t.settings.page.general;
+    String label(FileEditorEngine engine) => switch (engine) {
+      FileEditorEngine.cockpit => tr.editorEngineCockpit,
+      FileEditorEngine.neovim => tr.editorEngineNeovim,
+    };
+
+    return _DropdownChip(
+      icon: Icons.code,
+      label: label(value),
+      onTap: () async {
+        final picked = await showAppMenu<FileEditorEngine>(
+          context,
+          minWidth: 210,
+          items: [
+            for (final engine in FileEditorEngine.values)
+              AppMenuItem(
+                value: engine,
+                label: label(engine),
+                selected: engine == value,
+                enabled: engine != FileEditorEngine.neovim || neovimAvailable,
+              ),
+          ],
+        );
+        if (picked != null) onChanged(picked);
+      },
+    );
+  }
+}
+
 class _TerminalWeightDropdown extends StatelessWidget {
   const _TerminalWeightDropdown({required this.value, required this.onChanged});
 
@@ -1484,25 +1526,27 @@ class _AppearancePanel extends StatelessWidget {
                         onChanged: controller.setInterfaceSize,
                       ),
                     ),
-                    _Row(
-                      title: tr.codeFontTitle,
-                      description: tr.codeFontDesc,
-                      trailing: _FontField(
-                        value: s.codeFont,
-                        hint: 'JetBrains Mono',
-                        monospacedOnly: true,
-                        onChanged: controller.setCodeFont,
+                    if (EditorAppearancePolicy.showCodeFont(s))
+                      _Row(
+                        title: tr.codeFontTitle,
+                        description: tr.codeFontDesc,
+                        trailing: _FontField(
+                          value: s.codeFont,
+                          hint: 'JetBrains Mono',
+                          monospacedOnly: true,
+                          onChanged: controller.setCodeFont,
+                        ),
                       ),
-                    ),
-                    _Row(
-                      title: tr.codeSizeTitle,
-                      trailing: _SizeStepper(
-                        value: s.codeSize,
-                        min: 9,
-                        max: 20,
-                        onChanged: controller.setCodeSize,
+                    if (EditorAppearancePolicy.showCodeSize(s))
+                      _Row(
+                        title: tr.codeSizeTitle,
+                        trailing: _SizeStepper(
+                          value: s.codeSize,
+                          min: 9,
+                          max: 20,
+                          onChanged: controller.setCodeSize,
+                        ),
                       ),
-                    ),
                     _Row(
                       title: tr.terminalFontTitle,
                       description: tr.terminalFontDesc,

--- a/cockpit/lib/i18n/en.i18n.json
+++ b/cockpit/lib/i18n/en.i18n.json
@@ -895,7 +895,9 @@
       "general": {
         "sectionAgent": "Agent",
         "sectionEditor": "Editor",
-        "neovimTitle": "Open files in Neovim",
+      "editorEngineTitle": "Engine",
+      "editorEngineCockpit": "Cockpit (default)",
+      "editorEngineNeovim": "Neovim",
         "neovimChecking": "Looking for Neovim…",
         "neovimNotFound": "Neovim was not found in your shell PATH.",
         "neovimRefresh": "Check again",

--- a/cockpit/lib/i18n/en.i18n.json
+++ b/cockpit/lib/i18n/en.i18n.json
@@ -102,6 +102,13 @@
       "dontSave": "Don't save",
       "saveAndClose": "Save & close"
     },
+    "neovim": {
+      "unavailable": "Neovim is not available. Opening in Cockpit instead.",
+      "openFailed": "Could not reach Neovim. Opening in Cockpit instead.",
+      "unsavedTitle": "Unsaved Neovim buffers",
+      "unsavedMessage": "Neovim has modified buffers. Close the tab and discard those changes?",
+      "closeAnyway": "Close anyway"
+    },
     "historyDialog": {
       "title": "Session history",
       "subtitle": "Opening one replaces this agent's current transcript",
@@ -887,6 +894,11 @@
       },
       "general": {
         "sectionAgent": "Agent",
+        "sectionEditor": "Editor",
+        "neovimTitle": "Open files in Neovim",
+        "neovimChecking": "Looking for Neovim…",
+        "neovimNotFound": "Neovim was not found in your shell PATH.",
+        "neovimRefresh": "Check again",
         "enableAgentsTitle": "Enable agents",
         "enableAgentsDesc": "Show the option to open agent tabs (pi). When off, Cockpit works as a terminal-only workspace.",
         "showCockpitTitle": "Show Cockpit terminal",

--- a/cockpit/lib/i18n/es.i18n.json
+++ b/cockpit/lib/i18n/es.i18n.json
@@ -102,6 +102,13 @@
       "dontSave": "No guardar",
       "saveAndClose": "Guardar y cerrar"
     },
+    "neovim": {
+      "unavailable": "Neovim no está disponible. Abriendo en Cockpit.",
+      "openFailed": "No se pudo acceder a Neovim. Abriendo en Cockpit.",
+      "unsavedTitle": "Búferes de Neovim sin guardar",
+      "unsavedMessage": "Neovim tiene búferes modificados. ¿Cerrar la pestaña y descartar esos cambios?",
+      "closeAnyway": "Cerrar de todos modos"
+    },
     "historyDialog": {
       "title": "Historial de sesiones",
       "subtitle": "Abrir una reemplaza la transcripción actual de este agente",
@@ -887,6 +894,11 @@
       },
       "general": {
         "sectionAgent": "Agente",
+        "sectionEditor": "Editor",
+        "neovimTitle": "Abrir archivos en Neovim",
+        "neovimChecking": "Buscando Neovim…",
+        "neovimNotFound": "Neovim no se encontró en la PATH de tu shell.",
+        "neovimRefresh": "Comprobar de nuevo",
         "enableAgentsTitle": "Activar agentes",
         "enableAgentsDesc": "Muestra la opción de abrir pestañas de agente (pi). Cuando está desactivado, Cockpit funciona solo como workspace de terminal.",
         "showCockpitTitle": "Mostrar terminal de Cockpit",

--- a/cockpit/lib/i18n/es.i18n.json
+++ b/cockpit/lib/i18n/es.i18n.json
@@ -895,7 +895,9 @@
       "general": {
         "sectionAgent": "Agente",
         "sectionEditor": "Editor",
-        "neovimTitle": "Abrir archivos en Neovim",
+      "editorEngineTitle": "Motor",
+      "editorEngineCockpit": "Cockpit (predeterminado)",
+      "editorEngineNeovim": "Neovim",
         "neovimChecking": "Buscando Neovim…",
         "neovimNotFound": "Neovim no se encontró en la PATH de tu shell.",
         "neovimRefresh": "Comprobar de nuevo",

--- a/cockpit/lib/i18n/pt_BR.i18n.json
+++ b/cockpit/lib/i18n/pt_BR.i18n.json
@@ -895,7 +895,9 @@
       "general": {
         "sectionAgent": "Agente",
         "sectionEditor": "Editor",
-        "neovimTitle": "Abrir arquivos no Neovim",
+      "editorEngineTitle": "Motor",
+      "editorEngineCockpit": "Cockpit (padrão)",
+      "editorEngineNeovim": "Neovim",
         "neovimChecking": "Procurando o Neovim…",
         "neovimNotFound": "O Neovim não foi encontrado na PATH do seu shell.",
         "neovimRefresh": "Verificar novamente",

--- a/cockpit/lib/i18n/pt_BR.i18n.json
+++ b/cockpit/lib/i18n/pt_BR.i18n.json
@@ -102,6 +102,13 @@
       "dontSave": "Não salvar",
       "saveAndClose": "Salvar e fechar"
     },
+    "neovim": {
+      "unavailable": "O Neovim não está disponível. Abrindo no Cockpit.",
+      "openFailed": "Não foi possível acessar o Neovim. Abrindo no Cockpit.",
+      "unsavedTitle": "Buffers não salvos no Neovim",
+      "unsavedMessage": "O Neovim tem buffers modificados. Fechar a aba e descartar essas alterações?",
+      "closeAnyway": "Fechar mesmo assim"
+    },
     "historyDialog": {
       "title": "Histórico de sessões",
       "subtitle": "Abrir uma substitui a transcrição atual deste agente",
@@ -887,6 +894,11 @@
       },
       "general": {
         "sectionAgent": "Agente",
+        "sectionEditor": "Editor",
+        "neovimTitle": "Abrir arquivos no Neovim",
+        "neovimChecking": "Procurando o Neovim…",
+        "neovimNotFound": "O Neovim não foi encontrado na PATH do seu shell.",
+        "neovimRefresh": "Verificar novamente",
         "enableAgentsTitle": "Ativar agentes",
         "enableAgentsDesc": "Mostra a opção de abrir abas de agente (pi). Quando desligado, o Cockpit funciona apenas como workspace de terminal.",
         "showCockpitTitle": "Mostrar terminal do Cockpit",

--- a/cockpit/lib/i18n/strings.g.dart
+++ b/cockpit/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 3192 (1064 per locale)
+/// Strings: 3228 (1076 per locale)
 ///
-/// Built on 2026-09-10 at 19:11 UTC
+/// Built on 2026-09-10 at 19:20 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/cockpit/lib/i18n/strings_en.g.dart
+++ b/cockpit/lib/i18n/strings_en.g.dart
@@ -152,6 +152,7 @@ class Translations$cockpit$en {
 
 	// Translations
 	late final Translations$cockpit$confirmDialog$en confirmDialog = Translations$cockpit$confirmDialog$en.internal(_root);
+	late final Translations$cockpit$neovim$en neovim = Translations$cockpit$neovim$en.internal(_root);
 	late final Translations$cockpit$historyDialog$en historyDialog = Translations$cockpit$historyDialog$en.internal(_root);
 	late final Translations$cockpit$worktreeCreateDialog$en worktreeCreateDialog = Translations$cockpit$worktreeCreateDialog$en.internal(_root);
 	late final Translations$cockpit$subfolderDialog$en subfolderDialog = Translations$cockpit$subfolderDialog$en.internal(_root);
@@ -482,6 +483,30 @@ class Translations$cockpit$confirmDialog$en {
 
 	/// en: 'Save & close'
 	String get saveAndClose => 'Save & close';
+}
+
+// Path: cockpit.neovim
+class Translations$cockpit$neovim$en {
+	Translations$cockpit$neovim$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Neovim is not available. Opening in Cockpit instead.'
+	String get unavailable => 'Neovim is not available. Opening in Cockpit instead.';
+
+	/// en: 'Could not reach Neovim. Opening in Cockpit instead.'
+	String get openFailed => 'Could not reach Neovim. Opening in Cockpit instead.';
+
+	/// en: 'Unsaved Neovim buffers'
+	String get unsavedTitle => 'Unsaved Neovim buffers';
+
+	/// en: 'Neovim has modified buffers. Close the tab and discard those changes?'
+	String get unsavedMessage => 'Neovim has modified buffers. Close the tab and discard those changes?';
+
+	/// en: 'Close anyway'
+	String get closeAnyway => 'Close anyway';
 }
 
 // Path: cockpit.historyDialog
@@ -3217,6 +3242,21 @@ class Translations$settings$page$general$en {
 	/// en: 'Agent'
 	String get sectionAgent => 'Agent';
 
+	/// en: 'Editor'
+	String get sectionEditor => 'Editor';
+
+	/// en: 'Open files in Neovim'
+	String get neovimTitle => 'Open files in Neovim';
+
+	/// en: 'Looking for Neovim…'
+	String get neovimChecking => 'Looking for Neovim…';
+
+	/// en: 'Neovim was not found in your shell PATH.'
+	String get neovimNotFound => 'Neovim was not found in your shell PATH.';
+
+	/// en: 'Check again'
+	String get neovimRefresh => 'Check again';
+
 	/// en: 'Enable agents'
 	String get enableAgentsTitle => 'Enable agents';
 
@@ -4180,6 +4220,11 @@ extension on Translations {
 			'cockpit.confirmDialog.unsavedChangesMessage' => ({required Object fileName}) => '“${fileName}” has unsaved changes. Save them before closing?',
 			'cockpit.confirmDialog.dontSave' => 'Don\'t save',
 			'cockpit.confirmDialog.saveAndClose' => 'Save & close',
+			'cockpit.neovim.unavailable' => 'Neovim is not available. Opening in Cockpit instead.',
+			'cockpit.neovim.openFailed' => 'Could not reach Neovim. Opening in Cockpit instead.',
+			'cockpit.neovim.unsavedTitle' => 'Unsaved Neovim buffers',
+			'cockpit.neovim.unsavedMessage' => 'Neovim has modified buffers. Close the tab and discard those changes?',
+			'cockpit.neovim.closeAnyway' => 'Close anyway',
 			'cockpit.historyDialog.title' => 'Session history',
 			'cockpit.historyDialog.subtitle' => 'Opening one replaces this agent\'s current transcript',
 			'cockpit.historyDialog.empty' => 'No saved sessions in this folder.',
@@ -4656,6 +4701,8 @@ extension on Translations {
 			'cockpit.findBar.wholeWord' => 'Whole word',
 			'cockpit.findBar.useRegex' => 'Use regular expression',
 			'cockpit.findBar.previous' => 'Previous (⇧⏎)',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.findBar.next' => 'Next (⏎)',
 			'cockpit.findBar.close' => 'Close (Esc)',
 			'cockpit.findBar.badPattern' => 'Bad pattern',
@@ -4835,6 +4882,11 @@ extension on Translations {
 			'settings.page.nav.automations' => 'Automations',
 			'settings.page.nav.remoteHosts' => 'Remote hosts',
 			'settings.page.general.sectionAgent' => 'Agent',
+			'settings.page.general.sectionEditor' => 'Editor',
+			'settings.page.general.neovimTitle' => 'Open files in Neovim',
+			'settings.page.general.neovimChecking' => 'Looking for Neovim…',
+			'settings.page.general.neovimNotFound' => 'Neovim was not found in your shell PATH.',
+			'settings.page.general.neovimRefresh' => 'Check again',
 			'settings.page.general.enableAgentsTitle' => 'Enable agents',
 			'settings.page.general.enableAgentsDesc' => 'Show the option to open agent tabs (pi). When off, Cockpit works as a terminal-only workspace.',
 			'settings.page.general.showCockpitTitle' => 'Show Cockpit terminal',

--- a/cockpit/lib/i18n/strings_en.g.dart
+++ b/cockpit/lib/i18n/strings_en.g.dart
@@ -3245,8 +3245,14 @@ class Translations$settings$page$general$en {
 	/// en: 'Editor'
 	String get sectionEditor => 'Editor';
 
-	/// en: 'Open files in Neovim'
-	String get neovimTitle => 'Open files in Neovim';
+	/// en: 'Engine'
+	String get editorEngineTitle => 'Engine';
+
+	/// en: 'Cockpit (default)'
+	String get editorEngineCockpit => 'Cockpit (default)';
+
+	/// en: 'Neovim'
+	String get editorEngineNeovim => 'Neovim';
 
 	/// en: 'Looking for Neovim…'
 	String get neovimChecking => 'Looking for Neovim…';
@@ -4650,13 +4656,13 @@ extension on Translations {
 			'cockpit.dbConnectionDialog.testing' => 'Testing connection…',
 			'cockpit.dbConnectionDialog.connectionOk' => 'Connection OK',
 			'cockpit.dbConnectionDialog.connectionFailed' => 'Connection failed',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.dbConnectionDialog.editTitle' => 'Edit connection',
 			'cockpit.dbConnectionDialog.newTitle' => 'New connection',
 			'cockpit.dbConnectionDialog.connectionString' => 'Connection string',
 			'cockpit.dbConnectionDialog.invalidUrl' => 'Not a valid connection URL.',
 			'cockpit.dbConnectionDialog.sshTunnel' => 'SSH Tunnel',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.dbConnectionDialog.sshHost' => 'SSH Host',
 			'cockpit.dbConnectionDialog.sshPort' => 'SSH Port',
 			'cockpit.dbConnectionDialog.sshUser' => 'SSH User',
@@ -4701,8 +4707,6 @@ extension on Translations {
 			'cockpit.findBar.wholeWord' => 'Whole word',
 			'cockpit.findBar.useRegex' => 'Use regular expression',
 			'cockpit.findBar.previous' => 'Previous (⇧⏎)',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.findBar.next' => 'Next (⏎)',
 			'cockpit.findBar.close' => 'Close (Esc)',
 			'cockpit.findBar.badPattern' => 'Bad pattern',
@@ -4883,7 +4887,9 @@ extension on Translations {
 			'settings.page.nav.remoteHosts' => 'Remote hosts',
 			'settings.page.general.sectionAgent' => 'Agent',
 			'settings.page.general.sectionEditor' => 'Editor',
-			'settings.page.general.neovimTitle' => 'Open files in Neovim',
+			'settings.page.general.editorEngineTitle' => 'Engine',
+			'settings.page.general.editorEngineCockpit' => 'Cockpit (default)',
+			'settings.page.general.editorEngineNeovim' => 'Neovim',
 			'settings.page.general.neovimChecking' => 'Looking for Neovim…',
 			'settings.page.general.neovimNotFound' => 'Neovim was not found in your shell PATH.',
 			'settings.page.general.neovimRefresh' => 'Check again',
@@ -5164,6 +5170,8 @@ extension on Translations {
 			'settings.remoteHosts.helpBody' => 'Cockpit connects to your machine over SSH and talks to a small server that runs the terminals, files and git there. The host must have Cockpit (desktop) or the cockpit-server installed and running, and this device’s public key added to its ~/.ssh/authorized_keys.',
 			'automation.error.unavailable' => ({required Object harness}) => '${harness} is not installed or is not on PATH.',
 			'automation.error.modelUnavailable' => ({required Object model, required Object harness}) => 'Model "${model}" is not available for ${harness}. Choose another model in Settings.',
+			_ => null,
+		} ?? switch (path) {
 			'automation.error.authentication' => ({required Object harness, required Object detail}) => '${harness}: ${detail}',
 			'automation.error.timeout' => ({required Object harness, required Object seconds}) => '${harness} did not respond within ${seconds} seconds.',
 			'automation.error.cancelled' => 'Commit message generation was cancelled.',
@@ -5176,8 +5184,6 @@ extension on Translations {
 			'automation.error.fileOutsideWorkspace' => 'File is outside the workspace roots.',
 			'automation.error.fileUnreadable' => ({required Object detail}) => 'Could not read the file: ${detail}',
 			'automation.error.binaryFile' => 'A commit message cannot be generated for a binary file.',
-			_ => null,
-		} ?? switch (path) {
 			'automation.error.noFileChanges' => 'There are no changes to describe for this file.',
 			'automation.error.noStagedChanges' => 'There are no staged changes to describe.',
 			'automation.error.multipleRepositories' => 'Staged changes belong to multiple repositories. Generate them separately.',

--- a/cockpit/lib/i18n/strings_es.g.dart
+++ b/cockpit/lib/i18n/strings_es.g.dart
@@ -104,6 +104,7 @@ class _Translations$cockpit$es extends Translations$cockpit$en {
 
 	// Translations
 	@override late final _Translations$cockpit$confirmDialog$es confirmDialog = _Translations$cockpit$confirmDialog$es._(_root);
+	@override late final _Translations$cockpit$neovim$es neovim = _Translations$cockpit$neovim$es._(_root);
 	@override late final _Translations$cockpit$historyDialog$es historyDialog = _Translations$cockpit$historyDialog$es._(_root);
 	@override late final _Translations$cockpit$worktreeCreateDialog$es worktreeCreateDialog = _Translations$cockpit$worktreeCreateDialog$es._(_root);
 	@override late final _Translations$cockpit$subfolderDialog$es subfolderDialog = _Translations$cockpit$subfolderDialog$es._(_root);
@@ -316,6 +317,20 @@ class _Translations$cockpit$confirmDialog$es extends Translations$cockpit$confir
 	@override String unsavedChangesMessage({required Object fileName}) => '“${fileName}” tiene cambios sin guardar. ¿Guardarlos antes de cerrar?';
 	@override String get dontSave => 'No guardar';
 	@override String get saveAndClose => 'Guardar y cerrar';
+}
+
+// Path: cockpit.neovim
+class _Translations$cockpit$neovim$es extends Translations$cockpit$neovim$en {
+	_Translations$cockpit$neovim$es._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get unavailable => 'Neovim no está disponible. Abriendo en Cockpit.';
+	@override String get openFailed => 'No se pudo acceder a Neovim. Abriendo en Cockpit.';
+	@override String get unsavedTitle => 'Búferes de Neovim sin guardar';
+	@override String get unsavedMessage => 'Neovim tiene búferes modificados. ¿Cerrar la pestaña y descartar esos cambios?';
+	@override String get closeAnyway => 'Cerrar de todos modos';
 }
 
 // Path: cockpit.historyDialog
@@ -1606,6 +1621,11 @@ class _Translations$settings$page$general$es extends Translations$settings$page$
 
 	// Translations
 	@override String get sectionAgent => 'Agente';
+	@override String get sectionEditor => 'Editor';
+	@override String get neovimTitle => 'Abrir archivos en Neovim';
+	@override String get neovimChecking => 'Buscando Neovim…';
+	@override String get neovimNotFound => 'Neovim no se encontró en la PATH de tu shell.';
+	@override String get neovimRefresh => 'Comprobar de nuevo';
 	@override String get enableAgentsTitle => 'Activar agentes';
 	@override String get enableAgentsDesc => 'Muestra la opción de abrir pestañas de agente (pi). Cuando está desactivado, Cockpit funciona solo como workspace de terminal.';
 	@override String get showCockpitTitle => 'Mostrar terminal de Cockpit';
@@ -2061,6 +2081,11 @@ extension on TranslationsEs {
 			'cockpit.confirmDialog.unsavedChangesMessage' => ({required Object fileName}) => '“${fileName}” tiene cambios sin guardar. ¿Guardarlos antes de cerrar?',
 			'cockpit.confirmDialog.dontSave' => 'No guardar',
 			'cockpit.confirmDialog.saveAndClose' => 'Guardar y cerrar',
+			'cockpit.neovim.unavailable' => 'Neovim no está disponible. Abriendo en Cockpit.',
+			'cockpit.neovim.openFailed' => 'No se pudo acceder a Neovim. Abriendo en Cockpit.',
+			'cockpit.neovim.unsavedTitle' => 'Búferes de Neovim sin guardar',
+			'cockpit.neovim.unsavedMessage' => 'Neovim tiene búferes modificados. ¿Cerrar la pestaña y descartar esos cambios?',
+			'cockpit.neovim.closeAnyway' => 'Cerrar de todos modos',
 			'cockpit.historyDialog.title' => 'Historial de sesiones',
 			'cockpit.historyDialog.subtitle' => 'Abrir una reemplaza la transcripción actual de este agente',
 			'cockpit.historyDialog.empty' => 'No hay sesiones guardadas en esta carpeta.',
@@ -2537,6 +2562,8 @@ extension on TranslationsEs {
 			'cockpit.findBar.wholeWord' => 'Palabra completa',
 			'cockpit.findBar.useRegex' => 'Usar expresión regular',
 			'cockpit.findBar.previous' => 'Anterior (⇧⏎)',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.findBar.next' => 'Siguiente (⏎)',
 			'cockpit.findBar.close' => 'Cerrar (Esc)',
 			'cockpit.findBar.badPattern' => 'Patrón inválido',
@@ -2716,6 +2743,11 @@ extension on TranslationsEs {
 			'settings.page.nav.automations' => 'Automatizaciones',
 			'settings.page.nav.remoteHosts' => 'Hosts remotos',
 			'settings.page.general.sectionAgent' => 'Agente',
+			'settings.page.general.sectionEditor' => 'Editor',
+			'settings.page.general.neovimTitle' => 'Abrir archivos en Neovim',
+			'settings.page.general.neovimChecking' => 'Buscando Neovim…',
+			'settings.page.general.neovimNotFound' => 'Neovim no se encontró en la PATH de tu shell.',
+			'settings.page.general.neovimRefresh' => 'Comprobar de nuevo',
 			'settings.page.general.enableAgentsTitle' => 'Activar agentes',
 			'settings.page.general.enableAgentsDesc' => 'Muestra la opción de abrir pestañas de agente (pi). Cuando está desactivado, Cockpit funciona solo como workspace de terminal.',
 			'settings.page.general.showCockpitTitle' => 'Mostrar terminal de Cockpit',

--- a/cockpit/lib/i18n/strings_es.g.dart
+++ b/cockpit/lib/i18n/strings_es.g.dart
@@ -1622,7 +1622,9 @@ class _Translations$settings$page$general$es extends Translations$settings$page$
 	// Translations
 	@override String get sectionAgent => 'Agente';
 	@override String get sectionEditor => 'Editor';
-	@override String get neovimTitle => 'Abrir archivos en Neovim';
+	@override String get editorEngineTitle => 'Motor';
+	@override String get editorEngineCockpit => 'Cockpit (predeterminado)';
+	@override String get editorEngineNeovim => 'Neovim';
 	@override String get neovimChecking => 'Buscando Neovim…';
 	@override String get neovimNotFound => 'Neovim no se encontró en la PATH de tu shell.';
 	@override String get neovimRefresh => 'Comprobar de nuevo';
@@ -2511,13 +2513,13 @@ extension on TranslationsEs {
 			'cockpit.dbConnectionDialog.testing' => 'Probando conexión…',
 			'cockpit.dbConnectionDialog.connectionOk' => 'Conexión OK',
 			'cockpit.dbConnectionDialog.connectionFailed' => 'Fallo en la conexión',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.dbConnectionDialog.editTitle' => 'Editar conexión',
 			'cockpit.dbConnectionDialog.newTitle' => 'Nueva conexión',
 			'cockpit.dbConnectionDialog.connectionString' => 'Connection string',
 			'cockpit.dbConnectionDialog.invalidUrl' => 'URL de conexión no válida.',
 			'cockpit.dbConnectionDialog.sshTunnel' => 'Túnel SSH',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.dbConnectionDialog.sshHost' => 'Host SSH',
 			'cockpit.dbConnectionDialog.sshPort' => 'Puerto SSH',
 			'cockpit.dbConnectionDialog.sshUser' => 'Usuario SSH',
@@ -2562,8 +2564,6 @@ extension on TranslationsEs {
 			'cockpit.findBar.wholeWord' => 'Palabra completa',
 			'cockpit.findBar.useRegex' => 'Usar expresión regular',
 			'cockpit.findBar.previous' => 'Anterior (⇧⏎)',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.findBar.next' => 'Siguiente (⏎)',
 			'cockpit.findBar.close' => 'Cerrar (Esc)',
 			'cockpit.findBar.badPattern' => 'Patrón inválido',
@@ -2744,7 +2744,9 @@ extension on TranslationsEs {
 			'settings.page.nav.remoteHosts' => 'Hosts remotos',
 			'settings.page.general.sectionAgent' => 'Agente',
 			'settings.page.general.sectionEditor' => 'Editor',
-			'settings.page.general.neovimTitle' => 'Abrir archivos en Neovim',
+			'settings.page.general.editorEngineTitle' => 'Motor',
+			'settings.page.general.editorEngineCockpit' => 'Cockpit (predeterminado)',
+			'settings.page.general.editorEngineNeovim' => 'Neovim',
 			'settings.page.general.neovimChecking' => 'Buscando Neovim…',
 			'settings.page.general.neovimNotFound' => 'Neovim no se encontró en la PATH de tu shell.',
 			'settings.page.general.neovimRefresh' => 'Comprobar de nuevo',
@@ -3025,6 +3027,8 @@ extension on TranslationsEs {
 			'settings.remoteHosts.helpBody' => 'Cockpit se conecta a tu máquina por SSH y habla con un pequeño servidor que ejecuta las terminales, archivos y git allí. El host debe tener Cockpit (escritorio) o el cockpit-server instalado y en ejecución, y la clave pública de este dispositivo añadida en su ~/.ssh/authorized_keys.',
 			'automation.error.unavailable' => ({required Object harness}) => '${harness} no está instalado o no está en el PATH.',
 			'automation.error.modelUnavailable' => ({required Object model, required Object harness}) => 'El modelo "${model}" no está disponible para ${harness}. Elige otro modelo en Configuración.',
+			_ => null,
+		} ?? switch (path) {
 			'automation.error.authentication' => ({required Object harness, required Object detail}) => '${harness}: ${detail}',
 			'automation.error.timeout' => ({required Object harness, required Object seconds}) => '${harness} no respondió en ${seconds} segundos.',
 			'automation.error.cancelled' => 'Se canceló la generación del mensaje de commit.',
@@ -3037,8 +3041,6 @@ extension on TranslationsEs {
 			'automation.error.fileOutsideWorkspace' => 'El archivo está fuera de las raíces del workspace.',
 			'automation.error.fileUnreadable' => ({required Object detail}) => 'No se pudo leer el archivo: ${detail}',
 			'automation.error.binaryFile' => 'No se puede generar un mensaje de commit para un archivo binario.',
-			_ => null,
-		} ?? switch (path) {
 			'automation.error.noFileChanges' => 'No hay cambios que describir en este archivo.',
 			'automation.error.noStagedChanges' => 'No hay cambios en stage que describir.',
 			'automation.error.multipleRepositories' => 'Los cambios en stage pertenecen a varios repositorios. Genéralos por separado.',

--- a/cockpit/lib/i18n/strings_pt_BR.g.dart
+++ b/cockpit/lib/i18n/strings_pt_BR.g.dart
@@ -1622,7 +1622,9 @@ class _Translations$settings$page$general$pt_BR extends Translations$settings$pa
 	// Translations
 	@override String get sectionAgent => 'Agente';
 	@override String get sectionEditor => 'Editor';
-	@override String get neovimTitle => 'Abrir arquivos no Neovim';
+	@override String get editorEngineTitle => 'Motor';
+	@override String get editorEngineCockpit => 'Cockpit (padrão)';
+	@override String get editorEngineNeovim => 'Neovim';
 	@override String get neovimChecking => 'Procurando o Neovim…';
 	@override String get neovimNotFound => 'O Neovim não foi encontrado na PATH do seu shell.';
 	@override String get neovimRefresh => 'Verificar novamente';
@@ -2511,13 +2513,13 @@ extension on TranslationsPtBr {
 			'cockpit.dbConnectionDialog.testing' => 'Testando conexão…',
 			'cockpit.dbConnectionDialog.connectionOk' => 'Conexão OK',
 			'cockpit.dbConnectionDialog.connectionFailed' => 'Falha na conexão',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.dbConnectionDialog.editTitle' => 'Editar conexão',
 			'cockpit.dbConnectionDialog.newTitle' => 'Nova conexão',
 			'cockpit.dbConnectionDialog.connectionString' => 'Connection string',
 			'cockpit.dbConnectionDialog.invalidUrl' => 'URL de conexão inválida.',
 			'cockpit.dbConnectionDialog.sshTunnel' => 'Túnel SSH',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.dbConnectionDialog.sshHost' => 'Host SSH',
 			'cockpit.dbConnectionDialog.sshPort' => 'Porta SSH',
 			'cockpit.dbConnectionDialog.sshUser' => 'Usuário SSH',
@@ -2562,8 +2564,6 @@ extension on TranslationsPtBr {
 			'cockpit.findBar.wholeWord' => 'Palavra inteira',
 			'cockpit.findBar.useRegex' => 'Usar expressão regular',
 			'cockpit.findBar.previous' => 'Anterior (⇧⏎)',
-			_ => null,
-		} ?? switch (path) {
 			'cockpit.findBar.next' => 'Próximo (⏎)',
 			'cockpit.findBar.close' => 'Fechar (Esc)',
 			'cockpit.findBar.badPattern' => 'Padrão inválido',
@@ -2744,7 +2744,9 @@ extension on TranslationsPtBr {
 			'settings.page.nav.remoteHosts' => 'Hosts remotos',
 			'settings.page.general.sectionAgent' => 'Agente',
 			'settings.page.general.sectionEditor' => 'Editor',
-			'settings.page.general.neovimTitle' => 'Abrir arquivos no Neovim',
+			'settings.page.general.editorEngineTitle' => 'Motor',
+			'settings.page.general.editorEngineCockpit' => 'Cockpit (padrão)',
+			'settings.page.general.editorEngineNeovim' => 'Neovim',
 			'settings.page.general.neovimChecking' => 'Procurando o Neovim…',
 			'settings.page.general.neovimNotFound' => 'O Neovim não foi encontrado na PATH do seu shell.',
 			'settings.page.general.neovimRefresh' => 'Verificar novamente',
@@ -3025,6 +3027,8 @@ extension on TranslationsPtBr {
 			'settings.remoteHosts.helpBody' => 'O Cockpit conecta na sua máquina por SSH e fala com um servidor pequeno que roda os terminais, arquivos e git lá. O host precisa ter o Cockpit (desktop) ou o cockpit-server instalado e rodando, e a chave pública deste dispositivo adicionada no ~/.ssh/authorized_keys dele.',
 			'automation.error.unavailable' => ({required Object harness}) => '${harness} não está instalado ou não está no PATH.',
 			'automation.error.modelUnavailable' => ({required Object model, required Object harness}) => 'O modelo "${model}" não está disponível para ${harness}. Escolha outro modelo em Configurações.',
+			_ => null,
+		} ?? switch (path) {
 			'automation.error.authentication' => ({required Object harness, required Object detail}) => '${harness}: ${detail}',
 			'automation.error.timeout' => ({required Object harness, required Object seconds}) => '${harness} não respondeu em ${seconds} segundos.',
 			'automation.error.cancelled' => 'A geração da mensagem de commit foi cancelada.',
@@ -3037,8 +3041,6 @@ extension on TranslationsPtBr {
 			'automation.error.fileOutsideWorkspace' => 'O arquivo está fora das raízes do workspace.',
 			'automation.error.fileUnreadable' => ({required Object detail}) => 'Não foi possível ler o arquivo: ${detail}',
 			'automation.error.binaryFile' => 'Não é possível gerar mensagem de commit para um arquivo binário.',
-			_ => null,
-		} ?? switch (path) {
 			'automation.error.noFileChanges' => 'Não há mudanças a descrever neste arquivo.',
 			'automation.error.noStagedChanges' => 'Não há mudanças no stage a descrever.',
 			'automation.error.multipleRepositories' => 'As mudanças no stage pertencem a repositórios diferentes. Gere uma de cada vez.',

--- a/cockpit/lib/i18n/strings_pt_BR.g.dart
+++ b/cockpit/lib/i18n/strings_pt_BR.g.dart
@@ -104,6 +104,7 @@ class _Translations$cockpit$pt_BR extends Translations$cockpit$en {
 
 	// Translations
 	@override late final _Translations$cockpit$confirmDialog$pt_BR confirmDialog = _Translations$cockpit$confirmDialog$pt_BR._(_root);
+	@override late final _Translations$cockpit$neovim$pt_BR neovim = _Translations$cockpit$neovim$pt_BR._(_root);
 	@override late final _Translations$cockpit$historyDialog$pt_BR historyDialog = _Translations$cockpit$historyDialog$pt_BR._(_root);
 	@override late final _Translations$cockpit$worktreeCreateDialog$pt_BR worktreeCreateDialog = _Translations$cockpit$worktreeCreateDialog$pt_BR._(_root);
 	@override late final _Translations$cockpit$subfolderDialog$pt_BR subfolderDialog = _Translations$cockpit$subfolderDialog$pt_BR._(_root);
@@ -316,6 +317,20 @@ class _Translations$cockpit$confirmDialog$pt_BR extends Translations$cockpit$con
 	@override String unsavedChangesMessage({required Object fileName}) => '“${fileName}” tem alterações não salvas. Salvar antes de fechar?';
 	@override String get dontSave => 'Não salvar';
 	@override String get saveAndClose => 'Salvar e fechar';
+}
+
+// Path: cockpit.neovim
+class _Translations$cockpit$neovim$pt_BR extends Translations$cockpit$neovim$en {
+	_Translations$cockpit$neovim$pt_BR._(TranslationsPtBr root) : this._root = root, super.internal(root);
+
+	final TranslationsPtBr _root; // ignore: unused_field
+
+	// Translations
+	@override String get unavailable => 'O Neovim não está disponível. Abrindo no Cockpit.';
+	@override String get openFailed => 'Não foi possível acessar o Neovim. Abrindo no Cockpit.';
+	@override String get unsavedTitle => 'Buffers não salvos no Neovim';
+	@override String get unsavedMessage => 'O Neovim tem buffers modificados. Fechar a aba e descartar essas alterações?';
+	@override String get closeAnyway => 'Fechar mesmo assim';
 }
 
 // Path: cockpit.historyDialog
@@ -1606,6 +1621,11 @@ class _Translations$settings$page$general$pt_BR extends Translations$settings$pa
 
 	// Translations
 	@override String get sectionAgent => 'Agente';
+	@override String get sectionEditor => 'Editor';
+	@override String get neovimTitle => 'Abrir arquivos no Neovim';
+	@override String get neovimChecking => 'Procurando o Neovim…';
+	@override String get neovimNotFound => 'O Neovim não foi encontrado na PATH do seu shell.';
+	@override String get neovimRefresh => 'Verificar novamente';
 	@override String get enableAgentsTitle => 'Ativar agentes';
 	@override String get enableAgentsDesc => 'Mostra a opção de abrir abas de agente (pi). Quando desligado, o Cockpit funciona apenas como workspace de terminal.';
 	@override String get showCockpitTitle => 'Mostrar terminal do Cockpit';
@@ -2061,6 +2081,11 @@ extension on TranslationsPtBr {
 			'cockpit.confirmDialog.unsavedChangesMessage' => ({required Object fileName}) => '“${fileName}” tem alterações não salvas. Salvar antes de fechar?',
 			'cockpit.confirmDialog.dontSave' => 'Não salvar',
 			'cockpit.confirmDialog.saveAndClose' => 'Salvar e fechar',
+			'cockpit.neovim.unavailable' => 'O Neovim não está disponível. Abrindo no Cockpit.',
+			'cockpit.neovim.openFailed' => 'Não foi possível acessar o Neovim. Abrindo no Cockpit.',
+			'cockpit.neovim.unsavedTitle' => 'Buffers não salvos no Neovim',
+			'cockpit.neovim.unsavedMessage' => 'O Neovim tem buffers modificados. Fechar a aba e descartar essas alterações?',
+			'cockpit.neovim.closeAnyway' => 'Fechar mesmo assim',
 			'cockpit.historyDialog.title' => 'Histórico de sessões',
 			'cockpit.historyDialog.subtitle' => 'Abrir uma substitui a transcrição atual deste agente',
 			'cockpit.historyDialog.empty' => 'Nenhuma sessão salva nesta pasta.',
@@ -2537,6 +2562,8 @@ extension on TranslationsPtBr {
 			'cockpit.findBar.wholeWord' => 'Palavra inteira',
 			'cockpit.findBar.useRegex' => 'Usar expressão regular',
 			'cockpit.findBar.previous' => 'Anterior (⇧⏎)',
+			_ => null,
+		} ?? switch (path) {
 			'cockpit.findBar.next' => 'Próximo (⏎)',
 			'cockpit.findBar.close' => 'Fechar (Esc)',
 			'cockpit.findBar.badPattern' => 'Padrão inválido',
@@ -2716,6 +2743,11 @@ extension on TranslationsPtBr {
 			'settings.page.nav.automations' => 'Automações',
 			'settings.page.nav.remoteHosts' => 'Hosts remotos',
 			'settings.page.general.sectionAgent' => 'Agente',
+			'settings.page.general.sectionEditor' => 'Editor',
+			'settings.page.general.neovimTitle' => 'Abrir arquivos no Neovim',
+			'settings.page.general.neovimChecking' => 'Procurando o Neovim…',
+			'settings.page.general.neovimNotFound' => 'O Neovim não foi encontrado na PATH do seu shell.',
+			'settings.page.general.neovimRefresh' => 'Verificar novamente',
 			'settings.page.general.enableAgentsTitle' => 'Ativar agentes',
 			'settings.page.general.enableAgentsDesc' => 'Mostra a opção de abrir abas de agente (pi). Quando desligado, o Cockpit funciona apenas como workspace de terminal.',
 			'settings.page.general.showCockpitTitle' => 'Mostrar terminal do Cockpit',

--- a/cockpit/test/domain/app_settings_neovim_test.dart
+++ b/cockpit/test/domain/app_settings_neovim_test.dart
@@ -1,0 +1,41 @@
+import 'package:cockpit/app/core/domain/contracts/settings_store.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/core/ui/settings_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Store implements SettingsStore {
+  AppSettings? saved;
+
+  @override
+  Future<AppSettings> load() async => const AppSettings();
+
+  @override
+  Future<void> save(AppSettings settings) async => saved = settings;
+}
+
+void main() {
+  test('Neovim is disabled by default and absent from compact JSON', () {
+    const settings = AppSettings();
+    expect(settings.neovimEnabled, isFalse);
+    expect(settings.toJson(), isNot(contains('editor.neovim.enabled')));
+  });
+
+  test('Neovim preference round-trips with a stable key', () {
+    const settings = AppSettings(neovimEnabled: true);
+    final json = settings.toJson();
+    expect(json['editor.neovim.enabled'], isTrue);
+    expect(AppSettings.fromJson(json).neovimEnabled, isTrue);
+  });
+
+  test('SettingsController persists Neovim changes', () async {
+    final store = _Store();
+    final controller = SettingsController(store);
+    await controller.load();
+
+    controller.setNeovimEnabled(true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.settings.neovimEnabled, isTrue);
+    expect(store.saved?.neovimEnabled, isTrue);
+  });
+}

--- a/cockpit/test/domain/app_settings_neovim_test.dart
+++ b/cockpit/test/domain/app_settings_neovim_test.dart
@@ -14,17 +14,42 @@ class _Store implements SettingsStore {
 }
 
 void main() {
-  test('Neovim is disabled by default and absent from compact JSON', () {
+  test('Cockpit editor is the default and uses the stable engine key', () {
     const settings = AppSettings();
-    expect(settings.neovimEnabled, isFalse);
+    expect(settings.fileEditorEngine, FileEditorEngine.cockpit);
+    expect(settings.toJson()['editor.engine'], 'cockpit');
     expect(settings.toJson(), isNot(contains('editor.neovim.enabled')));
   });
 
-  test('Neovim preference round-trips with a stable key', () {
-    const settings = AppSettings(neovimEnabled: true);
+  test('Neovim engine round-trips with a stable key', () {
+    const settings = AppSettings(fileEditorEngine: FileEditorEngine.neovim);
     final json = settings.toJson();
-    expect(json['editor.neovim.enabled'], isTrue);
-    expect(AppSettings.fromJson(json).neovimEnabled, isTrue);
+    expect(json['editor.engine'], 'neovim');
+    expect(
+      AppSettings.fromJson(json).fileEditorEngine,
+      FileEditorEngine.neovim,
+    );
+  });
+
+  test('legacy Neovim boolean migrates and new key takes precedence', () {
+    expect(
+      AppSettings.fromJson({'editor.neovim.enabled': true}).fileEditorEngine,
+      FileEditorEngine.neovim,
+    );
+    expect(
+      AppSettings.fromJson({
+        'editor.engine': 'cockpit',
+        'editor.neovim.enabled': true,
+      }).fileEditorEngine,
+      FileEditorEngine.cockpit,
+    );
+  });
+
+  test('unknown editor engine falls back to Cockpit', () {
+    expect(
+      AppSettings.fromJson({'editor.engine': 'flack'}).fileEditorEngine,
+      FileEditorEngine.cockpit,
+    );
   });
 
   test('SettingsController persists Neovim changes', () async {
@@ -32,10 +57,10 @@ void main() {
     final controller = SettingsController(store);
     await controller.load();
 
-    controller.setNeovimEnabled(true);
+    controller.setFileEditorEngine(FileEditorEngine.neovim);
     await Future<void>.delayed(Duration.zero);
 
-    expect(controller.settings.neovimEnabled, isTrue);
-    expect(store.saved?.neovimEnabled, isTrue);
+    expect(controller.settings.fileEditorEngine, FileEditorEngine.neovim);
+    expect(store.saved?.fileEditorEngine, FileEditorEngine.neovim);
   });
 }

--- a/cockpit/test/domain/editor_appearance_policy_test.dart
+++ b/cockpit/test/domain/editor_appearance_policy_test.dart
@@ -1,0 +1,26 @@
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:cockpit/app/settings/domain/editor_appearance_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Cockpit engine exposes both code appearance settings', () {
+    const settings = AppSettings(fileEditorEngine: FileEditorEngine.cockpit);
+    expect(EditorAppearancePolicy.showCodeFont(settings), isTrue);
+    expect(EditorAppearancePolicy.showCodeSize(settings), isTrue);
+  });
+
+  test('external engine hides code font and explicit code size', () {
+    const settings = AppSettings(
+      fileEditorEngine: FileEditorEngine.neovim,
+      terminalSize: 15,
+    );
+    expect(EditorAppearancePolicy.showCodeFont(settings), isFalse);
+    expect(EditorAppearancePolicy.showCodeSize(settings), isFalse);
+  });
+
+  test('external engine keeps code size while terminal inherits it', () {
+    const settings = AppSettings(fileEditorEngine: FileEditorEngine.neovim);
+    expect(EditorAppearancePolicy.showCodeFont(settings), isFalse);
+    expect(EditorAppearancePolicy.showCodeSize(settings), isTrue);
+  });
+}

--- a/cockpit/test/domain/file_editor_facade_test.dart
+++ b/cockpit/test/domain/file_editor_facade_test.dart
@@ -1,0 +1,84 @@
+import 'package:cockpit/app/cockpit/domain/services/file_editor_facade.dart';
+import 'package:cockpit/app/core/domain/entities/app_settings.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late List<FileEditorEngine> calls;
+  late FileEditorFacade facade;
+
+  FileOpenRequest request(
+    String path, {
+    bool remote = false,
+    bool source = false,
+    bool notebook = false,
+  }) => FileOpenRequest(
+    path: path,
+    projectId: 'project',
+    paneId: 'pane',
+    isRemote: remote,
+    asSource: source,
+    isNotebook: notebook,
+  );
+
+  setUp(() {
+    calls = [];
+    facade = FileEditorFacade(
+      FileEditorRegistry({
+        FileEditorEngine.cockpit: (request) async {
+          calls.add(FileEditorEngine.cockpit);
+          return FileOpenOutcome.opened;
+        },
+        FileEditorEngine.neovim: (request) async {
+          calls.add(FileEditorEngine.neovim);
+          return FileOpenOutcome.opened;
+        },
+      }),
+    )..engine = FileEditorEngine.neovim;
+  });
+
+  test('routes ordinary local text through the selected engine', () async {
+    await facade.open(request('/repo/lib/main.dart'));
+    expect(calls, [FileEditorEngine.neovim]);
+  });
+
+  test('keeps remote and specialized content in Cockpit', () async {
+    for (final value in [
+      request('/repo/main.dart', remote: true),
+      request('/repo/request.http'),
+      request('/repo/query.dbq'),
+      request('/repo/board.kanban'),
+      request('/repo/logo.svg'),
+      request('/repo/image.png'),
+      request('/repo/project.notebook', notebook: true),
+    ]) {
+      calls.clear();
+      await facade.open(value);
+      expect(calls, [FileEditorEngine.cockpit]);
+    }
+  });
+
+  test('source action sends specialized text to selected engine', () async {
+    await facade.open(request('/repo/board.kanban', source: true));
+    expect(calls, [FileEditorEngine.neovim]);
+  });
+
+  test('falls back exactly once when external engine cannot open', () async {
+    facade = FileEditorFacade(
+      FileEditorRegistry({
+        FileEditorEngine.cockpit: (request) async {
+          calls.add(FileEditorEngine.cockpit);
+          return FileOpenOutcome.opened;
+        },
+        FileEditorEngine.neovim: (request) async {
+          calls.add(FileEditorEngine.neovim);
+          return FileOpenOutcome.notHandled;
+        },
+      }),
+    )..engine = FileEditorEngine.neovim;
+
+    final result = await facade.open(request('/repo/main.dart'));
+    expect(result.engine, FileEditorEngine.cockpit);
+    expect(result.outcome, FileOpenOutcome.opened);
+    expect(calls, [FileEditorEngine.neovim, FileEditorEngine.cockpit]);
+  });
+}

--- a/cockpit/test/ui/neovim_settings_viewmodel_test.dart
+++ b/cockpit/test/ui/neovim_settings_viewmodel_test.dart
@@ -1,0 +1,58 @@
+import 'package:cockpit/app/core/domain/contracts/neovim_gateway.dart';
+import 'package:cockpit/app/core/domain/exceptions/neovim_error.dart';
+import 'package:cockpit/app/core/domain/result.dart';
+import 'package:cockpit/app/settings/ui/neovim_settings_viewmodel.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Gateway implements NeovimGateway {
+  String? path;
+  int refreshes = 0;
+
+  @override
+  Future<String?> executable({bool refresh = false}) async {
+    if (refresh) refreshes++;
+    return path;
+  }
+
+  @override
+  Future<Result<bool, NeovimError>> hasModifiedBuffers(
+    String executable,
+    String address,
+  ) async => const Success(false);
+
+  @override
+  Future<bool> isAlive(String executable, String address) async => false;
+
+  @override
+  Future<Result<void, NeovimError>> openRemote(
+    String executable,
+    String address,
+    String path, {
+    int? line,
+  }) async => const Success(null);
+
+  @override
+  Future<void> prepareServer(String address) async {}
+
+  @override
+  String serverAddress(String workspaceId) => '/tmp/$workspaceId';
+}
+
+void main() {
+  test(
+    'reports unavailable, then refreshes after Neovim is installed',
+    () async {
+      final gateway = _Gateway();
+      final vm = NeovimSettingsViewModel(gateway);
+
+      await vm.check();
+      expect(vm.available, isFalse);
+
+      gateway.path = '/usr/bin/nvim';
+      await vm.check(refresh: true);
+      expect(vm.available, isTrue);
+      expect(vm.executable, '/usr/bin/nvim');
+      expect(gateway.refreshes, 1);
+    },
+  );
+}


### PR DESCRIPTION
## Resumo

- adiciona uma opção nas configurações para usar o Neovim como editor de arquivos locais
- mantém uma única instância do Neovim por workspace/worktree e reutiliza buffers na mesma aba do Cockpit
- integra explorer, busca rápida, busca global e links de arquivos do terminal, incluindo posicionamento na linha
- preserva o editor interno para workspaces remotos, diffs, mídia, SVG, arquivos HTTP e consultas de banco
- usa as configurações normais do usuário e restaura a sessão dedicada ao reabrir o Cockpit
- detecta a instalação do Neovim, apresenta mensagens localizadas e faz fallback para o editor integrado em caso de falha
- solicita confirmação antes de fechar uma sessão com buffers modificados

## Validação

- testes focados da preferência e detecção do Neovim
- análise estática dos arquivos alterados
- validação manual da abertura remota, posicionamento de linha e detecção de buffers modificados
- verificação de formatação do diff