### PR TITLE
fix(windows): don't misparse local drive-letter paths as remote pc labels

### DIFF
--- a/pi-extension/src/session/broker_remote.test.ts
+++ b/pi-extension/src/session/broker_remote.test.ts
@@ -452,6 +452,21 @@ describe("parseAddress", () => {
   test("multiple colons → split on first", () => {
     expect(parseAddress("trab:sub:agent")).toEqual({ pcLabel: "trab", peerName: "sub:agent" });
   });
+  // Windows local peer ids are "<drive>:\path@name" (e.g. a cwd-derived
+  // address like "C:\Users\ich\project@agent-1"). Without the drive-letter
+  // guard, the drive-letter colon looks exactly like a "<pcLabel>:" prefix
+  // and every local Windows peer gets misrouted as remote pc "C".
+  test("Windows drive-letter local path → null (not a remote pc prefix)", () => {
+    expect(parseAddress("C:\\Users\\ich\\project@agent-1")).toBeNull();
+  });
+  test("Windows drive-letter path with forward slashes → null", () => {
+    expect(parseAddress("D:/repos/project@agent-1")).toBeNull();
+  });
+  test("real remote label that happens to be one letter, but not a drive letter shape → still parses", () => {
+    // "x:agent-1" has no path separator right after the colon, so it's not
+    // mistakeable for a Windows drive letter and should parse normally.
+    expect(parseAddress("x:agent-1")).toEqual({ pcLabel: "x", peerName: "agent-1" });
+  });
 });
 
 // ── tryRouteOutbound ────────────────────────────────────────────────────────

--- a/pi-extension/src/session/broker_remote.ts
+++ b/pi-extension/src/session/broker_remote.ts
@@ -725,9 +725,15 @@ export class BrokerRemote implements RemoteRouter, BrokerRemoteLifecycle {
   }
 }
 
+// Same Windows-drive-letter-collision guard as session/peer_inventory.ts:
+// "C:\Users\..." is a local path, not a "<pcLabel>:<peerName>" remote
+// address, even though it contains a colon early in the string.
+const WINDOWS_DRIVE_LETTER_RE = /^[A-Za-z]:[\\/]/;
+
 export function parseAddress(
   to: string,
 ): { pcLabel: string; peerName: string } | null {
+  if (WINDOWS_DRIVE_LETTER_RE.test(to)) return null;
   const separator = to.indexOf(":");
   if (separator <= 0 || separator === to.length - 1) return null;
   return {
@@ -753,6 +759,7 @@ function stripKnownPcPrefix(
 }
 
 function stripRequiredPcPrefix(value: string): string | null {
+  if (WINDOWS_DRIVE_LETTER_RE.test(value)) return null;
   const separator = value.indexOf(":");
   if (separator <= 0 || separator === value.length - 1) return null;
   return value.slice(separator + 1);

--- a/pi-extension/src/session/peer_inventory.test.ts
+++ b/pi-extension/src/session/peer_inventory.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { formatPeerInventory } from "./peer_inventory.js";
+
+describe("formatPeerInventory", () => {
+  test("local peer with no colon", () => {
+    expect(formatPeerInventory(["sess-1"])).toBe("  local:\n    sess-1");
+  });
+
+  test("remote peer with pc_label prefix", () => {
+    expect(formatPeerInventory(["casa:sess-3"])).toBe(
+      "  local:\n    (none)\n\n  remote:casa\n    sess-3",
+    );
+  });
+
+  test("excludes selfName", () => {
+    expect(formatPeerInventory(["sess-1", "sess-2"], "sess-1")).toBe(
+      "  local:\n    sess-2",
+    );
+  });
+
+  // Regression test: on Windows, a local peer's cwd-derived address embeds a
+  // drive-letter colon (e.g. "C:\Users\ich\project@agent-1"). Before the
+  // drive-letter guard, the first colon (right after "C") was mistaken for a
+  // "<pc_label>:" remote prefix, so every local Windows peer rendered as a
+  // bogus remote peer under a one-letter pc label "C" with a mangled path as
+  // its "peer name" (e.g. "remote:C" / "\Users\ich\project@agent-1").
+  test("Windows local peer address (drive-letter cwd) stays local", () => {
+    const peers = ["C:\\Users\\ich\\Documents\\claude\\Trading Bot@Trading-Bot"];
+    expect(formatPeerInventory(peers)).toBe(
+      "  local:\n    C:\\Users\\ich\\Documents\\claude\\Trading Bot@Trading-Bot",
+    );
+  });
+
+  test("Windows local peer address with forward slashes stays local", () => {
+    const peers = ["D:/repos/project@agent-1"];
+    expect(formatPeerInventory(peers)).toBe("  local:\n    D:/repos/project@agent-1");
+  });
+
+  test("real remote label still works alongside Windows local peers", () => {
+    const peers = [
+      "C:\\Users\\ich\\project@agent-1",
+      "casa:sess-3",
+    ];
+    expect(formatPeerInventory(peers)).toBe(
+      [
+        "  local:",
+        "    C:\\Users\\ich\\project@agent-1",
+        "",
+        "  remote:casa",
+        "    sess-3",
+      ].join("\n"),
+    );
+  });
+});

--- a/pi-extension/src/session/peer_inventory.ts
+++ b/pi-extension/src/session/peer_inventory.ts
@@ -11,13 +11,23 @@
  * cross-PC peers with a `<pc_label>:<peer>` prefix (`casa:sess-3`).
  */
 
+// Windows local peer ids embed a drive-letter colon (e.g. "C:\Users\...@Name"),
+// which collides with the "<pc_label>:<rest>" remote-peer convention (both put
+// a colon early in the string). A drive letter is always a single ASCII letter
+// immediately followed by a path separator, so that specific shape is never a
+// real pc_label — treat it as local rather than mis-splitting on it. Without
+// this guard, every local peer on Windows renders as a bogus remote peer
+// under a one-letter pc label (e.g. "C:\Users\ich\...@Trading-Bot" becomes
+// remote label "C", peer name "\Users\ich\...@Trading-Bot").
+const WINDOWS_DRIVE_LETTER_RE = /^[A-Za-z]:[\\/]/;
+
 export function formatPeerInventory(peers: string[], selfName?: string): string {
   const locals: string[] = [];
   const remotes = new Map<string, string[]>();
   for (const p of peers) {
     if (selfName && p === selfName) continue;
     const idx = p.indexOf(":");
-    if (idx > 0 && idx < p.length - 1) {
+    if (idx > 0 && idx < p.length - 1 && !WINDOWS_DRIVE_LETTER_RE.test(p)) {
       const label = p.slice(0, idx);
       const name = p.slice(idx + 1);
       const bucket = remotes.get(label) ?? [];


### PR DESCRIPTION
## Bug

On Windows, local peer addresses embed a drive-letter colon (e.g.
`C:\Users\ich\project@agent-1`). `session/peer_inventory.ts`'s
`formatPeerInventory` and `session/broker_remote.ts`'s `parseAddress` /
`stripRequiredPcPrefix` all use a "first colon in the string = remote
`pc_label` separator" heuristic to distinguish local peers from
`<pc_label>:<peer>` remote ones.

That heuristic breaks on Windows: the drive-letter colon is
indistinguishable from a remote label separator, so every local peer gets
misparsed as a remote peer under a bogus one-letter pc label.

Concretely, running `remote-pi peers` on Windows renders a real local peer

```
C:\Users\ich\Documents\claude\Trading Bot@Trading-Bot
```

as

```
remote:C
    \Users\ich\Documents\claude\Trading Bot@Trading-Bot
```

— a phantom remote PC named `C` with a mangled peer name.

The same heuristic in `broker_remote.ts`'s `parseAddress`/
`stripRequiredPcPrefix` affects `BrokerRemote.tryRouteOutbound` and inbound
envelope routing too (lower real-world blast radius today, since it only
misfires if a genuine sibling PC happens to be registered under a one-letter
label — but same root cause, and it's live routing logic, not just display).

## Fix

A Windows drive letter is always a single ASCII letter immediately followed
by a path separator (`\` or `/`). Guard all three call sites with that shape
and treat it as "not a remote label" rather than splitting on it.

## Testing

- Added `pi-extension/src/session/peer_inventory.test.ts` (new file) with
  regression cases for backslash and forward-slash drive-letter paths, plus
  existing local/remote/selfName cases.
- Added drive-letter cases to the existing `describe("parseAddress", ...)`
  block in `broker_remote.test.ts`, including a case confirming a genuine
  one-letter remote label that *isn't* drive-letter-shaped (e.g. `x:agent-1`)
  still parses correctly — the fix is scoped to the drive-letter shape only,
  not "no single-letter labels ever".
- `npx vitest run` on both touched test files: 70 passed, 0 failed.
- `npx tsc --noEmit`: clean.

Found and fixed while running `remote-pi` as the agent-mesh backend for a
Windows-based coding-agent session — `remote-pi peers` was the first visible
symptom, traced it through to the shared routing logic in `broker_remote.ts`.