### PR TITLE
fix(pi-extension): dispatch mobile slash commands

### DIFF
--- a/pi-extension/src/extension.test.ts
+++ b/pi-extension/src/extension.test.ts
@@ -1894,6 +1894,25 @@ describe("multi-channel broadcast (W2D)", () => {
     expect(echo?.inner).not.toHaveProperty("streaming_behavior");
   });
 
+  test("app slash command opts into Pi command dispatch", async () => {
+    await _pairForTest("ownerA__1234567890");
+    const sendUserMessage = vi.fn();
+    _setPiForTest({ sendUserMessage, sendMessage: () => undefined });
+
+    relayRef.current!.emit("message", JSON.stringify({
+      peer: "ownerA__1234567890",
+      ct: Buffer.from(JSON.stringify({
+        type: "user_message", id: "msg-command", text: "/btw why?",
+      })).toString("base64"),
+    }));
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(sendUserMessage).toHaveBeenCalledWith("/btw why?", {
+      deliverAs: "steer",
+      expandPromptTemplates: true,
+    });
+  });
+
   test(
     "plan/43: active steering calls sendUserMessage(deliverAs='steer')",
     async () => {

--- a/pi-extension/src/index.ts
+++ b/pi-extension/src/index.ts
@@ -4073,8 +4073,12 @@ function _wakeAgent(
     return { ok: false, detail };
   }
   try {
-    const options = steeringBehavior
-      ? ({ deliverAs: steeringBehavior })
+    const expandPromptTemplates = typeof content === "string" && content.startsWith("/");
+    const options = steeringBehavior || expandPromptTemplates
+      ? {
+          ...(steeringBehavior ? { deliverAs: steeringBehavior } : {}),
+          ...(expandPromptTemplates ? { expandPromptTemplates: true } : {}),
+        }
       : undefined;
     _pi.sendUserMessage(content, options);
     return { ok: true };


### PR DESCRIPTION
## Summary
- opt slash-prefixed app messages into Pi’s extension-command and prompt expansion
- preserve steering behavior and ordinary/image message behavior
- cover `/btw`-style mobile command dispatch

## Verification
- `pnpm --dir pi-extension typecheck`
- `pnpm --dir pi-extension test` (799 passed, 3 skipped)