### PR TITLE
feat(cockpit): add workspace CLI and Linux ARM64 remote hosts

### DIFF
--- a/.github/workflows/cockpit-release.yml
+++ b/.github/workflows/cockpit-release.yml
@@ -154,14 +154,14 @@ jobs:
 
       # A CLI interna (`cockpit-cli`, crate em cockpit/cli) é compilada pelo
       # Run Script phase do Xcode como binário UNIVERSAL: o build_cli.sh gera
-      # arm64 + x86_64 e junta com `lipo`. O runner é Apple Silicon, então o
-      # target Intel precisa estar instalado — sem ele o app sai sem a fatia
-      # x86_64 e a CLI/hook não funcionam em Mac Intel.
-      - name: Rust + target Intel (CLI interna universal)
+      # arm64 + x86_64 e junta com `lipo`. O mesmo build empacota uma CLI Linux
+      # arm64 ao lado do cockpit-server cross-compiled para workspaces remotos.
+      - name: Rust + targets macOS universal e Linux arm64
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin \
+            aarch64-unknown-linux-gnu
           cargo --version
 
       - name: Baixa a fatia x86_64 do cockpit-server
@@ -234,6 +234,22 @@ jobs:
             want=$([ "$arch" = x64 ] && echo x86_64 || echo arm64)
             lipo -archs "$exe" | grep -q "$want" || {
               echo "::error::cockpit-server-$arch não é $want"; exit 1; }
+          done
+          # Gate do target enviado aos VMs de workspaces remotos. `file` prova
+          # que server, PTY e CLI são ELF aarch64, e não Mach-O do cliente.
+          LINUX_BUNDLE="$SERVER_BUNDLE/targets/linux-arm64"
+          for f in "$LINUX_BUNDLE/bin/cockpit-server" \
+                   "$LINUX_BUNDLE/bin/cockpit" \
+                   "$LINUX_BUNDLE/lib/libcockpit_pty.so" \
+                   "$LINUX_BUNDLE/lib/libanaki_mongodb.so" \
+                   "$LINUX_BUNDLE/lib/libanaki_mssql.so" \
+                   "$LINUX_BUNDLE/lib/libanaki_mysql.so" \
+                   "$LINUX_BUNDLE/lib/libanaki_postgres.so" \
+                   "$LINUX_BUNDLE/lib/libanaki_redis.so" \
+                   "$LINUX_BUNDLE/lib/libanaki_sqlite.so"; do
+            [ -f "$f" ] || { echo "::error::$f ausente"; exit 1; }
+            file "$f" | grep -q 'ELF 64-bit.*ARM aarch64' || {
+              echo "::error::$f não é Linux arm64"; file "$f"; exit 1; }
           done
           # Smoke test do binário assinado: sobe o servidor e exige o socket.
           # É o gate que faltava — o bundle universal da 1.28.0 passou por todas

--- a/cockpit/CLAUDE.md
+++ b/cockpit/CLAUDE.md
@@ -85,6 +85,8 @@ O `cargo` é resolvido pelo PATH e, como fallback, em `~/.cargo/bin` — o mesmo
 lugar onde o rustup instala. Isso cobre IDE/launcher que não herda o PATH do
 shell de login; se faltar mesmo, o CMake para no configure com a causa.
 
+- `rustup target add aarch64-unknown-linux-gnu` — uma vez; o build macOS usa
+  esse target + Zig para embarcar o cockpit-server/CLI dos hosts Linux arm64
 - `flutter pub get` — instala deps
 - `flutter analyze` — lint estático (deve passar zero issues)
 - `flutter test` — testes

--- a/cockpit/cli/src/commands.rs
+++ b/cockpit/cli/src/commands.rs
@@ -243,6 +243,305 @@ pub fn close_tab(args: &[String]) -> ! {
     std::process::exit(0)
 }
 
+// ---- workspaces -------------------------------------------------------------
+
+const NEW_WORKSPACE_HELP: &str = "cockpit new-workspace <path> [--host <ssh-target>] [--name <title>] [--json]
+  Adds a top-level workspace in Cockpit's sidebar (local or remote), selects it,
+  and ensures an initial terminal tab is opened.
+  Aliases: `cockpit open-workspace`, `cockpit new-remote-workspace`
+  If the directory is already open, focuses it and returns the existing workspace.
+  --host <target> SSH host or alias from ~/.ssh/config (creates a remote workspace)
+  --path <path>   path (alternative to positional <path>)
+  --name <title>  custom display title (default: folder name)
+  --tab-id <id>   caller tab (default: this tab / $COCKPIT_TAB_ID)
+  --json          output workspace as JSON: {\"id\": \"...\", \"name\": \"...\", \"path\": \"...\", \"tabs\": N}
+  Prints the workspace id.";
+
+pub fn new_workspace(args: &[String]) -> ! {
+    let mut path: Option<String> = None;
+    let mut host: Option<String> = None;
+    let mut name: Option<String> = None;
+    let mut tab_id: Option<String> = None;
+    let mut as_json = false;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if a == "--help" || a == "-h" {
+            println!("{NEW_WORKSPACE_HELP}");
+            std::process::exit(0);
+        }
+        if a == "--json" {
+            as_json = true;
+            i += 1;
+            continue;
+        }
+        if a == "--host" || a == "--remote" {
+            if i + 1 >= args.len() {
+                die("cockpit new-workspace: --host requires a value", 2);
+            }
+            i += 1;
+            host = Some(args[i].clone());
+            i += 1;
+            continue;
+        } else if let Some(v) = a.strip_prefix("--host=").or_else(|| a.strip_prefix("--remote=")) {
+            host = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        if a == "--path" {
+            if i + 1 >= args.len() {
+                die("cockpit new-workspace: --path requires a value", 2);
+            }
+            i += 1;
+            path = Some(args[i].clone());
+            i += 1;
+            continue;
+        } else if let Some(v) = a.strip_prefix("--path=") {
+            path = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        if a == "--name" {
+            if i + 1 >= args.len() {
+                die("cockpit new-workspace: --name requires a value", 2);
+            }
+            i += 1;
+            name = Some(args[i].clone());
+            i += 1;
+            continue;
+        } else if let Some(v) = a.strip_prefix("--name=") {
+            name = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        if a == "--tab-id" || a == "-t" {
+            if i + 1 >= args.len() {
+                die("cockpit: --tab-id requires a value", 2);
+            }
+            i += 1;
+            tab_id = Some(args[i].clone());
+            i += 1;
+            continue;
+        } else if let Some(v) = a.strip_prefix("--tab-id=") {
+            tab_id = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        if a.starts_with('-') {
+            die(&format!("cockpit: unknown flag \"{a}\""), 2);
+        }
+        if path.is_none() {
+            path = Some(a.to_string());
+        }
+        i += 1;
+    }
+
+    let raw_path = match path {
+        Some(p) if !p.is_empty() => p,
+        _ => die("cockpit new-workspace: missing <path> (or --path <path>)", 2),
+    };
+
+    let target_path = if host.is_some() {
+        // Caminho no HOST remoto: não resolve contra o cwd local
+        raw_path
+    } else {
+        resolve_path(&raw_path)
+    };
+
+    let mut cmd_args = Map::new();
+    cmd_args.insert("path".into(), json!(target_path));
+    if let Some(h) = host.filter(|h| !h.is_empty()) {
+        cmd_args.insert("host".into(), json!(h));
+    }
+    if let Some(n) = name.filter(|n| !n.is_empty()) {
+        cmd_args.insert("name".into(), json!(n));
+    }
+
+    let mut req = json!({"cmd": "new-workspace", "args": Value::Object(cmd_args)});
+    with_tab_id(&mut req, tab_id.or_else(self_tab_id));
+
+    let resp = transport::request(req, DEFAULT_TIMEOUT);
+    if !is_ok(&resp) {
+        fail_with(&resp);
+    }
+    let data = resp.get("data").cloned().unwrap_or_else(|| json!({}));
+    if as_json {
+        println!("{}", data);
+    } else {
+        let id = data.get("id").and_then(Value::as_str).unwrap_or("");
+        println!("{id}");
+    }
+    std::process::exit(0)
+}
+
+const CLOSE_WORKSPACE_HELP: &str = "cockpit close-workspace [<id|path>] [--tab-id <id>] [--json]
+  Closes a top-level project from Cockpit (ends its agents/tabs; folder on
+  disk is kept).
+  Without a target, closes the workspace owning the current tab (or currently
+  selected workspace).
+  Target may be a workspace UUID, directory path, or unique name.
+  --tab-id <id>   caller tab (default: this tab / $COCKPIT_TAB_ID)
+  --json          output as JSON: {\"id\": \"...\", \"path\": \"...\", \"closed\": true}
+  Prints the closed workspace id.";
+
+pub fn close_workspace(args: &[String]) -> ! {
+    let mut target: Option<String> = None;
+    let mut as_json = false;
+    let mut tab_id: Option<String> = None;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if a == "--help" || a == "-h" {
+            println!("{CLOSE_WORKSPACE_HELP}");
+            std::process::exit(0);
+        }
+        if a == "--json" {
+            as_json = true;
+            i += 1;
+            continue;
+        }
+        if a == "--tab-id" || a == "-t" {
+            if i + 1 >= args.len() {
+                die("cockpit: --tab-id requires a value", 2);
+            }
+            i += 1;
+            tab_id = Some(args[i].clone());
+            i += 1;
+            continue;
+        } else if let Some(v) = a.strip_prefix("--tab-id=") {
+            tab_id = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        if a.starts_with('-') {
+            die(&format!("cockpit: unknown flag \"{a}\""), 2);
+        }
+        if target.is_none() {
+            target = Some(a.to_string());
+        }
+        i += 1;
+    }
+
+    let mut cmd_args = Map::new();
+    if let Some(t) = target.filter(|t| !t.is_empty()) {
+        let resolved = if t.starts_with('~')
+            || t.starts_with('.')
+            || t.contains('/')
+            || t.contains('\\')
+        {
+            resolve_path(&t)
+        } else {
+            t
+        };
+        cmd_args.insert("target".into(), json!(resolved));
+    }
+    let mut req = json!({"cmd": "close-workspace", "args": Value::Object(cmd_args)});
+    with_tab_id(&mut req, tab_id.or_else(self_tab_id));
+
+    let resp = transport::request(req, DEFAULT_TIMEOUT);
+    if !is_ok(&resp) {
+        fail_with(&resp);
+    }
+    let data = resp.get("data").cloned().unwrap_or_else(|| json!({}));
+    if as_json {
+        println!("{}", data);
+    } else {
+        let id = data.get("id").and_then(Value::as_str).unwrap_or("");
+        println!("{id}");
+    }
+    std::process::exit(0)
+}
+
+const RENAME_WORKSPACE_HELP: &str = "cockpit rename-workspace [<id|path>] <new-name> [--tab-id <id>] [--json]
+  Renames the display title of a workspace in Cockpit's rail.
+  Target may be a workspace UUID, directory path, or unique name.
+  Without target, renames the workspace owning the current tab.
+  --tab-id <id>   caller tab (default: this tab / $COCKPIT_TAB_ID)
+  --json          output as JSON: {\"id\": \"...\", \"name\": \"...\", \"path\": \"...\"}
+  Prints the updated workspace id.";
+
+pub fn rename_workspace(args: &[String]) -> ! {
+    let mut target: Option<String> = None;
+    let mut new_name: Option<String> = None;
+    let mut tab_id: Option<String> = None;
+    let mut as_json = false;
+
+    let mut i = 0usize;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if a == "--help" || a == "-h" {
+            println!("{RENAME_WORKSPACE_HELP}");
+            std::process::exit(0);
+        }
+        if a == "--json" {
+            as_json = true;
+            i += 1;
+            continue;
+        }
+        if a == "--tab-id" || a == "-t" {
+            if i + 1 >= args.len() {
+                die("cockpit: --tab-id requires a value", 2);
+            }
+            i += 1;
+            tab_id = Some(args[i].clone());
+            i += 1;
+            continue;
+        } else if let Some(v) = a.strip_prefix("--tab-id=") {
+            tab_id = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        if a.starts_with('-') {
+            die(&format!("cockpit: unknown flag \"{a}\""), 2);
+        }
+        if target.is_none() {
+            target = Some(a.to_string());
+        } else if new_name.is_none() {
+            new_name = Some(a.to_string());
+        }
+        i += 1;
+    }
+
+    let (target_val, raw_name) = match (target, new_name) {
+        (Some(t), Some(n)) => (Some(t), n),
+        (Some(n), None) => (None, n),
+        _ => die("cockpit rename-workspace: missing workspace name", 2),
+    };
+
+    let mut cmd_args = Map::new();
+    if let Some(t) = target_val.filter(|t| !t.is_empty()) {
+        let resolved = if t.starts_with('~')
+            || t.starts_with('.')
+            || t.contains('/')
+            || t.contains('\\')
+        {
+            resolve_path(&t)
+        } else {
+            t
+        };
+        cmd_args.insert("target".into(), json!(resolved));
+    }
+    cmd_args.insert("name".into(), json!(raw_name));
+
+    let mut req = json!({"cmd": "rename-workspace", "args": Value::Object(cmd_args)});
+    with_tab_id(&mut req, tab_id.or_else(self_tab_id));
+
+    let resp = transport::request(req, DEFAULT_TIMEOUT);
+    if !is_ok(&resp) {
+        fail_with(&resp);
+    }
+    let data = resp.get("data").cloned().unwrap_or_else(|| json!({}));
+    if as_json {
+        println!("{}", data);
+    } else {
+        let id = data.get("id").and_then(Value::as_str).unwrap_or("");
+        println!("{id}");
+    }
+    std::process::exit(0)
+}
+
 // ---- browse -----------------------------------------------------------------
 
 const BROWSE_HELP: &str = "cockpit browse <url> [--json]

--- a/cockpit/cli/src/main.rs
+++ b/cockpit/cli/src/main.rs
@@ -66,6 +66,11 @@ fn main() {
         "mongo" => commands::mongo(args),
         "new-tab" => commands::new_tab(args),
         "close-tab" => commands::close_tab(args),
+        "new-workspace" | "open-workspace" | "new-remote-workspace" => {
+            commands::new_workspace(args)
+        }
+        "close-workspace" => commands::close_workspace(args),
+        "rename-workspace" => commands::rename_workspace(args),
         "browse" => commands::browse_url(args),
         "orchestrate" => commands::orchestrate(args),
         "note" => commands::note(args),

--- a/cockpit/cli/tests/wire.rs
+++ b/cockpit/cli/tests/wire.rs
@@ -487,3 +487,171 @@ fn sem_app_nenhum_falha_com_exit_3() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+#[test]
+fn new_workspace_manda_path_resolvido_e_nome_opcional() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &["new-workspace", "my/project", "--name", "My Project"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-1","name":"My Project","path":"/resolved/my/project","tabs":1}}"#,
+    );
+    assert_eq!(req["type"], "cmd");
+    assert_eq!(req["cmd"], "new-workspace");
+    assert!(
+        req["args"]["path"].as_str().unwrap().ends_with("my/project"),
+        "path deve ser absoluto: {}",
+        req["args"]["path"]
+    );
+    assert_eq!(req["args"]["name"], "My Project");
+    assert_eq!(stdout.trim(), "ws-uuid-1");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn new_remote_workspace_com_flags_host_e_path() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &[
+            "new-remote-workspace",
+            "--host",
+            "workspace-scott-meyer-2",
+            "--path",
+            "/home/ubuntu/repo-worktrees/task-1",
+            "--name",
+            "task-1",
+        ],
+        r#"{"ok":true,"data":{"id":"__remote__1::/home/ubuntu/repo-worktrees/task-1","name":"task-1","path":"/home/ubuntu/repo-worktrees/task-1","host":"workspace-scott-meyer-2","tabs":1}}"#,
+    );
+    assert_eq!(req["type"], "cmd");
+    assert_eq!(req["cmd"], "new-workspace");
+    assert_eq!(req["args"]["host"], "workspace-scott-meyer-2");
+    assert_eq!(
+        req["args"]["path"],
+        "/home/ubuntu/repo-worktrees/task-1",
+        "caminho remoto deve ser preservado exatamente como passado"
+    );
+    assert_eq!(req["args"]["name"], "task-1");
+    assert_eq!(
+        stdout.trim(),
+        "__remote__1::/home/ubuntu/repo-worktrees/task-1"
+    );
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn new_workspace_com_host_e_posicional_remoto() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &[
+            "new-workspace",
+            "/home/ubuntu/worktree",
+            "--host",
+            "workspace-vm",
+            "--json",
+        ],
+        r#"{"ok":true,"data":{"id":"__remote__2::/home/ubuntu/worktree","name":"worktree","path":"/home/ubuntu/worktree","host":"workspace-vm","tabs":1}}"#,
+    );
+    assert_eq!(req["cmd"], "new-workspace");
+    assert_eq!(req["args"]["host"], "workspace-vm");
+    assert_eq!(req["args"]["path"], "/home/ubuntu/worktree");
+    let parsed: Value = serde_json::from_str(&stdout).expect("JSON válido");
+    assert_eq!(parsed["id"], "__remote__2::/home/ubuntu/worktree");
+    assert_eq!(parsed["host"], "workspace-vm");
+    assert_eq!(code, 0);
+}
+
+
+#[test]
+fn new_workspace_json_ecoa_o_objeto_completo() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &["new-workspace", "/tmp/proj", "--json"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-2","name":"proj","path":"/tmp/proj","tabs":1}}"#,
+    );
+    assert_eq!(req["cmd"], "new-workspace");
+    assert_eq!(req["args"]["path"], "/tmp/proj");
+    assert!(req["args"].get("name").is_none());
+    let parsed: Value = serde_json::from_str(&stdout).expect("JSON válido");
+    assert_eq!(parsed["id"], "ws-uuid-2");
+    assert_eq!(parsed["tabs"], 1);
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn open_workspace_e_alias_de_new_workspace() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &["open-workspace", "/tmp/proj2"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-3","name":"proj2","path":"/tmp/proj2","tabs":1}}"#,
+    );
+    assert_eq!(req["cmd"], "new-workspace");
+    assert_eq!(req["args"]["path"], "/tmp/proj2");
+    assert_eq!(stdout.trim(), "ws-uuid-3");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn close_workspace_com_alvo_manda_target() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &["close-workspace", "ws-uuid-1"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-1","path":"/tmp/proj","closed":true}}"#,
+    );
+    assert_eq!(req["cmd"], "close-workspace");
+    assert_eq!(req["args"]["target"], "ws-uuid-1");
+    assert_eq!(stdout.trim(), "ws-uuid-1");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn close_workspace_sem_alvo_cai_na_tab_do_ambiente() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &["close-workspace"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-4","path":"/tmp/proj4","closed":true}}"#,
+    );
+    assert_eq!(req["cmd"], "close-workspace");
+    assert!(req["args"].get("target").is_none());
+    assert_eq!(req["tabId"], "t7");
+    assert_eq!(stdout.trim(), "ws-uuid-4");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn close_workspace_json_ecoa_data() {
+    let (_, stdout, _, code) = run_against_fake_app(
+        &["close-workspace", "ws-uuid-1", "--json"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-1","path":"/tmp/proj","closed":true}}"#,
+    );
+    let parsed: Value = serde_json::from_str(&stdout).expect("JSON válido");
+    assert_eq!(parsed["closed"], true);
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn rename_workspace_manda_target_e_name() {
+    let (req, stdout, _, code) = run_against_fake_app(
+        &["rename-workspace", "ws-uuid-1", "Novo Nome"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-1","name":"Novo Nome","path":"/tmp/proj"}}"#,
+    );
+    assert_eq!(req["cmd"], "rename-workspace");
+    assert_eq!(req["args"]["target"], "ws-uuid-1");
+    assert_eq!(req["args"]["name"], "Novo Nome");
+    assert_eq!(stdout.trim(), "ws-uuid-1");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn rename_workspace_json_ecoa_data() {
+    let (_, stdout, _, code) = run_against_fake_app(
+        &["rename-workspace", "ws-uuid-1", "Novo Nome", "--json"],
+        r#"{"ok":true,"data":{"id":"ws-uuid-1","name":"Novo Nome","path":"/tmp/proj"}}"#,
+    );
+    let parsed: Value = serde_json::from_str(&stdout).expect("JSON válido");
+    assert_eq!(parsed["name"], "Novo Nome");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn workspace_erros_propagam_exit_1() {
+    let (_, _, stderr, code) = run_against_fake_app(
+        &["new-workspace", "/nonexistent"],
+        r#"{"ok":false,"error":"directory not found: /nonexistent"}"#,
+    );
+    assert_eq!(code, 1);
+    assert!(stderr.contains("directory not found: /nonexistent"));
+}
+

--- a/cockpit/cli/text/help.txt
+++ b/cockpit/cli/text/help.txt
@@ -21,6 +21,13 @@ USAGE:
                                                open a new terminal tab (prints its id)
   cockpit close-tab [<label|tab-id>]           close a tab (default: the current
                                                one) — prints the closed tab id
+  cockpit new-workspace <path> [--host <host>] [--name <name>] [--json]
+                                               create/open a workspace (local or remote)
+  cockpit new-remote-workspace --host <h> --path <p> [--name <n>] [--json]
+                                               create/open a remote workspace
+  cockpit close-workspace [<id|path>] [--json] close a top-level workspace
+  cockpit rename-workspace <id|path> <name> [--json]
+                                               rename a workspace in the sidebar
   cockpit db <list|schema|query|run|execute>   SQL databases (see `cockpit db --help`)
   cockpit redis [browse] --db <conn> ...       Redis command / open key table
   cockpit mongo [browse] --db <conn> [--database <name>] ...
@@ -111,11 +118,34 @@ CLOSE-TAB:
   ends with it. Closing the last tab of a split removes the split; closing the
   last tab of a workspace leaves an empty tab (same as the tab's "x" in the UI).
 
+WORKSPACES (new-workspace / close-workspace / rename-workspace):
+  cockpit new-workspace <path> [--host <ssh-target>] [--name <title>] [--json]
+  cockpit new-remote-workspace --host <ssh-target> --path <remote-path> [--name <title>] [--json]
+  Alias: `cockpit open-workspace`. Adds a top-level workspace in Cockpit's
+  sidebar (local or remote), selects it, and ensures an initial terminal tab is
+  opened. For remote workspaces, --host specifies the SSH host or ~/.ssh/config
+  alias (automatically registered if not already present).
+  Idempotent: if already open, selects it and returns its info. Prints the
+  workspace id (or JSON object with --json).
+
+  cockpit close-workspace [<id|path>] [--json]
+  Closes a top-level workspace (ends its tabs; files on disk are kept). Target
+  may be a UUID, directory path, or unique name (default: current workspace).
+  Prints the closed workspace id.
+
+  cockpit rename-workspace [<id|path>] <new-name> [--json]
+  Updates the display title of a workspace in the sidebar. Target may be a UUID,
+  directory path, or unique name (default: current workspace).
+
 EXAMPLES:
   cockpit send "echo hi" && cockpit send-key Enter
   id=$(cockpit new-tab --cwd ~/proj --title Worker --split h)
   cockpit send --tab-id "$id" --enter "npm test"   # text + Enter in one call
   cockpit close-tab "$id"                      # close it when done (or: Worker)
+  ws=$(cockpit new-workspace ~/proj/my-service --name "My Service")
+  cockpit rename-workspace "$ws" "Renamed Service"
+  cockpit close-workspace "$ws"
+  rws=$(cockpit new-remote-workspace --host workspace-vm --path /home/ubuntu/wt --name "Task 1")
   cockpit send-key C-c
   cockpit send --tab-id t3 --enter "ls"
   cockpit .zprofile          # opens the file in the viewer (relative to tab cwd)

--- a/cockpit/cli/text/skill.md
+++ b/cockpit/cli/text/skill.md
@@ -222,6 +222,18 @@ Cockpit tabs (it is not on the global PATH).
   accepts). Resolve a tab by its stable `label`, not the dynamic `title`.
 - `cockpit list-workspaces [--json]` — open projects: `id` (opaque UUID),
   `name`, `path` (root on disk), `tabs`.
+- `cockpit new-workspace <path> [--host <ssh-target>] [--name <title>] [--json]`
+  (aliases: `open-workspace`, `new-remote-workspace`) — add `<path>` as a top-level
+  project in Cockpit's rail (local or remote), select it, and ensure an initial
+  terminal tab is opened. For remote workspaces, pass `--host` (SSH host or
+  `~/.ssh/config` alias). Idempotent: focuses an already open workspace.
+  Prints the workspace id (or full object with `--json`).
+- `cockpit close-workspace [<id|path>] [--json]` — remove a top-level project
+  from Cockpit (ends its tabs; files on disk are kept). Target may be an id,
+  path, or unique name (default: current workspace). Prints the closed workspace id.
+- `cockpit rename-workspace [<id|path>] <new-name> [--json]` — update the
+  display title of a workspace in the rail. Target may be an id, path, or
+  unique name (default: current workspace).
 - `cockpit orchestrate <file.ckp> [--json]` — apply a **pane layout** to the
   current workspace: opens the terminals/splits declared in the file and types
   each pane's `command`. Idempotent merge: a pane whose `name` already exists

--- a/cockpit/lib/app/cockpit/data/remote/host_shell/host_shell.dart
+++ b/cockpit/lib/app/cockpit/data/remote/host_shell/host_shell.dart
@@ -13,6 +13,9 @@
 library;
 
 import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart' show sha256;
 
 /// Como alcançar o `cockpit-server` de um host.
 ///
@@ -83,7 +86,70 @@ class ClientBundle {
   /// Raiz do bundle: `<root>/bin/cockpit-server` + `<root>/lib/*`.
   final String root;
   final String serverBinary;
+
+  /// Arquivos que realmente chegam ao host, com seus nomes canônicos lá.
+  ///
+  /// O bundle macOS universal pode selecionar `cockpit-server-arm64`, mas o
+  /// host sempre o recebe como `bin/cockpit-server`; o manifesto descreve o
+  /// destino, não o nome incidental da fatia local.
+  List<ClientBundleFile> deployedFiles() {
+    final files = <ClientBundleFile>[
+      ClientBundleFile(serverBinary, 'bin/cockpit-server'),
+    ];
+    final cli = File('$root/bin/cockpit');
+    if (cli.existsSync()) files.add(ClientBundleFile(cli.path, 'bin/cockpit'));
+
+    final libDir = Directory('$root/lib');
+    if (libDir.existsSync()) {
+      final libs = libDir.listSync().whereType<File>().toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+      for (final lib in libs) {
+        files.add(
+          ClientBundleFile(lib.path, 'lib/${_bundleBasename(lib.path)}'),
+        );
+      }
+    }
+    files.sort((a, b) => a.remotePath.compareTo(b.remotePath));
+    return files;
+  }
+
+  /// Manifesto `sha256sum -c` determinístico de TODO arquivo implantado.
+  /// O digest do próprio manifesto é o marcador barato de freshness.
+  Future<ClientBundleManifest> buildManifest() async {
+    final files = deployedFiles();
+    final lines = <String>[];
+    for (final file in files) {
+      final digest = sha256.convert(await File(file.localPath).readAsBytes());
+      lines.add('$digest  ${file.remotePath}');
+    }
+    final contents = '${lines.join('\n')}\n';
+    return ClientBundleManifest(
+      files: files,
+      contents: contents,
+      digest: sha256.convert(utf8.encode(contents)).toString(),
+    );
+  }
 }
+
+class ClientBundleFile {
+  const ClientBundleFile(this.localPath, this.remotePath);
+  final String localPath;
+  final String remotePath;
+}
+
+class ClientBundleManifest {
+  const ClientBundleManifest({
+    required this.files,
+    required this.contents,
+    required this.digest,
+  });
+
+  final List<ClientBundleFile> files;
+  final String contents;
+  final String digest;
+}
+
+String _bundleBasename(String path) => path.split(Platform.pathSeparator).last;
 
 /// Executor de comandos no host. É sempre o mesmo canal SSH do resto do
 /// conector — o dialeto decide o texto do comando, não como ele viaja.
@@ -127,10 +193,15 @@ abstract class HostShell {
   Future<bool> serverInstalled();
 
   /// SHA-256 do binário do servidor no host, ou `null` se indisponível.
-  /// Na dúvida devolve `null`: não se mexe num servidor que está funcionando.
+  /// Mantido para os dialetos/testes existentes; freshness POSIX usa o
+  /// manifesto completo abaixo.
   Future<String?> serverSha256();
 
-  /// Derruba o servidor em execução (troca de binário desatualizado).
+  /// SHA-256 do manifesto instalado por último. Dialetos que instalam a partir
+  /// do próprio host (Windows) não usam este marcador.
+  Future<String?> bundleManifestSha256() async => null;
+
+  /// Derruba o servidor em execução (troca de bundle desatualizado).
   Future<void> killServer();
 
   /// Instala a partir do bundle do CLIENTE (POSIX). Lança em falha.

--- a/cockpit/lib/app/cockpit/data/remote/host_shell/posix_host_shell.dart
+++ b/cockpit/lib/app/cockpit/data/remote/host_shell/posix_host_shell.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:cockpit/app/cockpit/data/remote/host_shell/host_shell.dart';
@@ -8,6 +9,39 @@ class PosixHostShell extends HostShell {
   PosixHostShell({required super.probe, required super.exec});
 
   static const _serverDir = r'$HOME/.cockpit/server';
+  static const _manifestPath = '$_serverDir/bundle.manifest';
+  static const _installLock = r'$HOME/.cockpit/server.install.lock';
+
+  // Diretórios nunca podem ser promovidos para o live com `mv source live`:
+  // se `live` surgir entre o teste e o mv, POSIX manda `source` para dentro
+  // dele. `rename(2)` troca/falha no caminho exato e, portanto, não aninha.
+  static const _noNestRename = r'''
+no_nest_rename() {
+  if mv --version 2>/dev/null | grep -q 'GNU coreutils'; then
+    mv -T -- "$1" "$2"
+    return $?
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$1" "$2" <<'PY'
+import os
+import sys
+
+try:
+    os.rename(sys.argv[1], sys.argv[2])
+except OSError as error:
+    print('cockpit-server rename failed: %s' % error, file=sys.stderr)
+    raise SystemExit(1)
+PY
+    return $?
+  fi
+  if command -v perl >/dev/null 2>&1; then
+    perl -e 'rename($ARGV[0], $ARGV[1]) or die "cockpit-server rename failed: $!\n"' "$1" "$2"
+    return $?
+  fi
+  echo "cockpit-server needs GNU mv -T, python3, or perl for a safe directory rename" >&2
+  return 69
+}
+''';
 
   @override
   String get serverBinaryPath => '$_serverDir/bin/cockpit-server';
@@ -47,7 +81,8 @@ class PosixHostShell extends HostShell {
   @override
   Future<bool> serverInstalled() async {
     final (code, out, _) = await exec(
-      'test -x $serverBinaryPath && echo yes || echo no',
+      'test -x $serverBinaryPath && test -f $_manifestPath && '
+      'echo yes || echo no',
     );
     return code == 0 && out.trim().endsWith('yes');
   }
@@ -64,39 +99,211 @@ class PosixHostShell extends HostShell {
   }
 
   @override
+  Future<String?> bundleManifestSha256() async {
+    final (code, out, _) = await exec(
+      'sha256sum $_manifestPath 2>/dev/null || '
+      'shasum -a 256 $_manifestPath 2>/dev/null',
+    );
+    if (code != 0) return null;
+    final token = out.trim().split(RegExp(r'\s+')).firstOrNull;
+    return (token != null && token.length == 64) ? token.toLowerCase() : null;
+  }
+
+  @override
   Future<void> killServer() async {
     await exec('pkill -f "$serverBinaryPath" || true');
   }
 
   @override
   Future<void> installFromClient(ClientBundle bundle) async {
-    Future<void> push(String local, String remote) async {
-      final bytes = await File(local).readAsBytes();
-      final (code, _, err) = await exec(
-        'mkdir -p ~/.cockpit/server/bin ~/.cockpit/server/lib && '
-        'cat > $remote && chmod +x $remote',
-        stdinBytes: bytes,
-      );
-      if (code != 0) throw HostShellException(err);
-    }
+    final manifest = await bundle.buildManifest();
+    final token = '$pid-${DateTime.now().microsecondsSinceEpoch}';
+    final stage = r'$HOME/.cockpit/server.staging-' + token;
+    final backup = r'$HOME/.cockpit/server.previous-' + token;
+    final conflict = r'$HOME/.cockpit/server.conflict-' + token;
 
-    await push(bundle.serverBinary, '~/.cockpit/server/bin/cockpit-server');
-
-    final libDir = Directory('${bundle.root}/lib');
-    if (libDir.existsSync()) {
-      for (final f in libDir.listSync().whereType<File>()) {
-        await push(f.path, '~/.cockpit/server/lib/${_basename(f.path)}');
+    Future<void> run(String command, {List<int>? stdinBytes}) async {
+      final (code, out, err) = await exec(command, stdinBytes: stdinBytes);
+      if (code != 0) {
+        throw HostShellException(err.isNotEmpty ? err : out);
       }
     }
 
-    // CLI ao lado do servidor: o servidor põe a pasta dela no PATH das PTYs, e
-    // é o que faz `cockpit …` responder num terminal remoto. Vai junto em toda
-    // (re)instalação, senão ficaria mais velha que o servidor que a invoca.
-    final cli = File('${bundle.root}/bin/cockpit');
-    if (cli.existsSync()) {
-      await push(cli.path, '~/.cockpit/server/bin/cockpit');
-      // Alias curto: symlink, que no POSIX custa zero em disco.
-      await exec('ln -sf cockpit ~/.cockpit/server/bin/ck');
+    var locked = false;
+    var promotionStarted = false;
+    var swapped = false;
+    try {
+      // `mkdir` é o mutex portátil entre processos/clientes. O mtime recebe
+      // heartbeat antes de cada upload; só um lock sem heartbeat por 10min é
+      // recuperado. Espera limitada evita deixar a UI presa indefinidamente.
+      await run('''
+mkdir -p "\$HOME/.cockpit"
+attempt=0
+while ! mkdir "$_installLock" 2>/dev/null; do
+  if find "$_installLock" -prune -mmin +10 -print 2>/dev/null | grep -q .; then
+    abandoned="$_installLock.abandoned-$token"
+    if mv "$_installLock" "\$abandoned" 2>/dev/null; then
+      rm -rf "\$abandoned"
+      continue
+    fi
+  fi
+  attempt=\$((attempt + 1))
+  if [ "\$attempt" -ge 30 ]; then
+    echo "cockpit-server install lock timed out" >&2
+    exit 75
+  fi
+  sleep 1
+done
+printf '%s\n' '$token' > "$_installLock/owner"
+touch "$_installLock"
+''');
+      locked = true;
+
+      Future<void> runLocked(String command, {List<int>? stdinBytes}) => run('''
+if [ "\$(cat "$_installLock/owner" 2>/dev/null)" != "$token" ]; then
+  echo "cockpit-server install lock lost" >&2
+  exit 75
+fi
+touch "$_installLock"
+$command
+''', stdinBytes: stdinBytes);
+
+      Future<void> push(ClientBundleFile file) async {
+        final parent = file.remotePath.split('/').first;
+        await runLocked(
+          'mkdir -p "$stage/$parent" && '
+          'cat > "$stage/${file.remotePath}" && '
+          'chmod +x "$stage/${file.remotePath}"',
+          stdinBytes: await File(file.localPath).readAsBytes(),
+        );
+      }
+
+      // Sob o lock, recupera um swap antigo interrompido e remove somente
+      // stages que não podem mais pertencer a uma transação ativa.
+      await runLocked('''
+$_noNestRename
+if { [ ! -e "$_serverDir" ] && [ ! -L "$_serverDir" ]; }; then
+  set -- "\$HOME/.cockpit"/server.previous-*
+  if [ -e "\$1" ] || [ -L "\$1" ]; then
+    no_nest_rename "\$1" "$_serverDir" || {
+      echo "cockpit-server could not safely recover prior backup" >&2
+      exit 76
+    }
+  fi
+fi
+for stale in "\$HOME/.cockpit"/server.staging-*; do
+  if [ -d "\$stale" ]; then rm -rf "\$stale"; fi
+done
+if [ -e "$backup" ] || [ -L "$backup" ]; then
+  echo "cockpit-server transaction backup path is occupied: $backup" >&2
+  exit 76
+fi
+mkdir -p "$stage"
+''');
+
+      for (final file in manifest.files) {
+        await push(file);
+      }
+
+      // O marcador vai por ÚLTIMO: sem ele, serverInstalled() trata qualquer
+      // resto de upload interrompido como incompleto e tenta de novo.
+      await runLocked(
+        'cat > "$stage/bundle.manifest"',
+        stdinBytes: utf8.encode(manifest.contents),
+      );
+
+      // Verifica cada byte ainda no staging e só então promove. O lock impede
+      // dois instaladores cooperantes. Renames para o live usam uma primitiva
+      // que nunca interpreta um destino que apareceu na corrida como diretório.
+      promotionStarted = true;
+      await runLocked('''
+set -eu
+$_noNestRename
+rollback_live() {
+  if [ ! -e "$backup" ] && [ ! -L "$backup" ]; then return 0; fi
+  if [ -e "$_serverDir" ] || [ -L "$_serverDir" ]; then
+    if [ -e "$conflict" ] || [ -L "$conflict" ]; then
+      echo "cockpit-server rollback conflict path is occupied: $conflict" >&2
+      return 1
+    fi
+    if ! mv "$_serverDir" "$conflict"; then
+      echo "cockpit-server could not quarantine unexpected live directory" >&2
+      return 1
+    fi
+  fi
+  if [ -e "$_serverDir" ] || [ -L "$_serverDir" ]; then
+    echo "cockpit-server live directory still exists during rollback" >&2
+    return 1
+  fi
+  no_nest_rename "$backup" "$_serverDir"
+}
+cd "$stage"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c bundle.manifest
+else
+  shasum -a 256 -c bundle.manifest
+fi
+if [ -x bin/cockpit ]; then ln -sf cockpit bin/ck; fi
+if [ -e "$_serverDir" ] || [ -L "$_serverDir" ]; then
+  mv "$_serverDir" "$backup"
+fi
+if [ -e "$_serverDir" ] || [ -L "$_serverDir" ]; then
+  rollback_live ||
+    echo "cockpit-server rollback incomplete; backup preserved at $backup" >&2
+  echo "cockpit-server live directory changed during promotion" >&2
+  exit 76
+fi
+if no_nest_rename "$stage" "$_serverDir"; then
+  # Só o sucesso definitivo da promoção autoriza apagar o known-good.
+  rm -rf "$backup" || true
+else
+  rollback_live ||
+    echo "cockpit-server rollback incomplete; backup preserved at $backup" >&2
+  exit 1
+fi
+''');
+      swapped = true;
+    } finally {
+      if (locked) {
+        // Ainda sob o lock, repara a janela live→backup caso o transporte tenha
+        // caído entre os dois renames. Um live ambíguo é preservado no conflito
+        // desta transação; o backup só volta depois de o caminho live sumir.
+        if (!swapped) {
+          try {
+            final failedStageCleanup = promotionStarted
+                ? ''
+                : 'rm -rf "$stage"';
+            await exec('''
+$_noNestRename
+if [ "\$(cat "$_installLock/owner" 2>/dev/null)" = "$token" ]; then
+  if [ -e "$backup" ] || [ -L "$backup" ]; then
+    if [ -e "$_serverDir" ] || [ -L "$_serverDir" ]; then
+      if [ ! -e "$conflict" ] && [ ! -L "$conflict" ]; then
+        mv "$_serverDir" "$conflict" || true
+      fi
+    fi
+    if { [ ! -e "$_serverDir" ] && [ ! -L "$_serverDir" ]; }; then
+      no_nest_rename "$backup" "$_serverDir" ||
+        echo "cockpit-server final recovery left backup at $backup" >&2
+    fi
+  fi
+  $failedStageCleanup
+fi
+''');
+          } on Object {
+            // Transporte caiu: o próximo dono recupera backup e stages stale.
+          }
+        }
+        try {
+          await exec('''
+if [ "\$(cat "$_installLock/owner" 2>/dev/null)" = "$token" ]; then
+  rm -rf "$_installLock"
+fi
+''');
+        } on Object {
+          // O lock ganha recovery por mtime se o transporte não voltar.
+        }
+      }
     }
   }
 
@@ -130,9 +337,6 @@ class PosixHostShell extends HostShell {
     );
     return out;
   }
-
-  static String _basename(String path) =>
-      path.split(Platform.pathSeparator).last;
 }
 
 /// Falha crua do host (stderr de terceiros). Vira `detail` de um

--- a/cockpit/lib/app/cockpit/data/remote/remote_host_connector.dart
+++ b/cockpit/lib/app/cockpit/data/remote/remote_host_connector.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:crypto/crypto.dart' show sha256;
-
 import 'package:cockpit/app/cockpit/data/remote/dartssh_host_connection.dart';
 import 'package:cockpit/app/cockpit/data/remote/mobile_ssh_key_store.dart';
 import 'package:cockpit/app/cockpit/data/remote/ssh_worker_connection.dart';
@@ -60,6 +58,19 @@ enum RemoteHostErrorKind {
   hostKeyChanged,
 }
 
+/// Gate one-shot que só fecha depois de um probe concluído. Exceção mantém o
+/// gate aberto para o retry; separado para testar a semântica sem SSH real.
+class ServerFreshnessProbeGate {
+  bool completed = false;
+
+  Future<bool> run(Future<bool> Function() probe) async {
+    if (completed) return false;
+    final result = await probe();
+    completed = true;
+    return result;
+  }
+}
+
 class RemoteHostException implements Exception {
   const RemoteHostException(this.kind, [this.detail]);
   final RemoteHostErrorKind kind;
@@ -90,12 +101,11 @@ class RemoteHostConnector {
 
   final RemoteHost host;
 
-  /// Resolve o binário local do cockpit-server (o mesmo do sidecar) usado como
-  /// fonte do bootstrap, para a arquitetura pedida (`arm64` | `x64`). Quem
-  /// manda é o `uname -sm` DO HOST, não a arquitetura desta máquina: um bundle
-  /// macOS traz as duas fatias, e mandar a errada instalava um binário que o
-  /// host não executa — falha que só aparecia como "não conectou".
-  final String? Function({String? arch}) localServerBinaryResolver;
+  /// Resolve o cockpit-server embarcado usado como fonte do bootstrap, para o
+  /// sistema e arquitetura pedidos (`darwin`/`linux`, `arm64`/`x64`). Quem
+  /// manda é o probe DO HOST, não a plataforma desta máquina: uma Release
+  /// macOS também pode trazer um target Linux para workspaces remotos.
+  final String? Function({String? os, String? arch}) localServerBinaryResolver;
 
   /// Resolve a senha SSH do host (auth por senha), lida do Keychain sob
   /// demanda. `null` = auth por chave (default). Plano 60, Wave C.
@@ -289,12 +299,29 @@ class RemoteHostConnector {
     // pronto — o bootstrap só rodava quando ninguém atendia, então um host
     // instalado uma vez ficava congelado para sempre naquela versão. Uma vez
     // por host por sessão (a comparação custa um SSH).
-    if (connection != null && !_serverFreshnessChecked) {
-      _serverFreshnessChecked = true;
-      if (await _remoteServerIsStale(shell)) {
-        _staleServer = true;
-        await connection.close();
-        connection = null;
+    if (connection != null && !_serverFreshness.completed) {
+      try {
+        if (await _serverFreshness.run(() => _remoteServerIsStale(shell))) {
+          _staleServer = true;
+          await connection.close();
+          connection = null;
+        }
+      } on Object {
+        // O probe usa o mesmo transporte SSH. Se ele falha, não adota a
+        // conexão meio-aberta nem vaza o túnel; e o gate continua aberto para
+        // a próxima tentativa.
+        try {
+          await connection?.close();
+        } on Object {
+          // Preserva a falha original do probe.
+        }
+        try {
+          await tunnel.close();
+        } on Object {
+          // Preserva a falha original do probe.
+        }
+        _tunnel = null;
+        rethrow;
       }
     }
     if (connection == null) {
@@ -534,50 +561,43 @@ class RemoteHostConnector {
   /// oposto da promessa de retomar de onde parou.
   static const _remoteIdleSeconds = 120;
 
-  /// `true` quando o binário do host **existe mas é diferente** do que este
-  /// cliente instalaria: o processo velho precisa morrer para o novo valer.
+  /// `true` quando o bundle do host difere do que este cliente instalaria: o
+  /// processo velho precisa morrer para a troca transacional valer.
   bool _staleServer = false;
 
   /// A comparação de versão do servidor roda uma vez por host por sessão —
   /// reconectar (o que acontece a cada oscilação de rede) não paga o SSH extra
   /// de novo.
-  bool _serverFreshnessChecked = false;
+  final _serverFreshness = ServerFreshnessProbeGate();
 
-  /// Compara o `cockpit-server` do host com o que este cliente enviaria.
+  /// Compara o manifesto de TODO o bundle com o que este cliente enviaria.
   ///
   /// Só vale quando o cliente é a FONTE da instalação: num host Windows quem
   /// instala é o próprio host, a partir do bundle do app de lá (D2), então o
-  /// binário local desta máquina não é referência de nada — comparar acusaria
-  /// "desatualizado" em todo boot e derrubaria o servidor remoto sem motivo.
+  /// binário local desta máquina não é referência de nada. Para POSIX, o
+  /// resolver devolve `null` se este build não embarca aquele target; nesse
+  /// caso o cliente também não tem autoridade para julgar o servidor remoto.
   Future<bool> _remoteServerIsStale(HostShell shell) async {
     if (shell.installsFromHostBundle) return false;
-    // Host de OUTRA plataforma: este cliente não tem binário para enviar (o
-    // `.deb` traz só o ELF do Linux, o `.app` só o Mach-O), então não é fonte
-    // da instalação e não tem autoridade para julgá-la.
-    //
-    // Sem esta linha o resolver caía no nome sem sufixo e devolvia o binário
-    // da PRÓPRIA plataforma: o hash nunca batia com o do host, todo boot
-    // acusava "desatualizado", e o cliente DERRUBAVA uma conexão que estava
-    // funcionando para tentar um bootstrap que o guard de OS logo abaixo
-    // recusa. Cliente Linux + host macOS ficava sem conexão nenhuma.
-    if (shell.probe.os != _localOsName) return false;
-    final local = localServerBinaryResolver(arch: shell.probe.arch);
+    final local = localServerBinaryResolver(
+      os: shell.probe.os,
+      arch: shell.probe.arch,
+    );
     if (local == null) return false;
-    final remoteHash = await shell.serverSha256();
-    if (remoteHash == null) return false;
     try {
-      final localHash = sha256.convert(await File(local).readAsBytes());
-      return localHash.toString() != remoteHash;
+      final bundle = ClientBundle(
+        root: File(local).parent.parent.path,
+        serverBinary: local,
+      );
+      final localDigest = (await bundle.buildManifest()).digest;
+      final remoteDigest = await shell.bundleManifestSha256();
+      // Ausência migra instalações antigas (que só comparavam o executável) e
+      // restos de uma instalação interrompida para o formato transacional.
+      return remoteDigest == null || localDigest != remoteDigest;
     } on FileSystemException {
       return false;
     }
   }
-
-  static String get _localOsName => Platform.isMacOS
-      ? 'darwin'
-      : Platform.isLinux
-      ? 'linux'
-      : 'windows';
 
   Future<void> _installAndStartServer(HostShell shell) async {
     var installed = await shell.serverInstalled();
@@ -595,18 +615,13 @@ class RemoteHostConnector {
           );
         }
       } else {
-        // POSIX: o bundle vem DESTE cliente, então precisa ser da plataforma
-        // do host. Antes o Mach-O do macOS era empurrado pra qualquer host e o
-        // servidor morria no `nohup` sem deixar rastro.
-        if (shell.probe.os != _localOsName) {
-          _setPhase(RemoteHostPhase.failed);
-          throw RemoteHostException(
-            RemoteHostErrorKind.serverInstallFailed,
-            'host runs ${shell.probe.os}; '
-            'this build only ships a $_localOsName cockpit-server',
-          );
-        }
-        final binary = localServerBinaryResolver(arch: shell.probe.arch);
+        // POSIX: o bundle vem DESTE cliente e o resolver exige um target exato.
+        // Isso evita tanto mandar Mach-O para Linux quanto cair no binário
+        // nativo sem sufixo quando o host roda outra plataforma.
+        final binary = localServerBinaryResolver(
+          os: shell.probe.os,
+          arch: shell.probe.arch,
+        );
         if (binary == null) {
           _setPhase(RemoteHostPhase.failed);
           throw RemoteHostException(
@@ -622,7 +637,6 @@ class RemoteHostConnector {
         // isso que só acontece quando o binário realmente mudou.
         if (_staleServer) {
           await shell.killServer();
-          _staleServer = false;
         }
         try {
           await shell.installFromClient(
@@ -631,6 +645,8 @@ class RemoteHostConnector {
               serverBinary: binary,
             ),
           );
+          // Só fica fresh DEPOIS de upload, verificação e swap concluírem.
+          _staleServer = false;
         } on HostShellException catch (e) {
           _setPhase(RemoteHostPhase.failed);
           throw RemoteHostException(
@@ -640,11 +656,6 @@ class RemoteHostConnector {
         }
       }
     }
-    if (_staleServer) {
-      await shell.killServer();
-      _staleServer = false;
-    }
-
     try {
       await shell.startServer(idleSeconds: _remoteIdleSeconds);
     } on HostShellException catch (e) {

--- a/cockpit/lib/app/cockpit/data/terminal/sidecar/sidecar_terminal_connector.dart
+++ b/cockpit/lib/app/cockpit/data/terminal/sidecar/sidecar_terminal_connector.dart
@@ -268,9 +268,8 @@ class SidecarTerminalConnector implements TurnStatusSource {
     return '${dir.path}/cockpit-server$suffix.sock';
   }
 
-  /// Resolve o binário do servidor no bundle `bin/`+`lib/` (dart build cli).
-  /// Ordem: env → bundle do app → app-managed (`~/.cockpit/server`) →
-  /// build de dev (`build/server-bundle`, fluxo `flutter run` no repo).
+  /// Resolve o binário NATIVO do servidor no bundle `bin/`+`lib/`.
+  /// Bundles de outras plataformas são usados apenas pelo bootstrap SSH.
   String? _resolveServerBinary() => resolveServerBundleBinary();
 
   /// Nome da lib nativa do PTY por plataforma (o servidor a carrega por FFI).
@@ -281,8 +280,10 @@ class SidecarTerminalConnector implements TurnStatusSource {
       : 'cockpit_pty.dll';
 
   /// Nome do executável do servidor no disco (Windows carrega a extensão).
-  static String get serverExeName =>
-      Platform.isWindows ? 'cockpit-server.exe' : 'cockpit-server';
+  static String get serverExeName => serverExeNameFor(hostOs);
+
+  static String serverExeNameFor(String os) =>
+      os == 'windows' ? 'cockpit-server.exe' : 'cockpit-server';
 
   /// Mesmo executável, com sufixo de arquitetura (`cockpit-server-arm64`).
   ///
@@ -292,8 +293,10 @@ class SidecarTerminalConnector implements TurnStatusSource {
   /// o binário morre nas duas arquiteturas. Então o bundle traz uma fatia por
   /// arquitetura, cada uma um Mach-O fino e válido, e quem escolhe é o
   /// runtime. Ver `tool/lipo-server-bundle.sh`.
-  static String serverExeFor(String arch) =>
-      Platform.isWindows ? 'cockpit-server-$arch.exe' : 'cockpit-server-$arch';
+  static String serverExeFor(String arch, {String? os}) =>
+      (os ?? hostOs) == 'windows'
+      ? 'cockpit-server-$arch.exe'
+      : 'cockpit-server-$arch';
 
   /// Arquitetura deste processo (`arm64` | `x64`), lida do `Platform.version`
   /// (`... on "macos_arm64"`) — a fonte confiável, como no resolver de perfis.
@@ -301,12 +304,21 @@ class SidecarTerminalConnector implements TurnStatusSource {
       Platform.version.toLowerCase().contains('arm') ? 'arm64' : 'x64';
 
   /// Escolhe o executável do servidor dentro de um `bin/`, preferindo a fatia
-  /// de [arch] (default: a desta máquina) e caindo no nome sem sufixo — que é
-  /// o layout de bundle de arquitetura única (dev, Windows, Linux).
-  static String? serverBinaryIn(String binDir, {String? arch}) {
+  /// de [arch]. O nome sem sufixo só é elegível para a arquitetura deste
+  /// processo, salvo quando [targetSpecificDir] garante a arquitetura no nome
+  /// do diretório (`targets/linux-arm64`).
+  static String? serverBinaryIn(
+    String binDir, {
+    String? os,
+    String? arch,
+    bool targetSpecificDir = false,
+  }) {
+    final requestedOs = os ?? hostOs;
+    final requestedArch = arch ?? hostArch;
     for (final name in <String>[
-      serverExeFor(arch ?? hostArch),
-      serverExeName,
+      serverExeFor(requestedArch, os: requestedOs),
+      if (targetSpecificDir || requestedArch == hostArch)
+        serverExeNameFor(requestedOs),
     ]) {
       final candidate = '$binDir/$name';
       if (File(candidate).existsSync()) return candidate;
@@ -314,22 +326,73 @@ class SidecarTerminalConnector implements TurnStatusSource {
     return null;
   }
 
-  /// Resolve o binário do servidor no bundle `bin/`+`lib/` (dart build cli).
-  /// Ordem: env → bundle do app → app-managed (`~/.cockpit/server`) →
-  /// build de dev (`build/server-bundle`, fluxo `flutter run` no repo).
+  /// Resolve o binário do servidor num bundle produzido por `dart build cli`.
   ///
-  /// Reusado pelo bootstrap SSH (RemoteHostConnector) como fonte local.
-  static String? resolveServerBundleBinary({String? arch}) {
-    final fromEnv = Platform.environment['COCKPIT_SERVER_BIN'];
-    if (fromEnv != null && fromEnv.isNotEmpty && File(fromEnv).existsSync()) {
-      return fromEnv;
+  /// O bundle nativo mantém o layout histórico `<root>/{bin,lib}`. Targets de
+  /// bootstrap cross-platform ficam isolados em
+  /// `<root>/targets/<os>-<arch>/{bin,lib}`, para o sidecar local nunca escolher
+  /// por engano um ELF e para o bootstrap inferir as libs do mesmo target a
+  /// partir do caminho do executável.
+  ///
+  /// Ordem das raízes: env (somente target nativo) → bundle do app →
+  /// app-managed (`~/.cockpit/server`) → build de dev.
+  static String? resolveServerBundleBinary({String? os, String? arch}) =>
+      resolveServerBundleBinaryFrom(
+        os: os ?? hostOs,
+        arch: arch ?? hostArch,
+        nativeBinDirs: serverBundleBinDirs(),
+        environmentBinary: Platform.environment['COCKPIT_SERVER_BIN'],
+      );
+
+  /// Núcleo injetável do resolver: permite provar que nem o env override nem o
+  /// nome puro escapam para um host da mesma plataforma em outra arquitetura.
+  @visibleForTesting
+  static String? resolveServerBundleBinaryFrom({
+    required String os,
+    required String arch,
+    required List<String> nativeBinDirs,
+    String? environmentBinary,
+  }) {
+    if (os == hostOs && arch == hostArch) {
+      final fromEnv = environmentBinary;
+      if (fromEnv != null && fromEnv.isNotEmpty && File(fromEnv).existsSync()) {
+        return fromEnv;
+      }
     }
-    for (final dir in serverBundleBinDirs()) {
-      final found = serverBinaryIn(dir, arch: arch);
+    for (final nativeBinDir in nativeBinDirs) {
+      final found = serverBinaryInBundle(
+        Directory(nativeBinDir).parent.path,
+        os: os,
+        arch: arch,
+      );
       if (found != null) return found;
     }
     return null;
   }
+
+  /// Resolve dentro de uma raiz de bundle explícita. Separado para tornar o
+  /// contrato de layout verificável sem depender da localização do executável.
+  @visibleForTesting
+  static String? serverBinaryInBundle(
+    String root, {
+    required String os,
+    required String arch,
+  }) {
+    final binDir = os == hostOs ? '$root/bin' : '$root/targets/$os-$arch/bin';
+    return serverBinaryIn(
+      binDir,
+      os: os,
+      arch: arch,
+      targetSpecificDir: os != hostOs,
+    );
+  }
+
+  /// Sistema deste processo no mesmo vocabulário de `uname`/`probeHost`.
+  static String get hostOs => Platform.isMacOS
+      ? 'darwin'
+      : Platform.isLinux
+      ? 'linux'
+      : 'windows';
 
   /// Pastas `bin/` onde o bundle do servidor pode estar, em ordem de prioridade.
   static List<String> serverBundleBinDirs() {

--- a/cockpit/lib/app/cockpit/domain/contracts/terminal_status_server.dart
+++ b/cockpit/lib/app/cockpit/domain/contracts/terminal_status_server.dart
@@ -66,7 +66,8 @@ enum AgentHarness {
 class CockpitCommand {
   const CockpitCommand({required this.cmd, this.tabId, this.args = const {}});
 
-  /// Verbo no wire: `write` (send/send-key) | `list-panes` | `list-workspaces`.
+  /// Verbo no wire: `write` (send/send-key) | `list-panes` | `list-workspaces` |
+  /// `new-workspace` | `close-workspace` | `rename-workspace`.
   final String cmd;
 
   /// Pane alvo (default = `$COCKPIT_PANE_ID` resolvido pela CLI). `null` só nos

--- a/cockpit/lib/app/cockpit/domain/contracts/terminal_status_server.dart
+++ b/cockpit/lib/app/cockpit/domain/contracts/terminal_status_server.dart
@@ -40,7 +40,8 @@ class ClaudeStatusUpdate {
 /// o comando de resume difere.
 enum AgentHarness {
   claude('claude'),
-  codex('codex');
+  codex('codex'),
+  pi('pi');
 
   const AgentHarness(this.wire);
 
@@ -49,8 +50,15 @@ enum AgentHarness {
 
   /// Comando que reata a sessão [sessionId] num shell novo.
   String resumeCommand(String sessionId) => switch (this) {
-    AgentHarness.claude => 'claude --resume $sessionId',
-    AgentHarness.codex => 'codex resume $sessionId',
+    AgentHarness.claude => sessionId == 'latest' || sessionId.isEmpty
+        ? 'claude -c'
+        : 'claude --resume $sessionId',
+    AgentHarness.codex => sessionId == 'latest' || sessionId.isEmpty
+        ? 'codex resume --last'
+        : 'codex resume $sessionId',
+    AgentHarness.pi => sessionId == 'latest' || sessionId.isEmpty
+        ? 'pi -c'
+        : 'pi --session $sessionId',
   };
 
   /// Converte o nome do wire. Desconhecido ou ausente cai em [claude]: layouts

--- a/cockpit/lib/app/cockpit/ui/remote/remote_hosts_controller.dart
+++ b/cockpit/lib/app/cockpit/ui/remote/remote_hosts_controller.dart
@@ -325,10 +325,10 @@ class RemoteHostsController extends ChangeNotifier {
     return '${existing + 1}';
   }
 
-  /// Fonte local do bootstrap remoto. [arch] vem do `uname -sm` do HOST, não
-  /// desta máquina — o bundle macOS traz as duas fatias do servidor.
-  String? _resolveLocalServerBinary({String? arch}) =>
-      SidecarTerminalConnector.resolveServerBundleBinary(arch: arch);
+  /// Fonte embarcada do bootstrap remoto. [os]/[arch] vêm do probe do HOST,
+  /// não desta máquina; o bundle macOS também pode trazer targets Linux.
+  String? _resolveLocalServerBinary({String? os, String? arch}) =>
+      SidecarTerminalConnector.resolveServerBundleBinary(os: os, arch: arch);
 
   @override
   void dispose() {

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
@@ -411,7 +411,7 @@ class CockpitCliHandler {
           // Resolve host existente (por id/sshTarget/nome) ou registra
           // automaticamente com o sshTarget (ex: alias do ~/.ssh/config).
           final host = await _resolveOrRegisterRemoteHost(hostRef);
-          final cleanPath = _cleanRemotePath(rawPath);
+          final cleanPath = await _resolveRemotePath(host, rawPath);
           await _vm.createRemoteWorkspace(host.id, cleanPath);
           final workspaceId =
               '${Project.remotePrefix}${RemoteWorkspacePin.idFor(host.id, cleanPath)}';
@@ -1232,8 +1232,22 @@ class CockpitCliHandler {
     );
   }
 
-  String _cleanRemotePath(String path) {
-    var p = path.trim();
+  Future<String> _resolveRemotePath(RemoteHost host, String rawPath) async {
+    var p = rawPath.trim();
+    if (p == '~' || p.startsWith('~/')) {
+      try {
+        final service = await _vm.remoteHosts.fileServiceFor(host);
+        final remoteHome = await service.home();
+        if (remoteHome.isNotEmpty) {
+          final normalizedHome = remoteHome.endsWith('/')
+              ? remoteHome.substring(0, remoteHome.length - 1)
+              : remoteHome;
+          p = p == '~' ? normalizedHome : '$normalizedHome/${p.substring(2)}';
+        }
+      } catch (_) {
+        // Best-effort: se a conexão imediata falhar, mantém o path com ~
+      }
+    }
     while (p.length > 1 && (p.endsWith('/') || p.endsWith(r'\'))) {
       p = p.substring(0, p.length - 1);
     }

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
@@ -15,6 +15,7 @@ import 'package:cockpit/app/cockpit/domain/exceptions/http_request_error.dart';
 import 'package:cockpit/app/cockpit/domain/entities/project.dart';
 import 'package:cockpit/app/cockpit/domain/entities/remote_host.dart';
 import 'package:cockpit/app/cockpit/domain/entities/remote_workspace_pin.dart';
+import 'package:cockpit/app/cockpit/data/remote/ssh_tunnel.dart';
 import 'package:cockpit/app/cockpit/domain/entities/sql_statements.dart';
 import 'package:cockpit/app/cockpit/domain/services/db_access_gate.dart';
 import 'package:cockpit/app/cockpit/domain/services/db_query_service.dart';
@@ -1236,16 +1237,31 @@ class CockpitCliHandler {
     var p = rawPath.trim();
     if (p == '~' || p.startsWith('~/')) {
       try {
-        final service = await _vm.remoteHosts.fileServiceFor(host);
-        final remoteHome = await service.home();
-        if (remoteHome.isNotEmpty) {
+        final (code, out, _) = await SshTunnel.capture(
+          host.sshTarget,
+          r'printf %s "$HOME"',
+          port: host.port,
+          identityFile: host.effectiveIdentityFile,
+        );
+        if (code == 0 && out.trim().isNotEmpty) {
+          final remoteHome = out.trim();
           final normalizedHome = remoteHome.endsWith('/')
               ? remoteHome.substring(0, remoteHome.length - 1)
               : remoteHome;
           p = p == '~' ? normalizedHome : '$normalizedHome/${p.substring(2)}';
         }
       } catch (_) {
-        // Best-effort: se a conexão imediata falhar, mantém o path com ~
+        // Fallback: tenta via fileService se capture falhar
+        try {
+          final service = await _vm.remoteHosts.fileServiceFor(host);
+          final remoteHome = await service.home();
+          if (remoteHome.isNotEmpty) {
+            final normalizedHome = remoteHome.endsWith('/')
+                ? remoteHome.substring(0, remoteHome.length - 1)
+                : remoteHome;
+            p = p == '~' ? normalizedHome : '$normalizedHome/${p.substring(2)}';
+          }
+        } catch (_) {}
       }
     }
     while (p.length > 1 && (p.endsWith('/') || p.endsWith(r'\'))) {

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_cli_handler.dart
@@ -1,5 +1,6 @@
+import 'dart:async' show unawaited;
 import 'dart:convert';
-import 'dart:io' show Directory, File, FileSystemException;
+import 'dart:io' show Directory, File, FileSystemException, Platform;
 
 import 'package:cockpit/app/cockpit/domain/contracts/http_request_runner.dart';
 import 'package:cockpit/app/cockpit/domain/contracts/task_discovery.dart';
@@ -12,12 +13,15 @@ import 'package:cockpit/app/cockpit/domain/entities/http_document.dart';
 import 'package:cockpit/app/cockpit/domain/entities/notebook_document.dart';
 import 'package:cockpit/app/cockpit/domain/exceptions/http_request_error.dart';
 import 'package:cockpit/app/cockpit/domain/entities/project.dart';
+import 'package:cockpit/app/cockpit/domain/entities/remote_host.dart';
+import 'package:cockpit/app/cockpit/domain/entities/remote_workspace_pin.dart';
 import 'package:cockpit/app/cockpit/domain/entities/sql_statements.dart';
 import 'package:cockpit/app/cockpit/domain/services/db_access_gate.dart';
 import 'package:cockpit/app/cockpit/domain/services/db_query_service.dart';
 import 'package:cockpit/app/cockpit/domain/services/mongo_browse_service.dart';
 import 'package:cockpit/app/cockpit/domain/entities/browser_capability.dart';
 import 'package:cockpit/app/core/domain/result.dart';
+import 'package:cockpit/app/core/utils/path_utils.dart';
 import 'package:cockpit/app/cockpit/ui/session/agent_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/browser_session.dart';
 import 'package:cockpit/app/cockpit/ui/session/notebook_session.dart';
@@ -385,6 +389,177 @@ class CockpitCliHandler {
             )
             .toList();
         return CockpitCommandResult.ok(ws);
+
+      // `cockpit new-workspace <path> [--host <host>] [--name <name>]`
+      // `cockpit new-remote-workspace --host <host> --path <path> [--name <name>]`
+      // Adiciona um workspace como projeto de primeiro nível no rail (local ou
+      // remoto). Idempotente: se já estiver aberto, seleciona e devolve os
+      // dados do workspace.
+      case 'new-remote-workspace':
+      case 'new-workspace':
+      case 'open-workspace':
+        final hostRef = (c.args['host'] ?? '').toString().trim();
+        final rawPath = (c.args['path'] ?? '').toString().trim();
+        if (rawPath.isEmpty) {
+          return const CockpitCommandResult.fail('missing path');
+        }
+        final rawName = (c.args['name'] ?? '').toString().trim();
+        final customName = rawName.isEmpty ? null : rawName;
+
+        if (hostRef.isNotEmpty) {
+          // Workspace REMOTO (plano 58 / dd-swarm):
+          // Resolve host existente (por id/sshTarget/nome) ou registra
+          // automaticamente com o sshTarget (ex: alias do ~/.ssh/config).
+          final host = await _resolveOrRegisterRemoteHost(hostRef);
+          final cleanPath = _cleanRemotePath(rawPath);
+          await _vm.createRemoteWorkspace(host.id, cleanPath);
+          final workspaceId =
+              '${Project.remotePrefix}${RemoteWorkspacePin.idFor(host.id, cleanPath)}';
+          if (customName != null) {
+            await _vm.updateRemoteWorkspace(workspaceId, name: customName);
+          }
+          final sessions = _vm.allSessions
+              .where((s) => s.projectId == workspaceId)
+              .toList();
+          if (sessions.isEmpty ||
+              sessions.every(
+                (s) => s is AgentSession && s.status == AgentStatus.empty,
+              )) {
+            _vm.newTerminalTab(cwd: cleanPath);
+          }
+          final project = _vm.projectById(workspaceId);
+          final tabCount = _vm.allSessions
+              .where((s) => s.projectId == workspaceId)
+              .length;
+          return CockpitCommandResult.ok({
+            'id': workspaceId,
+            'name': project?.name ?? (customName ?? cleanPath),
+            'path': project?.effectiveRoot ?? cleanPath,
+            'host': host.sshTarget,
+            'tabs': tabCount,
+          });
+        }
+
+        // Workspace LOCAL
+        final cleanPath = _cleanWorkspacePath(rawPath);
+        if (!_isRemoteTab(c.tabId) && !await Directory(cleanPath).exists()) {
+          return CockpitCommandResult.fail('directory not found: "$cleanPath"');
+        }
+
+        final project = await _vm.addProject(cleanPath, name: customName);
+        _vm.selectProject(project.id);
+
+        if (customName != null && customName != project.name) {
+          await _vm.updateProject(project.id, name: customName);
+        }
+
+        final sessions = _vm.allSessions
+            .where((s) => s.projectId == project.id)
+            .toList();
+        if (sessions.isEmpty ||
+            sessions.every(
+              (s) => s is AgentSession && s.status == AgentStatus.empty,
+            )) {
+          _vm.newTerminalTab(cwd: project.effectiveRoot);
+        }
+
+        final resolved = _vm.projectById(project.id) ?? project;
+        final tabCount = _vm.allSessions
+            .where((s) => s.projectId == resolved.id)
+            .length;
+
+        return CockpitCommandResult.ok({
+          'id': resolved.id,
+          'name': resolved.name,
+          'path': resolved.effectiveRoot,
+          'tabs': tabCount,
+        });
+
+      // `cockpit close-workspace [<id|path>]` — fecha/remove o workspace do
+      // Cockpit (mantém os arquivos no disco). Suporta workspaces locais e remotos.
+      // O encerramento roda em `afterResponse` para permitir que o socket
+      // responda antes de derrubar o PTY/shell caso o comando venha de dentro
+      // do workspace fechado.
+      case 'close-workspace':
+        final target = (c.args['target'] ?? '').toString().trim();
+        final Project? project;
+        if (target.isNotEmpty) {
+          project = _resolveWorkspace(target);
+          if (project == null) {
+            return CockpitCommandResult.fail('no workspace matches "$target"');
+          }
+        } else {
+          final sender = c.tabId == null ? null : _vm.session(c.tabId!);
+          project = sender != null
+              ? _vm.projectById(sender.projectId)
+              : _vm.selectedProject;
+          if (project == null) {
+            return const CockpitCommandResult.fail(
+              'missing target workspace (pass <id|path> or run inside a Cockpit workspace)',
+            );
+          }
+        }
+        if (project.isSystemTerminal) {
+          return const CockpitCommandResult.fail(
+            'cannot close the system terminal workspace',
+          );
+        }
+        final isRemote = project.isRemoteTerminal;
+        final closingId = project.id;
+        final closingPath = project.effectiveRoot;
+        return CockpitCommandResult.ok({
+          'id': closingId,
+          'path': closingPath,
+          'closed': true,
+        }, () {
+          if (isRemote) {
+            unawaited(_vm.removeRemoteWorkspace(closingId));
+          } else {
+            unawaited(_vm.removeProject(closingId));
+          }
+        });
+
+      // `cockpit rename-workspace [<id|path>] <new-name>` — renomeia o título
+      // de exibição do workspace no rail (local ou remoto).
+      case 'rename-workspace':
+        final target = (c.args['target'] ?? '').toString().trim();
+        final newName = (c.args['name'] ?? '').toString().trim();
+        if (newName.isEmpty) {
+          return const CockpitCommandResult.fail('missing new workspace name');
+        }
+        final Project? project;
+        if (target.isNotEmpty) {
+          project = _resolveWorkspace(target);
+          if (project == null) {
+            return CockpitCommandResult.fail('no workspace matches "$target"');
+          }
+        } else {
+          final sender = c.tabId == null ? null : _vm.session(c.tabId!);
+          project = sender != null
+              ? _vm.projectById(sender.projectId)
+              : _vm.selectedProject;
+          if (project == null) {
+            return const CockpitCommandResult.fail(
+              'missing target workspace (pass <id|path> or run inside a Cockpit workspace)',
+            );
+          }
+        }
+        if (project.isSystemTerminal) {
+          return const CockpitCommandResult.fail(
+            'cannot rename the system terminal workspace',
+          );
+        }
+        if (project.isRemoteTerminal) {
+          await _vm.updateRemoteWorkspace(project.id, name: newName);
+        } else {
+          await _vm.updateProject(project.id, name: newName);
+        }
+        final renamed = _vm.projectById(project.id) ?? project;
+        return CockpitCommandResult.ok({
+          'id': renamed.id,
+          'name': renamed.name,
+          'path': renamed.effectiveRoot,
+        });
 
       // `cockpit read-pane [<label|tab-id>]` — devolve uma janela de linhas do
       // buffer renderizado do pane (texto plano, sem ANSI — é o que o xterm já
@@ -1055,6 +1230,90 @@ class CockpitCliHandler {
     return Failure(
       'no tab with id or label "$target" (see `cockpit list-tabs`)',
     );
+  }
+
+  String _cleanRemotePath(String path) {
+    var p = path.trim();
+    while (p.length > 1 && (p.endsWith('/') || p.endsWith(r'\'))) {
+      p = p.substring(0, p.length - 1);
+    }
+    return p;
+  }
+
+  Future<RemoteHost> _resolveOrRegisterRemoteHost(String hostRef) async {
+    final clean = hostRef.trim();
+    for (final h in _vm.remoteHosts.hosts) {
+      if (h.id == clean ||
+          h.sshTarget == clean ||
+          h.name.toLowerCase() == clean.toLowerCase() ||
+          h.host == clean) {
+        return h;
+      }
+    }
+    await _vm.addRemoteHost(
+      name: clean,
+      sshTarget: clean,
+    );
+    for (final h in _vm.remoteHosts.hosts) {
+      if (h.sshTarget == clean || h.name == clean) {
+        return h;
+      }
+    }
+    return _vm.remoteHosts.hosts.last;
+  }
+
+  String _cleanWorkspacePath(String path) {
+    var p = normalizePath(path).trim();
+    if (p == '~' || p.startsWith('~/')) {
+      final home = Platform.environment['HOME'] ??
+          Platform.environment['USERPROFILE'];
+      if (home != null && home.isNotEmpty) {
+        final normHome = normalizePath(home);
+        p = p == '~' ? normHome : '$normHome${p.substring(1)}';
+      }
+    }
+    while (p.length > 1 && p.endsWith('/')) {
+      p = p.substring(0, p.length - 1);
+    }
+    return p;
+  }
+
+  Project? _resolveWorkspace(String target) {
+    if (target.isEmpty) return null;
+    final normalized = normalizePath(target);
+    final clean = _cleanWorkspacePath(target);
+    for (final p in _vm.projects) {
+      if (p.id == target ||
+          p.id == '${Project.remotePrefix}$target' ||
+          p.id.replaceFirst(Project.remotePrefix, '') == target) {
+        return p;
+      }
+      if (p.path == target || p.path == normalized || p.path == clean) return p;
+      if (p.effectiveRoot == target ||
+          p.effectiveRoot == normalized ||
+          p.effectiveRoot == clean) {
+        return p;
+      }
+      if (p.remotePath == target || p.remotePath == clean) return p;
+    }
+    try {
+      final dir = Directory(clean);
+      if (dir.existsSync()) {
+        final abs = _cleanWorkspacePath(dir.absolute.path);
+        for (final p in _vm.projects) {
+          if (p.path == abs || p.effectiveRoot == abs) {
+            return p;
+          }
+        }
+      }
+    } catch (_) {
+      /* ignore invalid path syntax */
+    }
+    final byName = _vm.projects
+        .where((p) => p.name.toLowerCase() == target.toLowerCase())
+        .toList();
+    if (byName.length == 1) return byName.first;
+    return null;
   }
 
   String _paneKind(PaneItem s) {

--- a/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
+++ b/cockpit/lib/app/cockpit/ui/viewmodels/cockpit_viewmodel.dart
@@ -5859,8 +5859,19 @@ class CockpitViewModel extends ChangeNotifier {
         // hook) pra reatar a sessão no restore. `harness` diz de quem é o id —
         // sem ele o restore assumiria Claude e o `codex` daria "No conversation
         // found". Chave `claude_sid` mantida por compat com layouts antigos.
-        if (s.claudeSessionId != null) 'claude_sid': s.claudeSessionId,
-        if (s.claudeSessionId != null) 'harness': s.agentHarness.wire,
+        if (s.claudeSessionId != null) ...{
+          'claude_sid': s.claudeSessionId,
+          'harness': s.agentHarness.wire,
+        } else if (s.activeHarness == HarnessKind.pi) ...{
+          'claude_sid': 'latest',
+          'harness': AgentHarness.pi.wire,
+        } else if (s.activeHarness == HarnessKind.claudeCode) ...{
+          'claude_sid': 'latest',
+          'harness': AgentHarness.claude.wire,
+        } else if (s.activeHarness == HarnessKind.codex) ...{
+          'claude_sid': 'latest',
+          'harness': AgentHarness.codex.wire,
+        },
       };
     }
     if (s is FileViewerSession) {

--- a/cockpit/macos/Runner/Release.entitlements
+++ b/cockpit/macos/Runner/Release.entitlements
@@ -6,5 +6,7 @@
 	     do usuário. Local-only dev tool, fora da App Store por enquanto. -->
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>

--- a/cockpit/macos/build_server.sh
+++ b/cockpit/macos/build_server.sh
@@ -3,8 +3,9 @@
 # SUPORTA build hooks (native assets do anaki), ao contrário do
 # `dart compile exe`. O resultado (bin/ + lib/) vai para
 #   Resources/cockpit-server-bundle/{bin,lib}
-# e o app resolve o binário lá (SidecarTerminalConnector). O exe carrega as
-# dylibs (anaki + pty) de ../lib via rpath.
+# e o app resolve o binário lá (SidecarTerminalConnector). Além do sidecar
+# Darwin, empacota o target de bootstrap remoto em
+#   Resources/cockpit-server-bundle/targets/linux-arm64/{bin,lib}.
 #
 # ATENÇÃO — arquitetura: fatia única (a do host que buildou), no nome sem
 # sufixo (`bin/cockpit-server`), que é o fallback do resolver. No CI, o
@@ -48,6 +49,12 @@ mv "$BUNDLE"/bundle/* "$DEST"/
 mv "$DEST/bin/cockpit_server" "$DEST/bin/cockpit-server"
 cp "$PTY" "$DEST/lib/libcockpit_pty.dylib"
 chmod +x "$DEST/bin/cockpit-server"
+
+# Target de bootstrap para os VMs Linux arm64 de workspaces remotos. Fica
+# isolado do sidecar macOS para o resolver nunca tentar executar um ELF local.
+# O helper também produz libcockpit_pty.so e a CLI Rust para o host remoto.
+"$ROOT/tool/build-linux-arm64-server-bundle.sh" \
+  "$DEST/targets/linux-arm64"
 
 # CLI `cockpit` embarcada AO LADO do server (plano 60, Wave G): o server instala
 # o hook do agente no ~/.claude do host apontando pra `cockpit hook`, e a acha

--- a/cockpit/packaging/README.md
+++ b/cockpit/packaging/README.md
@@ -48,8 +48,9 @@ linux/packaging/rpm/make_config.yaml
 ## macOS — build + sign + DMG + notarize + staple (ponta a ponta)
 
 Validado localmente em 2026-06-12 (DMG aceito pelo Gatekeeper). Pré-requisitos:
-identidade **"Developer ID Application: Jacob Moura (U843T2P7A2)"** no Keychain e
-a API key do App Store Connect.
+identidade **"Developer ID Application: Jacob Moura (U843T2P7A2)"** no Keychain,
+a API key do App Store Connect, Zig 0.16.0 e o target Rust usado pela CLI do
+servidor Linux remoto (`rustup target add aarch64-unknown-linux-gnu`).
 
 ```bash
 cd cockpit

--- a/cockpit/test/data/client_bundle_manifest_test.dart
+++ b/cockpit/test/data/client_bundle_manifest_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:cockpit/app/cockpit/data/remote/host_shell/host_shell.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory root;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('cockpit-client-bundle');
+    Directory('${root.path}/bin').createSync();
+    Directory('${root.path}/lib').createSync();
+  });
+
+  tearDown(() => root.deleteSync(recursive: true));
+
+  File put(String relative, String contents) {
+    final file = File('${root.path}/$relative')..writeAsStringSync(contents);
+    return file;
+  }
+
+  test(
+    'manifesto é determinístico e cobre todos os arquivos implantados',
+    () async {
+      final server = put('bin/cockpit-server-arm64', 'server');
+      put('bin/cockpit', 'cli');
+      put('lib/libcockpit_pty.so', 'pty');
+      put('lib/libanaki_sqlite.so', 'sqlite');
+      final bundle = ClientBundle(root: root.path, serverBinary: server.path);
+
+      final first = await bundle.buildManifest();
+      final second = await bundle.buildManifest();
+
+      expect(second.digest, first.digest);
+      expect(second.contents, first.contents);
+      expect(
+        first.files.map((file) => file.remotePath),
+        orderedEquals([
+          'bin/cockpit',
+          'bin/cockpit-server',
+          'lib/libanaki_sqlite.so',
+          'lib/libcockpit_pty.so',
+        ]),
+      );
+      expect(first.contents, contains('  bin/cockpit-server\n'));
+      expect(first.contents, contains('  lib/libcockpit_pty.so\n'));
+    },
+  );
+
+  test('mudança só na CLI ou só numa lib muda o digest do bundle', () async {
+    final server = put('bin/cockpit-server', 'same-server');
+    final cli = put('bin/cockpit', 'cli-v1');
+    final pty = put('lib/libcockpit_pty.so', 'pty-v1');
+    final bundle = ClientBundle(root: root.path, serverBinary: server.path);
+
+    final original = (await bundle.buildManifest()).digest;
+    cli.writeAsStringSync('cli-v2');
+    final cliChanged = (await bundle.buildManifest()).digest;
+    expect(cliChanged, isNot(original));
+
+    cli.writeAsStringSync('cli-v1');
+    pty.writeAsStringSync('pty-v2');
+    final ptyChanged = (await bundle.buildManifest()).digest;
+    expect(ptyChanged, isNot(original));
+  });
+}

--- a/cockpit/test/data/host_shell_test.dart
+++ b/cockpit/test/data/host_shell_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:cockpit/app/cockpit/data/remote/host_shell/host_shell.dart';
 import 'package:cockpit/app/cockpit/data/remote/host_shell/posix_host_shell.dart';
@@ -14,15 +15,62 @@ class _FakeExec {
 
   final List<(int, String, String)> Function(String command) _replies;
   final List<String> commands = [];
+  final List<List<int>?> stdinPayloads = [];
 
   Future<(int, String, String)> call(
     String command, {
     List<int>? stdinBytes,
   }) async {
     commands.add(command);
+    stdinPayloads.add(stdinBytes);
     final replies = _replies(command);
     return replies.isEmpty ? (0, '', '') : replies.first;
   }
+}
+
+/// Executa os comandos POSIX de verdade, mas com HOME isolado. Assim os testes
+/// de rollback cobrem renames e o filesystem, não só substrings do shell gerado.
+class _RealPosixExec {
+  _RealPosixExec({required this.home, String? pathPrefix})
+    : _path = [
+        ?pathPrefix,
+        '/usr/local/bin',
+        '/opt/homebrew/bin',
+        '/usr/bin',
+        '/bin',
+        '/usr/sbin',
+        '/sbin',
+      ].join(':');
+
+  final String home;
+  final String _path;
+
+  Future<(int, String, String)> call(
+    String command, {
+    List<int>? stdinBytes,
+  }) async {
+    final process = await Process.start(
+      '/bin/sh',
+      ['-c', command],
+      environment: {'HOME': home, 'PATH': _path},
+    );
+    final stdout = process.stdout.transform(utf8.decoder).join();
+    final stderr = process.stderr.transform(utf8.decoder).join();
+    if (stdinBytes != null) process.stdin.add(stdinBytes);
+    await process.stdin.close();
+    final code = await process.exitCode;
+    return (code, await stdout, await stderr);
+  }
+}
+
+ClientBundle _posixTestBundle(Directory root) {
+  final bin = Directory('${root.path}/bin')..createSync();
+  final lib = Directory('${root.path}/lib')..createSync();
+  final server = File('${bin.path}/cockpit-server')
+    ..writeAsStringSync('new-server');
+  File('${bin.path}/cockpit').writeAsStringSync('new-cli');
+  File('${lib.path}/libcockpit_pty.dylib').writeAsStringSync('new-pty');
+  return ClientBundle(root: root.path, serverBinary: server.path);
 }
 
 /// Desfaz o `-EncodedCommand`: base64 → UTF-16LE → script. É assim que os
@@ -277,6 +325,450 @@ void main() {
 
       expect(exec.commands.single, contains('libcockpit_pty.so'));
     });
+
+    test('serverInstalled exige executável e manifesto completo', () async {
+      final exec = _FakeExec((_) => [(0, 'yes', '')]);
+      expect(await shellWith(exec).serverInstalled(), isTrue);
+      expect(exec.commands.single, contains('test -x'));
+      expect(exec.commands.single, contains('bundle.manifest'));
+    });
+
+    test('freshness lê o digest do manifesto instalado', () async {
+      final hash = 'B' * 64;
+      final exec = _FakeExec((_) => [(0, hash, '')]);
+      expect(await shellWith(exec).bundleManifestSha256(), hash.toLowerCase());
+      expect(exec.commands.single, contains('bundle.manifest'));
+    });
+
+    test(
+      'instala no staging, verifica manifesto e só então troca o live',
+      () async {
+        final root = Directory.systemTemp.createTempSync(
+          'cockpit-posix-install',
+        );
+        addTearDown(() => root.deleteSync(recursive: true));
+        final bin = Directory('${root.path}/bin')..createSync();
+        final lib = Directory('${root.path}/lib')..createSync();
+        final server = File('${bin.path}/cockpit-server')
+          ..writeAsStringSync('server');
+        File('${bin.path}/cockpit').writeAsStringSync('cli');
+        File('${lib.path}/libcockpit_pty.dylib').writeAsStringSync('pty');
+        final exec = _FakeExec((_) => [(0, '', '')]);
+
+        await shellWith(exec).installFromClient(
+          ClientBundle(root: root.path, serverBinary: server.path),
+        );
+
+        final manifestIndex = exec.commands.indexWhere(
+          (command) =>
+              command.contains('cat >') && command.contains('bundle.manifest'),
+        );
+        final swapIndex = exec.commands.indexWhere(
+          (command) => command.contains('sha256sum -c bundle.manifest'),
+        );
+        expect(manifestIndex, greaterThan(0));
+        expect(swapIndex, greaterThan(manifestIndex));
+        expect(exec.commands.first, contains('while ! mkdir'));
+        expect(exec.commands.first, contains('server.install.lock'));
+        expect(exec.commands.first, contains('-mmin +10'));
+        expect(exec.commands.first, contains('attempt" -ge 30'));
+        final staleCleanupIndex = exec.commands.indexWhere(
+          (command) => command.contains('server.staging-*'),
+        );
+        expect(staleCleanupIndex, greaterThan(0));
+        expect(staleCleanupIndex, lessThan(manifestIndex));
+        expect(exec.commands[swapIndex], contains('server.previous-'));
+        expect(
+          exec.commands[swapIndex],
+          contains('no_nest_rename "\$HOME/.cockpit/server.staging-'),
+        );
+        expect(exec.commands[swapIndex], contains('mv -T -- "\$1" "\$2"'));
+        expect(exec.commands[swapIndex], contains('os.rename'));
+        expect(exec.commands[swapIndex], contains('perl -e'));
+        expect(
+          exec.commands[swapIndex],
+          contains('needs GNU mv -T, python3, or perl'),
+        );
+        expect(exec.commands[swapIndex], isNot(contains('mv "\$1" "\$2"')));
+        expect(exec.commands[swapIndex], contains('"\$HOME/.cockpit/server"'));
+        expect(
+          exec.commands[swapIndex],
+          isNot(contains('mv "\$HOME/.cockpit/server.staging-')),
+        );
+        expect(
+          exec.commands[swapIndex],
+          contains('live directory changed during promotion'),
+        );
+        expect(
+          exec.commands.last,
+          contains('rm -rf "\$HOME/.cockpit/server.install.lock"'),
+        );
+        final manifestText = utf8.decode(exec.stdinPayloads[manifestIndex]!);
+        expect(manifestText, contains('  bin/cockpit-server\n'));
+        expect(manifestText, contains('  bin/cockpit\n'));
+        expect(manifestText, contains('  lib/libcockpit_pty.dylib\n'));
+      },
+    );
+
+    test('upload interrompido não promove staging parcial', () async {
+      final root = Directory.systemTemp.createTempSync('cockpit-posix-fail');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final bin = Directory('${root.path}/bin')..createSync();
+      final lib = Directory('${root.path}/lib')..createSync();
+      final server = File('${bin.path}/cockpit-server')
+        ..writeAsStringSync('server');
+      File('${lib.path}/libcockpit_pty.dylib').writeAsStringSync('pty');
+      final exec = _FakeExec(
+        (command) => command.contains('libcockpit_pty.dylib')
+            ? [(1, '', 'network cut')]
+            : [(0, '', '')],
+      );
+
+      await expectLater(
+        shellWith(exec).installFromClient(
+          ClientBundle(root: root.path, serverBinary: server.path),
+        ),
+        throwsA(
+          isA<HostShellException>().having(
+            (error) => error.detail,
+            'detail',
+            'network cut',
+          ),
+        ),
+      );
+
+      expect(
+        exec.commands,
+        isNot(contains(contains('sha256sum -c bundle.manifest'))),
+      );
+      final cleanupIndex = exec.commands.indexWhere(
+        (command) =>
+            command.contains('rm -rf "\$HOME/.cockpit/server.staging-'),
+      );
+      expect(cleanupIndex, greaterThan(0));
+      expect(exec.commands[cleanupIndex], contains('server.previous-'));
+      expect(exec.commands.last, contains('server.install.lock'));
+      expect(exec.commands.last, contains('rm -rf'));
+    });
+
+    test('lock ocupado/timeout impede qualquer upload ou promoção', () async {
+      final root = Directory.systemTemp.createTempSync('cockpit-posix-locked');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final bin = Directory('${root.path}/bin')..createSync();
+      final server = File('${bin.path}/cockpit-server')
+        ..writeAsStringSync('server');
+      final exec = _FakeExec(
+        (command) => command.contains('while ! mkdir')
+            ? [(75, '', 'install lock timed out')]
+            : [(0, '', '')],
+      );
+
+      await expectLater(
+        shellWith(exec).installFromClient(
+          ClientBundle(root: root.path, serverBinary: server.path),
+        ),
+        throwsA(
+          isA<HostShellException>().having(
+            (error) => error.detail,
+            'detail',
+            'install lock timed out',
+          ),
+        ),
+      );
+
+      expect(exec.commands, hasLength(1));
+      expect(exec.stdinPayloads, everyElement(isNull));
+    });
+
+    test('falha na promoção repara backup antes de soltar o lock', () async {
+      final root = Directory.systemTemp.createTempSync(
+        'cockpit-posix-rollback',
+      );
+      addTearDown(() => root.deleteSync(recursive: true));
+      final bin = Directory('${root.path}/bin')..createSync();
+      final server = File('${bin.path}/cockpit-server')
+        ..writeAsStringSync('server');
+      final exec = _FakeExec(
+        (command) => command.contains('sha256sum -c bundle.manifest')
+            ? [(76, '', 'cut between renames')]
+            : [(0, '', '')],
+      );
+
+      await expectLater(
+        shellWith(exec).installFromClient(
+          ClientBundle(root: root.path, serverBinary: server.path),
+        ),
+        throwsA(isA<HostShellException>()),
+      );
+
+      final promotionIndex = exec.commands.indexWhere(
+        (command) => command.contains('sha256sum -c bundle.manifest'),
+      );
+      final recoveryIndex = exec.commands.lastIndexWhere(
+        (command) =>
+            !command.contains('sha256sum -c bundle.manifest') &&
+            command.contains(
+              'no_nest_rename "\$HOME/.cockpit/server.previous-',
+            ) &&
+            command.contains('"\$HOME/.cockpit/server"'),
+      );
+      final releaseIndex = exec.commands.lastIndexWhere(
+        (command) =>
+            command.contains('rm -rf "\$HOME/.cockpit/server.install.lock"'),
+      );
+      expect(recoveryIndex, greaterThan(promotionIndex));
+      expect(releaseIndex, greaterThan(recoveryIndex));
+      expect(
+        exec.commands[recoveryIndex],
+        isNot(contains('rm -rf "\$HOME/.cockpit/server.previous-')),
+      );
+    });
+
+    test(
+      'guard de promoção põe live inesperado em conflito sem aninhar backup',
+      () async {
+        final root = Directory.systemTemp.createTempSync(
+          'cockpit-posix-guard-fs',
+        );
+        addTearDown(() => root.deleteSync(recursive: true));
+        final home = Directory('${root.path}/home')..createSync();
+        final cockpit = Directory('${home.path}/.cockpit')..createSync();
+        final live = Directory('${cockpit.path}/server')..createSync();
+        File('${live.path}/known-good').writeAsStringSync('old');
+        final fakeBin = Directory('${root.path}/fake-bin')..createSync();
+        final fakeMv = File('${fakeBin.path}/mv')
+          ..writeAsStringSync(r'''#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "mv (GNU coreutils) test double"
+  exit 0
+fi
+if [ "$1" = "-T" ] && [ "$2" = "--" ]; then
+  source=$3
+  destination=$4
+  case "$source" in
+    "$HOME/.cockpit/server.staging-"*)
+      if [ "$destination" = "$HOME/.cockpit/server" ]; then
+        # A corrida acontece dentro da primitiva, depois de qualquer guard.
+        mkdir -p "$destination"
+        printf '%s' unexpected > "$destination/unexpected"
+        exit 1
+      fi
+      ;;
+  esac
+  exec /bin/mv "$source" "$destination"
+fi
+exec /bin/mv "$@"
+''');
+        Process.runSync('/bin/chmod', ['+x', fakeMv.path]);
+        final bundleRoot = Directory('${root.path}/bundle')..createSync();
+        final exec = _RealPosixExec(home: home.path, pathPrefix: fakeBin.path);
+        final shell = PosixHostShell(probe: _posixProbe, exec: exec.call);
+
+        await expectLater(
+          shell.installFromClient(_posixTestBundle(bundleRoot)),
+          throwsA(isA<HostShellException>()),
+        );
+
+        expect(File('${live.path}/known-good').readAsStringSync(), 'old');
+        expect(
+          live.listSync().where(
+            (entity) => entity.path
+                .split(Platform.pathSeparator)
+                .last
+                .startsWith('server.previous-'),
+          ),
+          isEmpty,
+        );
+        final conflicts = cockpit
+            .listSync()
+            .where(
+              (entity) => entity.path
+                  .split(Platform.pathSeparator)
+                  .last
+                  .startsWith('server.conflict-'),
+            )
+            .toList();
+        expect(conflicts, hasLength(1));
+        expect(
+          File('${conflicts.single.path}/unexpected').readAsStringSync(),
+          'unexpected',
+        );
+        expect(
+          cockpit.listSync().where(
+            (entity) => entity.path
+                .split(Platform.pathSeparator)
+                .last
+                .startsWith('server.previous-'),
+          ),
+          isEmpty,
+        );
+        final stages = cockpit
+            .listSync()
+            .whereType<Directory>()
+            .where(
+              (directory) => directory.path
+                  .split(Platform.pathSeparator)
+                  .last
+                  .startsWith('server.staging-'),
+            )
+            .toList();
+        expect(stages, hasLength(1));
+        expect(
+          File('${stages.single.path}/bin/cockpit-server').readAsStringSync(),
+          'new-server',
+        );
+      },
+      skip: Platform.isWindows,
+    );
+
+    test(
+      'recovery anterior recusa live surgido no rename sem aninhar backup',
+      () async {
+        final root = Directory.systemTemp.createTempSync(
+          'cockpit-posix-prior-recovery-race',
+        );
+        addTearDown(() => root.deleteSync(recursive: true));
+        final home = Directory('${root.path}/home')..createSync();
+        final cockpit = Directory('${home.path}/.cockpit')..createSync();
+        final prior = Directory('${cockpit.path}/server.previous-interrupted')
+          ..createSync();
+        File('${prior.path}/known-good').writeAsStringSync('old');
+        final fakeBin = Directory('${root.path}/fake-bin')..createSync();
+        final fakeMv = File('${fakeBin.path}/mv')
+          ..writeAsStringSync(r'''#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "mv (GNU coreutils) test double"
+  exit 0
+fi
+if [ "$1" = "-T" ] && [ "$2" = "--" ]; then
+  source=$3
+  destination=$4
+  case "$source" in
+    "$HOME/.cockpit/server.previous-"*)
+      if [ "$destination" = "$HOME/.cockpit/server" ]; then
+        mkdir -p "$destination"
+        printf '%s' raced > "$destination/unexpected"
+        exit 1
+      fi
+      ;;
+  esac
+  exec /bin/mv "$source" "$destination"
+fi
+exec /bin/mv "$@"
+''');
+        Process.runSync('/bin/chmod', ['+x', fakeMv.path]);
+        final bundleRoot = Directory('${root.path}/bundle')..createSync();
+        final exec = _RealPosixExec(home: home.path, pathPrefix: fakeBin.path);
+        final shell = PosixHostShell(probe: _posixProbe, exec: exec.call);
+
+        await expectLater(
+          shell.installFromClient(_posixTestBundle(bundleRoot)),
+          throwsA(isA<HostShellException>()),
+        );
+
+        expect(File('${prior.path}/known-good').readAsStringSync(), 'old');
+        expect(
+          File('${cockpit.path}/server/unexpected').readAsStringSync(),
+          'raced',
+        );
+        expect(
+          Directory(
+            '${cockpit.path}/server/server.previous-interrupted',
+          ).existsSync(),
+          isFalse,
+        );
+        expect(
+          cockpit.listSync().where(
+            (entity) => entity.path
+                .split(Platform.pathSeparator)
+                .last
+                .startsWith('server.staging-'),
+          ),
+          isEmpty,
+        );
+      },
+      skip: Platform.isWindows,
+    );
+
+    test(
+      'finally preserva live ambíguo e restaura backup sem aninhamento',
+      () async {
+        final root = Directory.systemTemp.createTempSync(
+          'cockpit-posix-finally-fs',
+        );
+        addTearDown(() => root.deleteSync(recursive: true));
+        final home = Directory('${root.path}/home')..createSync();
+        final cockpit = Directory('${home.path}/.cockpit')..createSync();
+        final live = Directory('${cockpit.path}/server')..createSync();
+        File('${live.path}/known-good').writeAsStringSync('old');
+        final bundleRoot = Directory('${root.path}/bundle')..createSync();
+        final realExec = _RealPosixExec(home: home.path);
+
+        Future<(int, String, String)> interruptedExec(
+          String command, {
+          List<int>? stdinBytes,
+        }) async {
+          if (command.contains('sha256sum -c bundle.manifest')) {
+            final stage = cockpit.listSync().whereType<Directory>().singleWhere(
+              (directory) => directory.path
+                  .split(Platform.pathSeparator)
+                  .last
+                  .startsWith('server.staging-'),
+            );
+            final token = stage.path
+                .split(Platform.pathSeparator)
+                .last
+                .substring('server.staging-'.length);
+            live.renameSync('${cockpit.path}/server.previous-$token');
+            live.createSync();
+            File('${live.path}/unexpected').writeAsStringSync('ambiguous');
+            return (76, '', 'simulated transport cut between renames');
+          }
+          return realExec.call(command, stdinBytes: stdinBytes);
+        }
+
+        final shell = PosixHostShell(probe: _posixProbe, exec: interruptedExec);
+        await expectLater(
+          shell.installFromClient(_posixTestBundle(bundleRoot)),
+          throwsA(isA<HostShellException>()),
+        );
+
+        expect(File('${live.path}/known-good').readAsStringSync(), 'old');
+        expect(
+          live.listSync().where(
+            (entity) => entity.path
+                .split(Platform.pathSeparator)
+                .last
+                .startsWith('server.previous-'),
+          ),
+          isEmpty,
+        );
+        final conflicts = cockpit
+            .listSync()
+            .where(
+              (entity) => entity.path
+                  .split(Platform.pathSeparator)
+                  .last
+                  .startsWith('server.conflict-'),
+            )
+            .toList();
+        expect(conflicts, hasLength(1));
+        expect(
+          File('${conflicts.single.path}/unexpected').readAsStringSync(),
+          'ambiguous',
+        );
+        expect(
+          cockpit.listSync().where(
+            (entity) => entity.path
+                .split(Platform.pathSeparator)
+                .last
+                .startsWith('server.previous-'),
+          ),
+          isEmpty,
+        );
+      },
+      skip: Platform.isWindows,
+    );
 
     test('não instala a partir do host — é caminho de Windows', () async {
       final exec = _FakeExec((_) => [(0, '', '')]);

--- a/cockpit/test/data/remote_host_key_test.dart
+++ b/cockpit/test/data/remote_host_key_test.dart
@@ -19,7 +19,7 @@ void main() {
     HostKeyPrompt? prompt,
   }) => RemoteHostConnector(
     host,
-    localServerBinaryResolver: ({String? arch}) => null,
+    localServerBinaryResolver: ({String? os, String? arch}) => null,
     hostKeyPrompt: prompt,
     knownHosts: knownHosts,
   );

--- a/cockpit/test/data/remote_host_terminal_gateway_test.dart
+++ b/cockpit/test/data/remote_host_terminal_gateway_test.dart
@@ -30,7 +30,8 @@ void main() {
 
     final connector = RemoteHostConnector(
       RemoteHost(id: 't', name: 'test', sshTarget: target),
-      localServerBinaryResolver: ({String? arch}) => binary.absolute.path,
+      localServerBinaryResolver: ({String? os, String? arch}) =>
+          binary.absolute.path,
     );
     addTearDown(connector.dispose);
 

--- a/cockpit/test/data/remote_server_freshness_gate_test.dart
+++ b/cockpit/test/data/remote_server_freshness_gate_test.dart
@@ -1,0 +1,49 @@
+import 'package:cockpit/app/cockpit/data/remote/remote_host_connector.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('probe que lança não fecha o gate e o retry pode concluir', () async {
+    final gate = ServerFreshnessProbeGate();
+    var attempts = 0;
+
+    await expectLater(
+      gate.run(() async {
+        attempts++;
+        throw StateError('transport dropped');
+      }),
+      throwsStateError,
+    );
+    expect(gate.completed, isFalse);
+
+    expect(
+      await gate.run(() async {
+        attempts++;
+        return true;
+      }),
+      isTrue,
+    );
+    expect(gate.completed, isTrue);
+    expect(attempts, 2);
+  });
+
+  test('probe concluído roda uma vez só', () async {
+    final gate = ServerFreshnessProbeGate();
+    var attempts = 0;
+
+    expect(
+      await gate.run(() async {
+        attempts++;
+        return false;
+      }),
+      isFalse,
+    );
+    expect(
+      await gate.run(() async {
+        attempts++;
+        return true;
+      }),
+      isFalse,
+    );
+    expect(attempts, 1);
+  });
+}

--- a/cockpit/test/data/sidecar_server_binary_test.dart
+++ b/cockpit/test/data/sidecar_server_binary_test.dart
@@ -32,11 +32,14 @@ void main() {
     expect(SidecarTerminalConnector.serverBinaryIn(bin.path, arch: 'x64'), x64);
   });
 
-  test('cai no nome sem sufixo (bundle de arquitetura única)', () {
+  test('cai no nome sem sufixo para a arquitetura nativa', () {
     final plain = touch(SidecarTerminalConnector.serverExeName);
 
     expect(
-      SidecarTerminalConnector.serverBinaryIn(bin.path, arch: 'arm64'),
+      SidecarTerminalConnector.serverBinaryIn(
+        bin.path,
+        arch: SidecarTerminalConnector.hostArch,
+      ),
       plain,
     );
   });
@@ -45,13 +48,103 @@ void main() {
     expect(SidecarTerminalConnector.serverBinaryIn(bin.path), isNull);
   });
 
-  test('a fatia pedida ausente não impede achar a outra pelo nome puro', () {
-    final plain = touch(SidecarTerminalConnector.serverExeName);
-    touch(SidecarTerminalConnector.serverExeFor('x64'));
+  test('target de outro OS usa a raiz targets/<os>-<arch>', () {
+    final root = bin.path;
+    final crossOs = SidecarTerminalConnector.hostOs == 'linux'
+        ? 'darwin'
+        : 'linux';
+    final targetBin = Directory('$root/targets/$crossOs-arm64/bin')
+      ..createSync(recursive: true);
+    final target = File(
+      '${targetBin.path}/${SidecarTerminalConnector.serverExeNameFor(crossOs)}',
+    )..writeAsStringSync('cross');
 
     expect(
-      SidecarTerminalConnector.serverBinaryIn(bin.path, arch: 'arm64'),
-      plain,
+      SidecarTerminalConnector.serverBinaryInBundle(
+        root,
+        os: crossOs,
+        arch: 'arm64',
+      ),
+      target.path,
+    );
+  });
+
+  test('mesmo OS em outra arquitetura rejeita binário sem sufixo', () {
+    final root = bin.path;
+    final nativeBin = Directory('$root/bin')..createSync();
+    File(
+      '${nativeBin.path}/${SidecarTerminalConnector.serverExeName}',
+    ).writeAsStringSync('native');
+    final otherArch = SidecarTerminalConnector.hostArch == 'arm64'
+        ? 'x64'
+        : 'arm64';
+
+    expect(
+      SidecarTerminalConnector.serverBinaryInBundle(
+        root,
+        os: SidecarTerminalConnector.hostOs,
+        arch: otherArch,
+      ),
+      isNull,
+    );
+  });
+
+  test('env override também é rejeitado para outra arquitetura', () {
+    final root = bin.path;
+    final nativeBin = Directory('$root/bin')..createSync();
+    final envBinary = File('$root/from-env')..writeAsStringSync('native');
+    final otherArch = SidecarTerminalConnector.hostArch == 'arm64'
+        ? 'x64'
+        : 'arm64';
+
+    expect(
+      SidecarTerminalConnector.resolveServerBundleBinaryFrom(
+        os: SidecarTerminalConnector.hostOs,
+        arch: otherArch,
+        nativeBinDirs: [nativeBin.path],
+        environmentBinary: envBinary.path,
+      ),
+      isNull,
+    );
+  });
+
+  test('mesmo OS em outra arquitetura aceita fatia explícita', () {
+    final root = bin.path;
+    final nativeBin = Directory('$root/bin')..createSync();
+    final otherArch = SidecarTerminalConnector.hostArch == 'arm64'
+        ? 'x64'
+        : 'arm64';
+    final slice = File(
+      '${nativeBin.path}/${SidecarTerminalConnector.serverExeFor(otherArch)}',
+    )..writeAsStringSync('slice');
+
+    expect(
+      SidecarTerminalConnector.serverBinaryInBundle(
+        root,
+        os: SidecarTerminalConnector.hostOs,
+        arch: otherArch,
+      ),
+      slice.path,
+    );
+  });
+
+  test('target de outro OS nunca cai no binário nativo', () {
+    final root = bin.path;
+    final nativeBin = Directory('$root/bin')..createSync();
+    File(
+      '${nativeBin.path}/${SidecarTerminalConnector.serverExeName}',
+    ).writeAsStringSync('native');
+    final crossOs = SidecarTerminalConnector.hostOs == 'linux'
+        ? 'darwin'
+        : 'linux';
+
+    expect(
+      SidecarTerminalConnector.serverBinaryInBundle(
+        root,
+        os: crossOs,
+        arch: 'arm64',
+      ),
+      isNull,
     );
   });
 }

--- a/cockpit/tool/build-linux-arm64-server-bundle.sh
+++ b/cockpit/tool/build-linux-arm64-server-bundle.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Cross-compiles the cockpit-server bundle deployed by a macOS client to Linux
+# arm64 remote hosts. The Dart AOT executable and anaki native assets are built
+# by `dart build cli`; the PTY library and Rust CLI use Zig as the cross linker.
+#
+# Usage: tool/build-linux-arm64-server-bundle.sh <destination>
+# Output: <destination>/{bin,lib}
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="${1:?destination is required}"
+TARGET="aarch64-unknown-linux-gnu"
+
+resolve_tool() {
+  local name="$1" fallback="${2:-}"
+  if command -v "$name" >/dev/null 2>&1; then
+    command -v "$name"
+  elif [ -n "$fallback" ] && [ -x "$fallback" ]; then
+    echo "$fallback"
+  else
+    echo "[linux-server] error: '$name' not found" >&2
+    exit 1
+  fi
+}
+
+if [ -n "${FLUTTER_ROOT:-}" ] && [ -x "$FLUTTER_ROOT/bin/dart" ]; then
+  DART="$FLUTTER_ROOT/bin/dart"
+else
+  DART="$(resolve_tool dart)"
+fi
+ZIG="$(resolve_tool zig)"
+CARGO="$(resolve_tool cargo "$HOME/.cargo/bin/cargo")"
+RUSTUP="$(resolve_tool rustup "$HOME/.cargo/bin/rustup")"
+
+if ! "$RUSTUP" target list --installed | grep -qx "$TARGET"; then
+  echo "[linux-server] error: Rust target '$TARGET' is not installed" >&2
+  echo "[linux-server] run: rustup target add $TARGET" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+(
+  cd "$ROOT/packages/cockpit_server"
+  "$DART" pub get >/dev/null
+  "$DART" build cli \
+    --target-os linux \
+    --target-arch arm64 \
+    -o "$TMP/dart" >/dev/null
+)
+mv "$TMP/dart/bundle"/* "$DEST"/
+mv "$DEST/bin/cockpit_server" "$DEST/bin/cockpit-server"
+
+# cockpit_pty is intentionally not a Dart native asset yet. Build the same C
+# source as the native sidecar, but against Zig's Linux aarch64 sysroot.
+"$ZIG" cc -target aarch64-linux-gnu -shared -O2 -DDART_SHARED_LIB \
+  -o "$DEST/lib/libcockpit_pty.so" \
+  "$ROOT/plugins/cockpit_pty/src/cockpit_pty.c" \
+  -I"$ROOT/plugins/cockpit_pty/src" -lpthread
+
+# Cargo accepts a linker executable, not a command with arguments, so wrap Zig.
+ZIG_LINKER="$TMP/zig-aarch64-linux-gnu-cc"
+cat >"$ZIG_LINKER" <<EOF
+#!/bin/sh
+exec "$ZIG" cc -target aarch64-linux-gnu "\$@"
+EOF
+chmod +x "$ZIG_LINKER"
+(
+  cd "$ROOT/cli"
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="$ZIG_LINKER" \
+    "$CARGO" build --release --target "$TARGET" >/dev/null
+)
+cp "$ROOT/cli/target/$TARGET/release/cockpit" "$DEST/bin/cockpit"
+chmod +x "$DEST/bin/cockpit-server" "$DEST/bin/cockpit"
+
+echo "[linux-server] bundle OK -> $DEST"

--- a/scripts/build-cockpit.sh
+++ b/scripts/build-cockpit.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and package Cockpit desktop app and the `cockpit` / `ck` internal CLI.
+#
+# Usage:
+#   scripts/build-cockpit.sh [--install] [--dest <path>]
+#
+# Options:
+#   --install       Installs Cockpit.app to ~/Applications/Cockpit.app (with backup)
+#   --dest <dir>    Custom destination directory for the installed Cockpit.app
+#   --help, -h      Show this help
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COCKPIT_DIR="$REPO_ROOT/cockpit"
+CLI_DIR="$COCKPIT_DIR/cli"
+
+DO_INSTALL=false
+DEST_DIR="$HOME/Applications"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)
+      DO_INSTALL=true
+      shift
+      ;;
+    --dest)
+      DEST_DIR="$2"
+      DO_INSTALL=true
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: scripts/build-cockpit.sh [--install] [--dest <path>]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "==> Checking prerequisites..."
+command -v cargo >/dev/null 2>&1 || { echo "Error: 'cargo' not found in PATH" >&2; exit 1; }
+command -v flutter >/dev/null 2>&1 || { echo "Error: 'flutter' not found in PATH" >&2; exit 1; }
+command -v zig >/dev/null 2>&1 || { echo "Error: 'zig' not found in PATH" >&2; exit 1; }
+
+echo "==> Building Rust CLI (cockpit-cli)..."
+cargo build --release --manifest-path "$CLI_DIR/Cargo.toml"
+cargo test --manifest-path "$CLI_DIR/Cargo.toml" --quiet
+
+echo "==> Installing CLI to ~/.cockpit/bin..."
+mkdir -p "$HOME/.cockpit/bin"
+cp "$CLI_DIR/target/release/cockpit" "$HOME/.cockpit/bin/cockpit"
+chmod +x "$HOME/.cockpit/bin/cockpit"
+ln -sf cockpit "$HOME/.cockpit/bin/ck"
+
+echo "==> Preparing Flutter dependencies..."
+cd "$COCKPIT_DIR"
+flutter pub get
+
+echo "==> Applying macOS patches (media_kit BSD cut)..."
+find "$HOME/.pub-cache" -name "create_framework_symlinks.sh" -exec sed -i '' "s/cut -d '-' -f 1 -f 3/cut -d '-' -f 1,3/g" {} + 2>/dev/null || true
+if [ -f "macos/Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos/create_framework_symlinks.sh" ]; then
+  sed -i '' "s/cut -d '-' -f 1 -f 3/cut -d '-' -f 1,3/g" "macos/Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos/create_framework_symlinks.sh" 2>/dev/null || true
+fi
+
+echo "==> Building macOS release application..."
+flutter build macos
+
+BUILT_APP="$COCKPIT_DIR/build/macos/Build/Products/Release/Cockpit.app"
+if [ ! -d "$BUILT_APP" ]; then
+  echo "Error: Built app not found at $BUILT_APP" >&2
+  exit 1
+fi
+
+echo "==> Verifying code signature..."
+codesign --verify --deep --strict "$BUILT_APP"
+
+echo "==> Build successful: $BUILT_APP"
+
+if [ "$DO_INSTALL" = true ]; then
+  TARGET_APP="$DEST_DIR/Cockpit.app"
+  BACKUP_APP="$DEST_DIR/Cockpit.app.bak"
+  mkdir -p "$DEST_DIR"
+  if [ -d "$TARGET_APP" ]; then
+    echo "==> Backing up existing app to $BACKUP_APP..."
+    rm -rf "$BACKUP_APP"
+    cp -R "$TARGET_APP" "$BACKUP_APP"
+  fi
+  echo "==> Staging install to $TARGET_APP..."
+  TEMP_APP="$DEST_DIR/Cockpit.app.tmp.$$"
+  rm -rf "$TEMP_APP"
+  ditto "$BUILT_APP" "$TEMP_APP"
+  rm -rf "$TARGET_APP"
+  mv "$TEMP_APP" "$TARGET_APP"
+  echo "==> Successfully installed to $TARGET_APP!"
+fi


### PR DESCRIPTION
## Summary

This adds programmatic top-level workspace management to Cockpit’s internal CLI (`ck` / `cockpit`) and socket IPC, including remote workspaces that a macOS client can open on Linux ARM64 hosts.

```sh
ck new-workspace <path> [--name <title>] [--host <ssh-target>] [--json]
ck new-remote-workspace --host <ssh-target> --path <remote-path> [--name <title>] [--json]
ck close-workspace [<id|path>] [--json]
ck rename-workspace [<id|path>] <new-name> [--json]
```

Remote `~` paths are resolved using the host’s actual `$HOME`. The returned workspace ID matches `list-workspaces` and `list-tabs`, making the commands idempotent and scriptable.

## Remote hosts

A macOS Release now carries a target-specific Linux ARM64 server bundle. Cockpit selects a remote bundle from the host’s probed OS and architecture, without falling back to an incompatible native executable.

Remote installation is treated as a whole bundle rather than one executable:

- deterministic manifest covers the server, CLI, PTY library, and database native assets;
- freshness compares the complete manifest;
- uploads are verified in staging before promotion;
- an ownership-checked host lock serializes concurrent clients;
- exact-path renames prevent directory nesting during promotion or rollback;
- interrupted installs retain recoverable staging/backup data.

The native macOS bundle layout and local sidecar behavior remain unchanged.

## Validation

- CLI wire tests cover local/remote create, aliases, flags, JSON, close, and rename.
- 44 focused Flutter tests cover manifests, host locking, interruption recovery, rename-time races, freshness retry, and OS/architecture selection.
- Targeted Flutter analysis is clean.
- A macOS Release build completed with all nine required Linux ARM64 files verified as ELF aarch64.
- The exact Release bundle was installed concurrently by two clients on a Linux ARM64 host; both serialized successfully and the final manifest verified every file.
- The installed server completed protocol v2 handshake and returned output from a real remote PTY.

The repository-wide Flutter suite still has six unrelated existing/flaky failures in menu, terminal-input, and worktree tests; affected focused tests pass.