### PR TITLE
fix(cockpit): prevent terminal crash on truncated Unicode table

### DIFF
--- a/cockpit/lib/app/core/terminal/xterm/src/utils/unicode_v11.dart
+++ b/cockpit/lib/app/core/terminal/xterm/src/utils/unicode_v11.dart
@@ -502,7 +502,18 @@ class UnicodeV11 {
   int wcwidth(int codePoint) {
     if (codePoint < 32) return 0;
     if (codePoint < 127) return 1;
-    if (codePoint < 65536) return table[codePoint];
+    // Keep this lookup defensive. The generated BMP table normally has one
+    // entry per code point, but a stale/partially generated release asset can
+    // contain only the first 256 entries. Terminal output must not crash just
+    // because it contains a character such as U+0100.
+    if (codePoint < 65536 && codePoint < table.length) {
+      return table[codePoint];
+    }
+    if (codePoint < 65536) {
+      if (bisearch(codePoint, BMP_COMBINING)) return 0;
+      if (bisearch(codePoint, BMP_WIDE)) return 2;
+      return 1;
+    }
     if (bisearch(codePoint, HIGH_COMBINING)) return 0;
     if (bisearch(codePoint, HIGH_WIDE)) return 2;
     return 1;

--- a/cockpit/test/core/terminal/xterm/src/utils/unicode_v11_test.dart
+++ b/cockpit/test/core/terminal/xterm/src/utils/unicode_v11_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cockpit/app/core/terminal/xterm/src/utils/unicode_v11.dart';
+
+void main() {
+  test('does not fail for BMP code points beyond a truncated table', () {
+    expect(unicodeV11.wcwidth(0x0100), 1);
+    expect(unicodeV11.wcwidth(0x0300), 0);
+    expect(unicodeV11.wcwidth(0x1100), 2);
+  });
+}


### PR DESCRIPTION
## Context

Terminal output containing a BMP character at or above U+0100 could crash the xterm width calculation when the runtime Unicode table was truncated to 256 entries.

## Changes

- Guard the BMP width-table lookup against truncated tables.
- Fall back to the BMP combining/wide ranges and a single-cell default.
- Add regression coverage for U+0100, U+0300, and U+1100.

## Validation

- Local: `git diff --check` passed.
- Local: `flutter test test/core/terminal/xterm/src/utils/unicode_v11_test.dart` could not complete because Flutter hung before producing output and was interrupted.

## Notes

- The branch is rebased onto the latest `main`.
- The existing unrelated `cockpit/pubspec.lock` working-tree change is excluded from this PR.