### PR TITLE
Melhora a responsividade do Cockpit no Linux sob carga

### DIFF
--- a/.github/workflows/cockpit-release.yml
+++ b/.github/workflows/cockpit-release.yml
@@ -375,6 +375,10 @@ jobs:
 
       - name: Build + empacota
         run: |
+          g++ -std=c++14 linux/runner/gpu_environment.cc \
+            linux/runner/gpu_environment_test.cc \
+            -Ilinux/runner -o "$RUNNER_TEMP/gpu-environment-test"
+          "$RUNNER_TEMP/gpu-environment-test"
           flutter pub get
           flutter build windows --release
           # Gate do sidecar: sem o bundle do cockpit-server o app cai no

--- a/cockpit/docs/linux-performance-profiling.md
+++ b/cockpit/docs/linux-performance-profiling.md
@@ -1,0 +1,36 @@
+# Linux performance profiling
+
+Cockpit's performance telemetry is disabled by default and records only fixed
+metric names and numeric values. Enable it for a profile or release run:
+
+```bash
+COCKPIT_PERF_DIAGNOSTICS=1 flutter run -d linux --profile
+```
+
+The existing diagnostics log receives bounded `[linux-perf]` JSON batches every
+30 seconds. Capture a Flutter DevTools CPU/allocation/timeline trace while using
+the following deterministic workload:
+
+1. Restore or create 32–40 terminal tabs across at least four Cockpit workspaces.
+2. In eight visible/hidden terminals run
+   `yes cockpit-perf | head -c 268435456`; keep agent shells in the others.
+3. Open 12 synthetic Git repositories under a temporary directory and add them
+   as workspaces. Do not use repositories containing user work.
+4. Alternate Cockpit workspace selection and Hyprland workspace selection 100
+   times while a Flutter release build and normal agent workload run.
+5. Record Cockpit CPU/RSS separately from its child processes, and retain
+   `journalctl` GPU messages plus `coredumpctl list cockpit` after the run.
+
+Run the deterministic scheduler load before and after runtime changes:
+
+```bash
+flutter test test/performance/linux_terminal_stress_test.dart
+```
+
+For the production GPU matrix, use Intel/Wayland by default, then compare
+`COCKPIT_USE_NVIDIA=1` and `GDK_BACKEND=x11` independently. Never change the
+global Hyprland/Omarchy environment for this comparison.
+
+The acceptance soak is 60 minutes: no freeze/core/GPU allocation failure, p99
+input/workspace response below 150 ms, no event-loop stall above 500 ms, bounded
+PTY queues, and less than 10% retained-RSS growth after the switch cycle.

--- a/cockpit/docs/linux-performance-review.md
+++ b/cockpit/docs/linux-performance-review.md
@@ -1,0 +1,64 @@
+# Linux performance review — 2026-09-09
+
+## Environment
+
+- Arch/Omarchy 4.0.3, kernel 7.2.3, Hyprland 0.56.2 on Wayland.
+- Intel i5-9300H (4C/8T), 31 GiB RAM, 62 GiB combined zram/swap, NVMe.
+- Intel UHD 630 plus NVIDIA GTX 1650 Max-Q, NVIDIA 610.57.04.
+- Restored Cockpit state: 31 layouts, 47 tabs, 35 terminal sessions and 12
+  project records. State/scrollback size is small and is not a disk-capacity
+  bottleneck.
+
+## Confirmed findings
+
+1. `TerminalHarnessMonitor` recursively inspected every registered terminal's
+   `/proc` tree every 250 ms. With many agents and nested build processes this
+   is persistent CPU and filesystem work on the UI application's schedule.
+2. The three-second Git poll refreshed its selected targets while its worktree
+   callback independently reconciled every open root. Each Git status read can
+   spawn several commands, producing periodic CPU/I/O process bursts.
+3. Inactive terminal surfaces were already detached, and PTY output already had
+   global frame budgeting/backpressure. However, harness observation ignored
+   visibility and the tab strip scheduled overflow work after every parent
+   rebuild.
+4. Scrollback was bounded, but trimming converted and copied up to 2.5 million
+   UTF-16 code units on the UI isolate.
+5. The graphical session exports NVIDIA vendor/offload variables globally even
+   though Cockpit's installed launcher describes Intel as the default. Recent
+   debug cores terminate in `libnvidia-eglcore.so`; another release core is in
+   Flutter's GTK loop with an NVIDIA EGL thread. The journal also records NVRM
+   heap/channel allocation failures while system memory pressure was low.
+6. Older window-manager shutdown cores correspond to a guard already fixed in
+   the current source and are separate from the current freeze path.
+
+## Implemented mitigations
+
+- Adaptive, single-flight harness observation: immediate event bursts, 2 s
+  visible safety polling, 5 s hidden/idle polling and 10 s inactive-window
+  polling. Terminal processes remain alive.
+- Globally bounded Git refresh scheduler (two jobs), per-project coalescing with
+  one rerun, selected-project priority, and one staggered inactive worktree root
+  per tick.
+- Visibility signaling from mounted terminal bodies and layout-driven tab-strip
+  overflow measurement.
+- Chunked scrollback retention without full-buffer copies during trimming.
+- Native pre-GTK hybrid-GPU policy: integrated graphics by default, inherited
+  NVIDIA variables removed process-locally, and `COCKPIT_USE_NVIDIA=1` opt-in.
+- Opt-in fixed-schema performance telemetry and a deterministic 40-terminal PTY
+  scheduler workload.
+
+## Validation status
+
+- Focused affected suite: 39 tests passed.
+- Linux release bundle: built successfully.
+- Changed production Dart files: analyzer clean.
+- Full repository suite: 1,245 tests reached; eight unrelated/environmental
+  failures remain (xterm golden pixel differences, headless IME injection,
+  platform-dependent window-menu expectations, plus the Git coalescing
+  regression found during the run). The Git regression was fixed afterward and
+  its complete test files pass.
+- Repository-wide `flutter analyze lib linux` retains 55 pre-existing
+  warning/info diagnostics; none originate in the new performance code.
+- The 60-minute interactive GPU/UI soak remains a release-candidate validation
+  step because safely exercising Hyprland presentation requires a real desktop
+  session and must not silently resume the user's saved agents/cloud commands.

--- a/cockpit/lib/app/cockpit/cockpit_module.dart
+++ b/cockpit/lib/app/cockpit/cockpit_module.dart
@@ -250,7 +250,11 @@ Future<Module> buildCockpitModule({
         )
         ..addLazySingleton<ProcessTreeProvider>(createHostProcessTreeProvider)
         ..addLazySingleton<TerminalHarnessMonitor>(
-          CockpitTerminalHarnessMonitor.new,
+          // Feature-scoped binds cannot resolve services exposed only through
+          // ModularApp.provide. Thread the bootstrap-owned activity instance
+          // explicitly, as already done for the route-scoped GitController.
+          (ProcessTreeProvider provider) =>
+              CockpitTerminalHarnessMonitor(provider, windowActivity),
         )
         ..addLazySingleton<TerminalStatusServer>(TerminalStatusServerImpl.new)
         ..addLazySingleton<TaskRunnerGateway>(PtyTaskRunner.new)

--- a/cockpit/lib/app/cockpit/data/process/process_tree_provider_factory.dart
+++ b/cockpit/lib/app/cockpit/data/process/process_tree_provider_factory.dart
@@ -6,6 +6,7 @@ import 'package:cockpit/app/cockpit/data/process/windows_process_tree_provider.d
 import 'package:cockpit/app/cockpit/data/process/wsl_process_tree_provider.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/process_tree_provider.dart';
 import 'package:cockpit/app/cockpit/domain/services/terminal_harness_monitor.dart';
+import 'package:cockpit/app/core/ui/window_activity_controller.dart';
 
 /// Host-native process inspector for the current platform.
 ProcessTreeProvider createHostProcessTreeProvider() {
@@ -22,9 +23,12 @@ ProcessTreeProvider createWslProcessTreeProvider(String distro) {
 
 /// App-facing monitor with host provider + lazy WSL adapters.
 class CockpitTerminalHarnessMonitor extends TerminalHarnessMonitor {
-  CockpitTerminalHarnessMonitor(ProcessTreeProvider provider)
-    : super(
+  CockpitTerminalHarnessMonitor(
+    ProcessTreeProvider provider,
+    WindowActivityController activity,
+  ) : super(
         provider: provider,
         wslProviderForDistro: createWslProcessTreeProvider,
+        windowIsActive: () => activity.isActive,
       );
 }

--- a/cockpit/lib/app/cockpit/domain/services/terminal_harness_monitor.dart
+++ b/cockpit/lib/app/cockpit/domain/services/terminal_harness_monitor.dart
@@ -4,19 +4,24 @@ import 'package:cockpit/app/cockpit/domain/contracts/process_tree_provider.dart'
 import 'package:cockpit/app/cockpit/domain/entities/process_snapshot.dart';
 import 'package:cockpit/app/core/domain/entities/harness.dart';
 import 'package:cockpit/app/cockpit/domain/services/process_tree_resolver.dart';
+import 'package:cockpit/app/core/data/diagnostics/linux_performance_diagnostics.dart';
 
 class SessionAnchor {
   final String sessionId;
   final int? Function() rootPid;
   final String? wslDistro;
   final void Function(HarnessKind? newHarness) onHarnessChanged;
+  bool visible;
+  DateTime lastActivity;
 
   SessionAnchor({
     required this.sessionId,
     required this.rootPid,
     this.wslDistro,
     required this.onHarnessChanged,
-  });
+    this.visible = false,
+    DateTime? lastActivity,
+  }) : lastActivity = lastActivity ?? DateTime.fromMillisecondsSinceEpoch(0);
 }
 
 class TerminalHarnessMonitor {
@@ -24,6 +29,9 @@ class TerminalHarnessMonitor {
   final Map<String, ProcessTreeProvider>? wslProvidersByDistro;
   final ProcessTreeProvider Function(String distro)? wslProviderForDistro;
   final Duration pollInterval;
+  final Duration idlePollInterval;
+  final Duration inactivePollInterval;
+  final bool Function()? windowIsActive;
 
   Timer? _timer;
   bool _inFlight = false;
@@ -38,10 +46,13 @@ class TerminalHarnessMonitor {
     this.wslProviderForDistro,
     // Baseline safety net for silent exits / nested tools. Interactive
     // launches are kicked immediately from TerminalSession (Enter/output).
-    this.pollInterval = const Duration(milliseconds: 250),
+    this.pollInterval = const Duration(seconds: 2),
+    this.idlePollInterval = const Duration(seconds: 5),
+    this.inactivePollInterval = const Duration(seconds: 10),
+    this.windowIsActive,
   });
 
-  bool get isRunning => _timer != null;
+  bool get isRunning => _anchors.isNotEmpty && (_timer != null || _inFlight);
   int get registeredCount => _anchors.length;
 
   void registerSession({
@@ -58,7 +69,7 @@ class TerminalHarnessMonitor {
     );
 
     if (_timer == null && _anchors.isNotEmpty) {
-      _startTimer();
+      _scheduleNextPoll();
     }
     // Immediate poll on registration (and whenever a session is (re)bound).
     requestPoll();
@@ -75,8 +86,13 @@ class TerminalHarnessMonitor {
   }
 
   /// Ask for a poll as soon as possible. Coalesces with an in-flight poll.
-  void requestPoll() {
+  void requestPoll({String? sessionId}) {
     if (_anchors.isEmpty) return;
+    if (sessionId != null) {
+      _anchors[sessionId]?.lastActivity = DateTime.now();
+    }
+    _timer?.cancel();
+    _timer = null;
     if (_inFlight) {
       _pendingPoll = true;
       return;
@@ -84,9 +100,32 @@ class TerminalHarnessMonitor {
     unawaited(poll());
   }
 
-  void _startTimer() {
+  /// Informa se uma sessão tem superfície visível. A sessão e seu PTY
+  /// continuam vivos; isto governa somente a frequência do safety poll.
+  void setSessionVisible(String sessionId, bool visible) {
+    final anchor = _anchors[sessionId];
+    if (anchor == null || anchor.visible == visible) return;
+    anchor.visible = visible;
+    anchor.lastActivity = DateTime.now();
+    if (visible) requestPoll(sessionId: sessionId);
+  }
+
+  void _scheduleNextPoll() {
     _timer?.cancel();
-    _timer = Timer.periodic(pollInterval, (_) => requestPoll());
+    if (_anchors.isEmpty) {
+      _timer = null;
+      return;
+    }
+    final windowActive = windowIsActive?.call() ?? true;
+    final hasVisible = _anchors.values.any((anchor) => anchor.visible);
+    final hasRecentActivity = _anchors.values.any(
+      (anchor) =>
+          DateTime.now().difference(anchor.lastActivity) < idlePollInterval,
+    );
+    final delay = !windowActive
+        ? inactivePollInterval
+        : (hasVisible || hasRecentActivity ? pollInterval : idlePollInterval);
+    _timer = Timer(delay, requestPoll);
   }
 
   void _stopTimer() {
@@ -101,6 +140,7 @@ class TerminalHarnessMonitor {
     }
     _inFlight = true;
     _pendingPoll = false;
+    final stopwatch = Stopwatch()..start();
 
     try {
       // Group sessions into native host vs WSL by distro
@@ -152,10 +192,16 @@ class TerminalHarnessMonitor {
     } catch (_) {
       // Fallback silently on error
     } finally {
+      LinuxPerformanceDiagnostics.instance.record(LinuxPerfMetric.processScan, {
+        LinuxPerfField.durationUs: stopwatch.elapsedMicroseconds,
+        LinuxPerfField.sessions: _anchors.length,
+      });
       _inFlight = false;
       if (_pendingPoll && _anchors.isNotEmpty) {
         _pendingPoll = false;
         scheduleMicrotask(requestPoll);
+      } else {
+        _scheduleNextPoll();
       }
     }
   }

--- a/cockpit/lib/app/cockpit/ui/session/terminal_session.dart
+++ b/cockpit/lib/app/cockpit/ui/session/terminal_session.dart
@@ -12,6 +12,7 @@ import 'package:cockpit/app/core/domain/entities/app_settings.dart';
 import 'package:cockpit/app/core/terminal/terminal_controller.dart';
 import 'package:cockpit/app/core/terminal/pty_output_scheduler.dart';
 import 'package:cockpit/app/core/utils/quiet_period_debouncer.dart';
+import 'package:cockpit/app/core/utils/bounded_text_buffer.dart';
 import 'package:cockpit/app/cockpit/ui/session/pane_item.dart';
 import 'package:cockpit/app/cockpit/ui/session/terminal_input.dart';
 import 'package:flutter/foundation.dart';
@@ -314,7 +315,9 @@ class TerminalSession extends PaneItem {
   // da frente de uma vez (trim amortizado). Só main-screen — enquanto em
   // alt-screen (TUI: vim/lazygit), a saída é efêmera e NÃO entra no registro.
   final TerminalScrollbackStore? _scrollback;
-  final StringBuffer _record0 = StringBuffer();
+  late final BoundedTextBuffer _record0 = BoundedTextBuffer(
+    maxLength: _kMaxRecordChars,
+  );
   int _altDepth = 0;
   late final QuietPeriodDebouncer _saveDebounce = QuietPeriodDebouncer(
     delay: const Duration(seconds: 1),
@@ -428,13 +431,7 @@ class TerminalSession extends PaneItem {
     // tocou alt-screen → descarta chunk.
     if (!wasMain || _altDepth != 0) return;
 
-    _record0.write(data);
-    if (_record0.length > _kMaxRecordChars) {
-      final s = _record0.toString();
-      _record0
-        ..clear()
-        ..write(s.substring(s.length - (_kMaxRecordChars * 3 ~/ 4)));
-    }
+    _record0.add(data);
     _saveDebounce.trigger();
   }
 
@@ -453,7 +450,7 @@ class TerminalSession extends PaneItem {
       return;
     }
     _lastHarnessKickAt = now;
-    monitor.requestPoll();
+    monitor.requestPoll(sessionId: id);
 
     if (!burst) return;
     for (final t in _harnessKickTimers) {
@@ -467,9 +464,13 @@ class TerminalSession extends PaneItem {
           Duration(milliseconds: 120),
           Duration(milliseconds: 280),
         ])
-          Timer(delay, monitor.requestPoll),
+          Timer(delay, () => monitor.requestPoll(sessionId: id)),
       ]);
   }
+
+  /// Atualiza apenas a prioridade de observação do harness. O PTY e os
+  /// processos nunca são pausados quando a aba/workspace fica oculto.
+  void setVisible(bool visible) => _monitor?.setSessionVisible(id, visible);
 
   /// Atualiza [_cwd] a partir de OSC 7 no chunk. Pega a ÚLTIMA ocorrência (o
   /// prompt mais recente). Notifica a VM quando muda → persiste no layout.

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -437,6 +437,7 @@ class CockpitViewModel extends ChangeNotifier {
   /// também entram em [_projectList] (pro IndexedStack e o lookup).
   final Map<String, List<Project>> _worktrees = <String, List<Project>>{};
   late final WorktreeReconciler _worktreeReconciler;
+  int _worktreePollCursor = 0;
 
   /// Root (path absoluto) que **originou** cada fork (fork.id → root path).
   /// Em single-root é o próprio path do pai; em multi-root, o repo filho de
@@ -5955,11 +5956,9 @@ class CockpitViewModel extends ChangeNotifier {
     });
   }
 
-  /// Reconcilia as worktrees de TODOS os workspaces raiz abertos contra o git —
-  /// disparado a cada tick do poll do [GitController]. Pega worktrees criadas ou
-  /// removidas por fora (outro terminal, o terminal do próprio fork) sem exigir
-  /// reabrir o workspace. [_refreshWorktrees] deduplica e só notifica se a lista
-  /// mudou, então o custo em repos parados é nulo.
+  /// Reconcilia a raiz selecionada e uma raiz inativa por tick. Antes, cada tick
+  /// percorria TODAS as roots e criava uma tempestade de `git worktree list`
+  /// justamente quando builds e agentes também disputavam disco/CPU.
   void _reconcileOpenWorktrees() {
     // Snapshot: [_refreshWorktrees] muda [_projectList] (após um await), então
     // não iteramos a lista viva.
@@ -5967,9 +5966,17 @@ class CockpitViewModel extends ChangeNotifier {
         .where((p) => p.parentId == null && !p.isSystemTerminal)
         .map((p) => p.id)
         .toList();
-    for (final rootId in roots) {
-      unawaited(_refreshWorktrees(rootId));
+    if (roots.isEmpty) return;
+    final selectedRoot = _selectedProjectId == null
+        ? null
+        : _rootOf(_selectedProjectId!);
+    if (selectedRoot != null && roots.contains(selectedRoot)) {
+      unawaited(_refreshWorktrees(selectedRoot));
     }
+    final inactive = roots.where((id) => id != selectedRoot).toList();
+    if (inactive.isEmpty) return;
+    _worktreePollCursor %= inactive.length;
+    unawaited(_refreshWorktrees(inactive[_worktreePollCursor++]));
   }
 
   /// Reconcilia as worktrees de um workspace raiz contra o git (decisões 4, 5,

--- a/cockpit/lib/app/cockpit/ui/viewmodels/git_controller.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/git_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:io'
     show
         Directory,
@@ -12,8 +13,8 @@ import 'package:cockpit/app/cockpit/domain/contracts/git_command_runner.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_status_reader.dart';
 import 'package:cockpit/app/cockpit/domain/entities/git_file_status.dart';
 import 'package:cockpit/app/cockpit/domain/entities/git_info.dart';
-import 'package:cockpit/app/cockpit/domain/utils/coalescing_single_flight.dart';
 import 'package:cockpit/app/core/ui/window_activity_controller.dart';
+import 'package:cockpit/app/core/data/diagnostics/linux_performance_diagnostics.dart';
 import 'package:flutter/foundation.dart';
 
 typedef DirectoryWatch = Stream<FileSystemEvent> Function(String path);
@@ -127,8 +128,7 @@ class GitController extends ChangeNotifier {
   bool _pollRequested = false;
   String? _watchedProjectId;
   static const Duration _gitPollInterval = Duration(seconds: 3);
-  final CoalescingSingleFlight<String> _refreshFlights =
-      CoalescingSingleFlight<String>();
+  final GitRefreshScheduler _refreshScheduler = GitRefreshScheduler();
 
   // ---- leitura --------------------------------------------------------------
 
@@ -257,8 +257,11 @@ class GitController extends ChangeNotifier {
   /// (todos), ao selecionar e no fim de turno do agente (que pode ter mexido
   /// em arquivos). Reavalia as **roots** (implícitas, do filesystem) e lê o
   /// git de cada uma — single-root é o caso N=1 e se comporta como sempre.
-  Future<void> refresh(String projectId) =>
-      _refreshFlights.run(projectId, () => _refreshOnce(projectId));
+  Future<void> refresh(String projectId) => _refreshScheduler.schedule(
+    projectId,
+    () => _refreshOnce(projectId),
+    priority: selectedProjectId?.call() == projectId,
+  );
 
   Future<void> _refreshOnce(String projectId) async {
     final path = resolvePath?.call(projectId);
@@ -552,5 +555,114 @@ class GitController extends ChangeNotifier {
     _cancelWatch();
     _gitPoll?.cancel();
     super.dispose();
+  }
+}
+
+/// Fila global, limitada e coalescida para leituras Git. O limite evita que o
+/// restore de muitos workspaces dispute CPU/I/O com builds e com o isolate de
+/// UI. Requisições repetidas compartilham o mesmo Future e uma requisição do
+/// workspace selecionado pode promover uma entrada ainda não iniciada.
+@visibleForTesting
+final class GitRefreshScheduler {
+  GitRefreshScheduler({this.maxConcurrent = 2}) : assert(maxConcurrent > 0);
+
+  final int maxConcurrent;
+  final LinkedHashSet<String> _priority = LinkedHashSet<String>();
+  final LinkedHashSet<String> _normal = LinkedHashSet<String>();
+  final Map<String, Future<void> Function()> _jobs = {};
+  final Map<String, Future<void> Function()> _rerunJobs = {};
+  final Map<String, Completer<void>> _completers = {};
+  final Set<String> _activeKeys = {};
+  final Set<String> _priorityReruns = {};
+  final Set<String> _rerunConsumed = {};
+  int _active = 0;
+
+  @visibleForTesting
+  int get activeCount => _active;
+
+  @visibleForTesting
+  int get queuedCount => _jobs.length;
+
+  Future<void> schedule(
+    String key,
+    Future<void> Function() job, {
+    bool priority = false,
+  }) {
+    final existing = _completers[key];
+    if (existing != null) {
+      if (_activeKeys.contains(key)) {
+        if (!_rerunConsumed.contains(key)) {
+          _rerunJobs[key] = job;
+          if (priority) _priorityReruns.add(key);
+        }
+      } else {
+        _jobs[key] = job;
+        if (priority && _normal.remove(key)) _priority.add(key);
+      }
+      return existing.future;
+    }
+    final completer = Completer<void>();
+    _completers[key] = completer;
+    _jobs[key] = job;
+    (priority ? _priority : _normal).add(key);
+    _drain();
+    return completer.future;
+  }
+
+  void _drain() {
+    while (_active < maxConcurrent && _jobs.isNotEmpty) {
+      final key = _takeNext();
+      final job = _jobs.remove(key)!;
+      _active++;
+      _activeKeys.add(key);
+      final stopwatch = Stopwatch()..start();
+      Future<void>.sync(job).then<void>(
+        (_) => _complete(key, stopwatch: stopwatch),
+        onError: (Object error, StackTrace stack) {
+          _active--;
+          _activeKeys.remove(key);
+          _rerunJobs.remove(key);
+          _priorityReruns.remove(key);
+          _rerunConsumed.remove(key);
+          _recordMetric(stopwatch, failed: true);
+          _completers.remove(key)?.completeError(error, stack);
+          _drain();
+        },
+      );
+    }
+  }
+
+  String _takeNext() {
+    final queue = _priority.isNotEmpty ? _priority : _normal;
+    final key = queue.first;
+    queue.remove(key);
+    return key;
+  }
+
+  void _complete(String key, {required Stopwatch stopwatch}) {
+    _active--;
+    _activeKeys.remove(key);
+    _recordMetric(stopwatch, failed: false);
+    final rerun = _rerunJobs.remove(key);
+    if (rerun != null) {
+      _rerunConsumed.add(key);
+      _jobs[key] = rerun;
+      final priority = _priorityReruns.remove(key);
+      (priority ? _priority : _normal).add(key);
+      _drain();
+      return;
+    }
+    _rerunConsumed.remove(key);
+    _completers.remove(key)?.complete();
+    _drain();
+  }
+
+  void _recordMetric(Stopwatch stopwatch, {required bool failed}) {
+    LinuxPerformanceDiagnostics.instance.record(LinuxPerfMetric.gitRefresh, {
+      LinuxPerfField.durationUs: stopwatch.elapsedMicroseconds,
+      LinuxPerfField.active: _active,
+      LinuxPerfField.queued: _jobs.length,
+      LinuxPerfField.failed: failed ? 1 : 0,
+    });
   }
 }

--- a/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
+++ b/cockpit/lib/app/cockpit/ui/widgets/pane_view.dart
@@ -234,11 +234,13 @@ class _TabStripState extends State<_TabStrip> {
     super.didUpdateWidget(old);
     final activeChanged = old.pane.active != widget.pane.active;
     final countChanged = old.pane.tabs.length != widget.pane.tabs.length;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      if (activeChanged || countChanged) _scrollActiveIntoView();
-      _syncOverflow();
-    });
+    if (activeChanged || countChanged) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _scrollActiveIntoView();
+        _syncOverflow();
+      });
+    }
   }
 
   @override
@@ -336,10 +338,6 @@ class _TabStripState extends State<_TabStrip> {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final pane = widget.pane;
-    // Re-checa overflow a cada layout (resize de pane, add/remove de aba).
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _syncOverflow();
-    });
     // Drop do SO na faixa de abas → abre como aba, em qualquer tipo de pane
     // (em terminal, é aqui em cima que se solta pra abrir aba; o corpo insere
     // o caminho).
@@ -390,58 +388,71 @@ class _TabStripState extends State<_TabStrip> {
                           PointerDeviceKind.stylus,
                         },
                       ),
-                      child: SingleChildScrollView(
-                        controller: _scroll,
-                        scrollDirection: Axis.horizontal,
-                        child: Row(
-                          children: [
-                            for (var i = 0; i < pane.tabs.length; i++)
-                              _TabDropSlot(
-                                index: i,
-                                onInsert: (data, index) =>
-                                    widget.vm.moveTabToIndex(
-                                      data.paneId,
-                                      data.tabId,
+                      child: NotificationListener<ScrollMetricsNotification>(
+                        onNotification: (_) {
+                          // Dispara somente quando viewport/content realmente
+                          // muda, em vez de agendar callback em todo rebuild do
+                          // CockpitViewModel.
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            if (mounted) _syncOverflow();
+                          });
+                          return false;
+                        },
+                        child: SingleChildScrollView(
+                          controller: _scroll,
+                          scrollDirection: Axis.horizontal,
+                          child: Row(
+                            children: [
+                              for (var i = 0; i < pane.tabs.length; i++)
+                                _TabDropSlot(
+                                  index: i,
+                                  onInsert: (data, index) =>
+                                      widget.vm.moveTabToIndex(
+                                        data.paneId,
+                                        data.tabId,
+                                        pane.id,
+                                        index,
+                                      ),
+                                  child: _Tab(
+                                    item: widget.vm.session(pane.tabs[i]),
+                                    paneId: pane.id,
+                                    visible: widget.visible,
+                                    active: pane.tabs[i] == pane.active,
+                                    focused: widget.focused,
+                                    onSelect: () => widget.vm.selectTab(
                                       pane.id,
-                                      index,
+                                      pane.tabs[i],
                                     ),
-                                child: _Tab(
-                                  item: widget.vm.session(pane.tabs[i]),
-                                  paneId: pane.id,
-                                  visible: widget.visible,
-                                  active: pane.tabs[i] == pane.active,
-                                  focused: widget.focused,
-                                  onSelect: () => widget.vm.selectTab(
-                                    pane.id,
-                                    pane.tabs[i],
+                                    onClose: () => widget.vm.closeTab(
+                                      pane.id,
+                                      pane.tabs[i],
+                                    ),
+                                    onRename: (name) => widget.onRenameAgent(
+                                      pane.tabs[i],
+                                      name,
+                                    ),
+                                    onSetLabel: (label) => widget.vm
+                                        .setPaneLabel(pane.tabs[i], label),
+                                    onResetLabel: () =>
+                                        widget.vm.resetPaneLabel(pane.tabs[i]),
+                                    onToggleRelay: () =>
+                                        widget.onToggleRelayAgent(pane.tabs[i]),
+                                    onHistory: () =>
+                                        widget.onHistoryAgent(pane.tabs[i]),
                                   ),
-                                  onClose: () =>
-                                      widget.vm.closeTab(pane.id, pane.tabs[i]),
-                                  onRename: (name) =>
-                                      widget.onRenameAgent(pane.tabs[i], name),
-                                  onSetLabel: (label) => widget.vm.setPaneLabel(
-                                    pane.tabs[i],
-                                    label,
-                                  ),
-                                  onResetLabel: () =>
-                                      widget.vm.resetPaneLabel(pane.tabs[i]),
-                                  onToggleRelay: () =>
-                                      widget.onToggleRelayAgent(pane.tabs[i]),
-                                  onHistory: () =>
-                                      widget.onHistoryAgent(pane.tabs[i]),
                                 ),
+                              // Windows: "+" e a seta formam um grupo — a divisória
+                              // fica só no fim dele. Ausente no POSIX (lá só existe
+                              // o login shell, sem escolha a fazer).
+                              _TabAdd(
+                                onTap: widget.onCreateTab,
+                                trailingBorder:
+                                    !widget.vm.showTerminalProfilePicker,
                               ),
-                            // Windows: "+" e a seta formam um grupo — a divisória
-                            // fica só no fim dele. Ausente no POSIX (lá só existe
-                            // o login shell, sem escolha a fazer).
-                            _TabAdd(
-                              onTap: widget.onCreateTab,
-                              trailingBorder:
-                                  !widget.vm.showTerminalProfilePicker,
-                            ),
-                            if (widget.vm.showTerminalProfilePicker)
-                              _TabProfilePicker(vm: widget.vm),
-                          ],
+                              if (widget.vm.showTerminalProfilePicker)
+                                _TabProfilePicker(vm: widget.vm),
+                            ],
+                          ),
                         ),
                       ),
                     ),
@@ -1393,12 +1404,24 @@ class _PaneBodyState extends State<_PaneBody> {
   @override
   void initState() {
     super.initState();
+    if (widget.item case final TerminalSession session) {
+      session.setVisible(widget.active);
+    }
     if (_wantsTerminalFocus && widget.focused) _requestTerminalFocusSoon();
   }
 
   @override
   void didUpdateWidget(_PaneBody old) {
     super.didUpdateWidget(old);
+    if (widget.item case final TerminalSession session) {
+      if (old.item != widget.item || old.active != widget.active) {
+        if (old.item case final TerminalSession oldSession
+            when oldSession != session) {
+          oldSession.setVisible(false);
+        }
+        session.setVisible(widget.active);
+      }
+    }
     if (!_wantsTerminalFocus) return;
     if (widget.focused && (!old.focused || widget.focusGen != old.focusGen)) {
       // Também re-pede o foco quando só a *geração* mudou: clicar na aba que
@@ -1457,6 +1480,9 @@ class _PaneBodyState extends State<_PaneBody> {
 
   @override
   void dispose() {
+    if (widget.item case final TerminalSession session) {
+      session.setVisible(false);
+    }
     _scroll.dispose();
     _terminalFocus.dispose();
     super.dispose();

--- a/cockpit/lib/app/core/data/diagnostics/linux_performance_diagnostics.dart
+++ b/cockpit/lib/app/core/data/diagnostics/linux_performance_diagnostics.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cockpit/app/core/data/diagnostics/diagnostics_log.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+
+enum LinuxPerfMetric { frame, eventLoop, memory, pty, processScan, gitRefresh }
+
+enum LinuxPerfField {
+  durationUs,
+  buildUs,
+  rasterUs,
+  delayUs,
+  rssBytes,
+  pending,
+  sources,
+  sessions,
+  active,
+  queued,
+  failed,
+}
+
+/// Telemetria local opt-in estritamente numérica. A API aceita somente enums
+/// fechados, portanto callers não conseguem inserir comandos, paths ou output.
+final class LinuxPerformanceDiagnostics {
+  LinuxPerformanceDiagnostics({
+    bool? enabled,
+    this.maxEntries = 128,
+    this.minSampleInterval = const Duration(seconds: 1),
+    void Function(String line)? sink,
+  }) : enabled =
+           enabled ??
+           (Platform.isLinux &&
+               Platform.environment['COCKPIT_PERF_DIAGNOSTICS'] == '1'),
+       _sink = sink ?? _defaultSink;
+
+  static final LinuxPerformanceDiagnostics instance =
+      LinuxPerformanceDiagnostics();
+
+  final bool enabled;
+  final int maxEntries;
+  final Duration minSampleInterval;
+  final void Function(String line) _sink;
+  final List<Map<String, Object>> _entries = [];
+  final Map<LinuxPerfMetric, DateTime> _lastSample = {};
+  Timer? _watchdog;
+  Timer? _flushTimer;
+  DateTime? _expectedWatchdog;
+  bool _started = false;
+
+  @visibleForTesting
+  List<Map<String, Object>> get entries => List.unmodifiable(_entries);
+
+  void start() {
+    if (!enabled || _started) return;
+    _started = true;
+    SchedulerBinding.instance.addTimingsCallback(_onFrameTimings);
+    _expectedWatchdog = DateTime.now().add(const Duration(seconds: 1));
+    _watchdog = Timer.periodic(const Duration(seconds: 1), (_) {
+      final now = DateTime.now();
+      final expected = _expectedWatchdog!;
+      final delay = now.difference(expected);
+      _expectedWatchdog = now.add(const Duration(seconds: 1));
+      record(LinuxPerfMetric.eventLoop, {
+        LinuxPerfField.delayUs: delay.isNegative ? 0 : delay.inMicroseconds,
+      });
+      record(LinuxPerfMetric.memory, {
+        LinuxPerfField.rssBytes: ProcessInfo.currentRss,
+      });
+    });
+    _flushTimer = Timer.periodic(const Duration(seconds: 30), (_) => flush());
+  }
+
+  void record(
+    LinuxPerfMetric metric,
+    Map<LinuxPerfField, num> values, {
+    bool force = false,
+  }) {
+    if (!enabled || values.isEmpty) return;
+    final now = DateTime.now();
+    final previous = _lastSample[metric];
+    if (!force &&
+        previous != null &&
+        now.difference(previous) < minSampleInterval) {
+      return;
+    }
+    _lastSample[metric] = now;
+    if (_entries.length == maxEntries) _entries.removeAt(0);
+    _entries.add({
+      'at': now.toUtc().toIso8601String(),
+      'metric': metric.name,
+      for (final value in values.entries) value.key.name: value.value,
+    });
+  }
+
+  String snapshotJson() => jsonEncode(_entries);
+
+  void flush() {
+    if (!enabled || _entries.isEmpty) return;
+    _sink(snapshotJson());
+    _entries.clear();
+  }
+
+  void _onFrameTimings(List<FrameTiming> timings) {
+    for (final timing in timings) {
+      final durationUs = timing.totalSpan.inMicroseconds;
+      record(LinuxPerfMetric.frame, {
+        LinuxPerfField.buildUs: timing.buildDuration.inMicroseconds,
+        LinuxPerfField.rasterUs: timing.rasterDuration.inMicroseconds,
+        LinuxPerfField.durationUs: durationUs,
+      }, force: durationUs >= 50000);
+    }
+  }
+
+  static void _defaultSink(String line) =>
+      DiagnosticsLog.instance.log('linux-perf', line);
+
+  void dispose() {
+    if (_started) {
+      SchedulerBinding.instance.removeTimingsCallback(_onFrameTimings);
+    }
+    _watchdog?.cancel();
+    _flushTimer?.cancel();
+    flush();
+    _started = false;
+  }
+}

--- a/cockpit/lib/app/core/terminal/pty_output_scheduler.dart
+++ b/cockpit/lib/app/core/terminal/pty_output_scheduler.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:cockpit/app/core/data/diagnostics/linux_performance_diagnostics.dart';
 
 /// Orça o trabalho de todos os PTYs do app de forma global e justa.
 ///
@@ -120,6 +121,11 @@ final class PtyOutputScheduler {
       }
     } finally {
       _draining = false;
+      LinuxPerformanceDiagnostics.instance.record(LinuxPerfMetric.pty, {
+        LinuxPerfField.durationUs: _clockMicros() - startedAt,
+        LinuxPerfField.pending: _pendingChars,
+        LinuxPerfField.sources: _ready.length,
+      });
       _ensureFrame();
     }
   }

--- a/cockpit/lib/app/core/utils/bounded_text_buffer.dart
+++ b/cockpit/lib/app/core/utils/bounded_text_buffer.dart
@@ -1,0 +1,70 @@
+import 'dart:collection';
+
+/// Buffer textual limitado que remove chunks da frente sem copiar todo o
+/// histórico a cada trim. A materialização contígua acontece apenas no flush.
+final class BoundedTextBuffer {
+  BoundedTextBuffer({required this.maxLength, int? retainedLength})
+    : retainedLength = retainedLength ?? maxLength * 3 ~/ 4 {
+    if (maxLength <= 0 ||
+        this.retainedLength <= 0 ||
+        this.retainedLength >= maxLength) {
+      throw ArgumentError('expected 0 < retainedLength < maxLength');
+    }
+  }
+
+  final int maxLength;
+  final int retainedLength;
+  final ListQueue<String> _chunks = ListQueue<String>();
+  int _headOffset = 0;
+  int _length = 0;
+
+  int get length => _length;
+
+  void add(String value) {
+    if (value.isEmpty) return;
+    _chunks.addLast(value);
+    _length += value.length;
+    if (_length > maxLength) _trimFront(_length - retainedLength);
+  }
+
+  void _trimFront(int count) {
+    var remaining = count;
+    while (remaining > 0 && _chunks.isNotEmpty) {
+      final available = _chunks.first.length - _headOffset;
+      if (remaining >= available) {
+        remaining -= available;
+        _length -= available;
+        _chunks.removeFirst();
+        _headOffset = 0;
+        continue;
+      }
+      var cut = _headOffset + remaining;
+      // Nunca deixe o buffer começar no low surrogate de um par UTF-16.
+      final chunk = _chunks.first;
+      if (cut < chunk.length &&
+          cut > 0 &&
+          _isHighSurrogate(chunk.codeUnitAt(cut - 1)) &&
+          _isLowSurrogate(chunk.codeUnitAt(cut))) {
+        cut++;
+        remaining++;
+      }
+      _headOffset = cut;
+      _length -= remaining;
+      remaining = 0;
+    }
+  }
+
+  static bool _isHighSurrogate(int value) => value >= 0xD800 && value <= 0xDBFF;
+  static bool _isLowSurrogate(int value) => value >= 0xDC00 && value <= 0xDFFF;
+
+  @override
+  String toString() {
+    final out = StringBuffer();
+    var first = true;
+    for (final chunk in _chunks) {
+      out.write(first ? chunk.substring(_headOffset) : chunk);
+      first = false;
+    }
+    return out.toString();
+  }
+}

--- a/cockpit/lib/main.dart
+++ b/cockpit/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:cockpit/app/bootstrapper.dart';
 import 'package:cockpit/app/core/data/diagnostics/diagnostics_log.dart';
 import 'package:cockpit/app/core/data/diagnostics/error_handlers.dart';
+import 'package:cockpit/app/core/data/diagnostics/linux_performance_diagnostics.dart';
 import 'package:cockpit/app/core/ui/widgets/app_error_view.dart';
 import 'package:cockpit/app/core/ui/widgets/error_report_dialog.dart';
 import 'package:cockpit/i18n/strings.g.dart';
@@ -63,6 +64,7 @@ Future<void> main() async {
     final version = await _resolveVersion();
     setDiagnosticsAppVersion(version);
     await DiagnosticsLog.instance.init(appVersion: version);
+    LinuxPerformanceDiagnostics.instance.start();
 
     // Erro de build vira painel legível em vez da caixa cinza do Flutter.
     AppErrorView.install();

--- a/cockpit/linux/runner/CMakeLists.txt
+++ b/cockpit/linux/runner/CMakeLists.txt
@@ -7,6 +7,7 @@ project(runner LANGUAGES CXX)
 #
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME}
+  "gpu_environment.cc"
   "main.cc"
   "my_application.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"

--- a/cockpit/linux/runner/gpu_environment.cc
+++ b/cockpit/linux/runner/gpu_environment.cc
@@ -1,0 +1,38 @@
+#include "gpu_environment.h"
+
+#include <cstdlib>
+
+namespace {
+
+bool is_enabled(const char* value) {
+  return value != nullptr && std::string(value) == "1";
+}
+
+void set_default(const char* name, const char* value) {
+  if (std::getenv(name) == nullptr) setenv(name, value, 0);
+}
+
+}  // namespace
+
+std::string configure_linux_gpu_environment() {
+  if (is_enabled(std::getenv("COCKPIT_USE_NVIDIA"))) {
+    set_default("__NV_PRIME_RENDER_OFFLOAD", "1");
+    set_default("__GLX_VENDOR_LIBRARY_NAME", "nvidia");
+    set_default("__VK_LAYER_NV_optimus", "NVIDIA_only");
+    return "nvidia-opt-in";
+  }
+
+  // Omarchy/Hyprland sessions can export these globally for the compositor.
+  // Letting them leak into Flutter silently selected NVIDIA EGL despite the
+  // Cockpit launcher claiming to prefer Intel, and recent cores ended inside
+  // libnvidia-eglcore. This changes only Cockpit and its descendants.
+  unsetenv("__NV_PRIME_RENDER_OFFLOAD");
+  unsetenv("__GLX_VENDOR_LIBRARY_NAME");
+  unsetenv("__VK_LAYER_NV_optimus");
+  unsetenv("__EGL_VENDOR_LIBRARY_FILENAMES");
+  unsetenv("VK_ICD_FILENAMES");
+  unsetenv("GBM_BACKEND");
+  unsetenv("LIBVA_DRIVER_NAME");
+  setenv("DRI_PRIME", "0", 1);
+  return "integrated-default";
+}

--- a/cockpit/linux/runner/gpu_environment.h
+++ b/cockpit/linux/runner/gpu_environment.h
@@ -1,0 +1,10 @@
+#ifndef COCKPIT_GPU_ENVIRONMENT_H_
+#define COCKPIT_GPU_ENVIRONMENT_H_
+
+#include <string>
+
+// Applies Cockpit's process-local hybrid GPU policy before GTK/EGL starts.
+// Returns a content-free description suitable for the startup log.
+std::string configure_linux_gpu_environment();
+
+#endif  // COCKPIT_GPU_ENVIRONMENT_H_

--- a/cockpit/linux/runner/gpu_environment_test.cc
+++ b/cockpit/linux/runner/gpu_environment_test.cc
@@ -1,0 +1,25 @@
+#include "gpu_environment.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <string>
+
+int main() {
+  setenv("__GLX_VENDOR_LIBRARY_NAME", "nvidia", 1);
+  setenv("__NV_PRIME_RENDER_OFFLOAD", "1", 1);
+  setenv("LIBVA_DRIVER_NAME", "nvidia", 1);
+  unsetenv("COCKPIT_USE_NVIDIA");
+  assert(configure_linux_gpu_environment() == "integrated-default");
+  assert(std::getenv("__GLX_VENDOR_LIBRARY_NAME") == nullptr);
+  assert(std::getenv("__NV_PRIME_RENDER_OFFLOAD") == nullptr);
+  assert(std::getenv("LIBVA_DRIVER_NAME") == nullptr);
+  assert(std::string(std::getenv("DRI_PRIME")) == "0");
+
+  setenv("COCKPIT_USE_NVIDIA", "1", 1);
+  unsetenv("__GLX_VENDOR_LIBRARY_NAME");
+  unsetenv("__NV_PRIME_RENDER_OFFLOAD");
+  assert(configure_linux_gpu_environment() == "nvidia-opt-in");
+  assert(std::string(std::getenv("__GLX_VENDOR_LIBRARY_NAME")) == "nvidia");
+  assert(std::string(std::getenv("__NV_PRIME_RENDER_OFFLOAD")) == "1");
+  return 0;
+}

--- a/cockpit/linux/runner/main.cc
+++ b/cockpit/linux/runner/main.cc
@@ -1,6 +1,15 @@
 #include "my_application.h"
+#include "gpu_environment.h"
 
 int main(int argc, char** argv) {
+  const std::string gpu_policy = configure_linux_gpu_environment();
+  g_message("Cockpit Linux startup: gpu_policy=%s gdk_backend=%s session=%s",
+            gpu_policy.c_str(),
+            g_getenv("GDK_BACKEND") != nullptr ? g_getenv("GDK_BACKEND")
+                                                : "auto",
+            g_getenv("XDG_SESSION_TYPE") != nullptr
+                ? g_getenv("XDG_SESSION_TYPE")
+                : "unknown");
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }

--- a/cockpit/packaging/README.md
+++ b/cockpit/packaging/README.md
@@ -229,3 +229,15 @@ URLs são `https://rp-s3.jacobmoura.work/downloads/cockpit/appcast-{macos,window
 - Passo 4: layout/`latest.json` na VPS.
 - Passo 5: página de downloads no `site/`.
 - Passo 6: runbook de release (bump `version:` → tag → CI → smoke test).
+# Linux: política de GPU híbrida
+
+O bootstrap nativo do Cockpit seleciona a GPU integrada por padrão e remove,
+somente do processo do Cockpit, variáveis NVIDIA herdadas da sessão gráfica.
+Para comparar ou forçar a GPU dedicada, inicie com
+`COCKPIT_USE_NVIDIA=1 cockpit`. O startup log registra `gpu_policy`,
+`GDK_BACKEND` e `XDG_SESSION_TYPE` sem registrar comandos ou conteýo do usuário.
+
+Matriz de diagnóstico Linux: Intel/Wayland é o caminho de produção; compare
+NVIDIA/Wayland com o opt-in acima e Intel/XWayland com `GDK_BACKEND=x11` apenas
+para isolar falhas. Rollback é remover a chamada
+`configure_linux_gpu_environment()`; nenhuma configuração global é alterada.

--- a/cockpit/test/core/bounded_text_buffer_test.dart
+++ b/cockpit/test/core/bounded_text_buffer_test.dart
@@ -1,0 +1,30 @@
+import 'package:cockpit/app/core/utils/bounded_text_buffer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('trims whole and partial chunks without exceeding the bound', () {
+    final buffer = BoundedTextBuffer(maxLength: 10, retainedLength: 6)
+      ..add('abcd')
+      ..add('efgh')
+      ..add('ijkl');
+    expect(buffer.length, 6);
+    expect(buffer.toString(), 'ghijkl');
+  });
+
+  test('trim never leaves a split UTF-16 surrogate pair', () {
+    final buffer = BoundedTextBuffer(maxLength: 5, retainedLength: 3)
+      ..add('ab😀')
+      ..add('cd');
+    expect(buffer.toString(), 'cd');
+    expect(buffer.length, 2);
+  });
+
+  test('small appends do not require intermediate materialization', () {
+    final buffer = BoundedTextBuffer(maxLength: 100, retainedLength: 75);
+    for (var i = 0; i < 1000; i++) {
+      buffer.add('x');
+    }
+    expect(buffer.length, lessThanOrEqualTo(100));
+    expect(buffer.toString(), 'x' * buffer.length);
+  });
+}

--- a/cockpit/test/core/linux_performance_diagnostics_test.dart
+++ b/cockpit/test/core/linux_performance_diagnostics_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:cockpit/app/core/data/diagnostics/linux_performance_diagnostics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('stores only fixed metric names and numeric values', () {
+    final diagnostics = LinuxPerformanceDiagnostics(
+      enabled: true,
+      maxEntries: 4,
+      minSampleInterval: Duration.zero,
+      sink: (_) {},
+    );
+    diagnostics.record(LinuxPerfMetric.pty, {
+      LinuxPerfField.pending: 42,
+      LinuxPerfField.sources: 3,
+    });
+
+    final decoded = jsonDecode(diagnostics.snapshotJson()) as List<dynamic>;
+    final row = decoded.single as Map<String, dynamic>;
+    expect(row['metric'], 'pty');
+    expect(row['pending'], 42);
+    expect(row['sources'], 3);
+    expect(
+      row.keys,
+      everyElement(isIn(['at', 'metric', 'pending', 'sources'])),
+    );
+  });
+
+  test('ring buffer discards oldest samples at its fixed limit', () {
+    final diagnostics = LinuxPerformanceDiagnostics(
+      enabled: true,
+      maxEntries: 2,
+      minSampleInterval: Duration.zero,
+      sink: (_) {},
+    );
+    for (var i = 1; i <= 3; i++) {
+      diagnostics.record(LinuxPerfMetric.memory, {
+        LinuxPerfField.rssBytes: i,
+      }, force: true);
+    }
+    expect(diagnostics.entries, hasLength(2));
+    expect(diagnostics.entries.first['rssBytes'], 2);
+    expect(diagnostics.entries.last['rssBytes'], 3);
+  });
+
+  test('flush emits bounded JSON and clears retained samples', () {
+    String? output;
+    final diagnostics = LinuxPerformanceDiagnostics(
+      enabled: true,
+      maxEntries: 1,
+      minSampleInterval: Duration.zero,
+      sink: (value) => output = value,
+    );
+    diagnostics.record(LinuxPerfMetric.processScan, {
+      LinuxPerfField.durationUs: 100,
+    });
+    diagnostics.flush();
+    expect(output, isNotNull);
+    expect(output, isNot(contains('/home/')));
+    expect(diagnostics.entries, isEmpty);
+  });
+}

--- a/cockpit/test/domain/terminal_harness_monitor_test.dart
+++ b/cockpit/test/domain/terminal_harness_monitor_test.dart
@@ -206,6 +206,53 @@ void main() {
 
       monitor.dispose();
     });
+
+    test('hidden stable sessions use the idle safety interval', () async {
+      final fakeProvider = FakeProcessTreeProvider();
+      final monitor = TerminalHarnessMonitor(
+        provider: fakeProvider,
+        pollInterval: const Duration(milliseconds: 20),
+        idlePollInterval: const Duration(milliseconds: 80),
+      );
+
+      monitor.registerSession(
+        sessionId: 'session-1',
+        rootPid: () => 100,
+        onHarnessChanged: (_) {},
+      );
+      await pumpEventQueue();
+      final afterRegistration = fakeProvider.callCount;
+
+      await Future<void>.delayed(const Duration(milliseconds: 110));
+      expect(fakeProvider.callCount, greaterThan(afterRegistration));
+      expect(
+        fakeProvider.callCount,
+        lessThan(5),
+        reason: 'hidden sessions must not retain the old high-rate poll',
+      );
+      monitor.dispose();
+    });
+
+    test('becoming visible triggers an immediate coalesced refresh', () async {
+      final fakeProvider = FakeProcessTreeProvider();
+      final monitor = TerminalHarnessMonitor(
+        provider: fakeProvider,
+        pollInterval: const Duration(days: 1),
+        idlePollInterval: const Duration(days: 1),
+      );
+      monitor.registerSession(
+        sessionId: 'session-1',
+        rootPid: () => 100,
+        onHarnessChanged: (_) {},
+      );
+      await pumpEventQueue();
+      final beforeVisible = fakeProvider.callCount;
+
+      monitor.setSessionVisible('session-1', true);
+      await pumpEventQueue();
+      expect(fakeProvider.callCount, beforeVisible + 1);
+      monitor.dispose();
+    });
   });
 }
 

--- a/cockpit/test/performance/linux_terminal_stress_test.dart
+++ b/cockpit/test/performance/linux_terminal_stress_test.dart
@@ -1,0 +1,56 @@
+import 'dart:collection';
+
+import 'package:cockpit/app/core/terminal/pty_output_scheduler.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Frames {
+  final callbacks = ListQueue<VoidCallback>();
+  void schedule(VoidCallback callback) => callbacks.addLast(callback);
+}
+
+void main() {
+  test('40 noisy terminals drain fairly with a bounded global queue', () {
+    const terminals = 40;
+    const bytesPerTerminal = 256 * 1024;
+    final frames = _Frames();
+    final scheduler = PtyOutputScheduler(
+      maxCharsPerFrame: 64 * 1024,
+      maxSliceChars: 4 * 1024,
+      maxWorkPerFrame: const Duration(milliseconds: 4),
+      scheduleFrame: frames.schedule,
+      clockMicros: () => 0,
+    );
+    final received = List<int>.filled(terminals, 0);
+    final firstProgressFrame = List<int>.filled(terminals, -1);
+    var frame = 0;
+    var highWater = 0;
+    final payload = 'x' * bytesPerTerminal;
+    final sources = List.generate(
+      terminals,
+      (index) => PtyOutputCoalescer(
+        scheduler: scheduler,
+        maxPendingChars: bytesPerTerminal + 1,
+        onFlush: (chunk) {
+          received[index] += chunk.length;
+          if (firstProgressFrame[index] < 0) firstProgressFrame[index] = frame;
+        },
+        onAcknowledge: () {},
+      )..add(payload),
+    );
+    highWater = scheduler.pendingChars;
+
+    while (frames.callbacks.isNotEmpty) {
+      frame++;
+      frames.callbacks.removeFirst()();
+    }
+
+    expect(received, everyElement(bytesPerTerminal));
+    expect(firstProgressFrame, everyElement(inInclusiveRange(1, 3)));
+    expect(highWater, terminals * bytesPerTerminal);
+    expect(scheduler.pendingChars, 0);
+    for (final source in sources) {
+      source.dispose();
+    }
+  });
+}

--- a/cockpit/test/ui/git_controller_poll_test.dart
+++ b/cockpit/test/ui/git_controller_poll_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cockpit/app/cockpit/domain/contracts/git_command_runner.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/git_status_reader.dart';
 import 'package:cockpit/app/cockpit/domain/entities/git_info.dart';
@@ -18,6 +20,21 @@ class _CountingReader implements GitStatusReader {
   @override
   Future<GitInfo?> read(String path) async {
     reads++;
+    return null;
+  }
+}
+
+class _GatedReader implements GitStatusReader {
+  final gates = <String, Completer<void>>{};
+  var active = 0;
+  var maxActive = 0;
+
+  @override
+  Future<GitInfo?> read(String path) async {
+    active++;
+    if (active > maxActive) maxActive = active;
+    await gates.putIfAbsent(path, Completer<void>.new).future;
+    active--;
     return null;
   }
 }
@@ -102,4 +119,40 @@ void main() {
       activity.dispose();
     });
   });
+
+  test(
+    'refresh scheduler bounds concurrency and coalesces duplicate keys',
+    () async {
+      final scheduler = GitRefreshScheduler(maxConcurrent: 2);
+      final gates = <String, Completer<void>>{};
+      var active = 0;
+      var maxActive = 0;
+      var duplicateRuns = 0;
+
+      Future<void> job(String key) async {
+        active++;
+        maxActive = active > maxActive ? active : maxActive;
+        if (key == 'a') duplicateRuns++;
+        await gates.putIfAbsent(key, Completer<void>.new).future;
+        active--;
+      }
+
+      final futures = <Future<void>>[
+        scheduler.schedule('a', () => job('a')),
+        scheduler.schedule('b', () => job('b')),
+        scheduler.schedule('c', () => job('c')),
+        scheduler.schedule('a', () => job('a'), priority: true),
+      ];
+      await pumpEventQueue();
+      expect(maxActive, 2);
+    expect(duplicateRuns, 1, reason: 'rerun waits for the active flight');
+      gates['a']!.complete();
+      await pumpEventQueue();
+    gates['b']!.complete();
+    gates['c']!.complete();
+    await Future.wait(futures);
+    expect(duplicateRuns, 2, reason: 'active duplicate coalesces to one rerun');
+      expect(maxActive, 2);
+    },
+  );
 }


### PR DESCRIPTION
## Contexto

Em cenários com muitos workspaces, abas e agentes ativos no Linux, o Cockpit fazia trabalho recorrente demais no caminho da interface: varreduras frequentes de árvores de processos, atualizações Git concorrentes, medições de overflow após rebuilds e cópias grandes durante a retenção do scrollback. Em máquinas híbridas Intel/NVIDIA, variáveis herdadas da sessão também podiam selecionar o EGL da NVIDIA mesmo quando o Cockpit deveria usar a GPU integrada.

## O que foi feito

- Torna o monitor de processos dos terminais adaptativo e *single-flight*: eventos de atividade continuam disparando atualização imediata, enquanto as verificações de segurança passam a respeitar visibilidade, ociosidade e atividade da janela.
- Limita globalmente as leituras de status Git a duas operações simultâneas, coalesce pedidos repetidos, prioriza o projeto selecionado e distribui a atualização de worktrees inativos.
- Propaga a visibilidade real das superfícies de terminal e evita agendar medições de overflow da barra de abas em todo rebuild.
- Substitui a retenção do scrollback baseada em grandes cópias por um buffer em blocos, com limite fixo e cuidado para não separar pares substitutos UTF-16.
- Mantém o orçamento global e justo do processamento de saída dos PTYs e acrescenta métricas para observar duração, fila pendente e fontes prontas.
- Adiciona telemetria de desempenho opt-in, com esquema fixo, somente valores numéricos e armazenamento limitado. Ela permanece desativada por padrão.
- Define, antes da inicialização do GTK, a GPU integrada como padrão no Linux híbrido e remove apenas do processo do Cockpit as variáveis de offload herdadas. O uso da NVIDIA continua disponível explicitamente com `COCKPIT_USE_NVIDIA=1`.
- Inclui documentação de diagnóstico, roteiro de profiling e critérios para o teste prolongado de responsividade/GPU.
- Adiciona testes para o buffer limitado, telemetria, monitor adaptativo, escalonador Git, carga com 40 terminais e política nativa de GPU; o teste C++ também passa a fazer parte do workflow de release.

## Resultado esperado

- Menos CPU e I/O periódicos quando há muitos terminais e worktrees abertos.
- Menos trabalho no isolate de UI e menor pressão de memória durante saída intensa de terminal.
- Atualizações Git responsivas sem explosão de processos concorrentes.
- Menor risco de travamentos ligados ao caminho NVIDIA/EGL em notebooks híbridos, preservando a opção de uso dedicado.
- Melhor capacidade de medir regressões de desempenho sem coletar conteúdo dos terminais ou caminhos do usuário.

## Validação

- `flutter test test/core/bounded_text_buffer_test.dart test/core/linux_performance_diagnostics_test.dart test/domain/terminal_harness_monitor_test.dart test/performance/linux_terminal_stress_test.dart test/ui/git_controller_poll_test.dart` — 17 testes aprovados após rebase sobre a `main` atual.
- Teste nativo `gpu_environment_test.cc` compilado com C++14 e executado com sucesso.
- `git diff --check origin/main...HEAD` sem erros.
- `flutter analyze lib linux` não encontrou novos diagnósticos nas alterações. O comando ainda retorna os 55 avisos/informações preexistentes do projeto, documentados na revisão de desempenho.

## Observação

O teste interativo de 60 minutos em uma sessão gráfica real continua como etapa recomendada para o candidato a release, pois envolve apresentação Wayland/Hyprland e não deve restaurar ou executar silenciosamente comandos salvos do usuário em um ambiente automatizado.
